### PR TITLE
Bump clusterman-metrics to 2.2.1 to fix decimal error when writing metrics

### DIFF
--- a/examples/clusterman_metrics/clusterman_metrics/util/misc.py
+++ b/examples/clusterman_metrics/clusterman_metrics/util/misc.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from decimal import Decimal
+from decimal import getcontext
+from decimal import localcontext
 from decimal import ROUND_HALF_UP
 
 MAX_DECIMAL_PLACES = 20
@@ -20,9 +22,17 @@ _PLACES_VALUE = Decimal(10) ** (-1 * MAX_DECIMAL_PLACES)
 
 def convert_decimal(numeric):
     full_decimal = Decimal(numeric)
-    _, _, exponent = full_decimal.as_tuple()
+    _, digits, exponent = full_decimal.as_tuple()
     # Round to MAX_DECIMAL_PLACES, if result has more places than that.
     if exponent < -MAX_DECIMAL_PLACES:
-        return full_decimal.quantize(_PLACES_VALUE, rounding=ROUND_HALF_UP)
+        # quantize can raise `decimal.InvalidOperation` if result is greater
+        # than context precision, which is 28 by default. to get around this,
+        # temporarily set a new precision up to the max number of sig figs  of
+        # `full_decimal`, which is also the max for the result of `quantize`.
+        # this ensures that the result of `quantize` will be within the precision
+        # limit, and not raise the error.
+        with localcontext() as ctx:
+            ctx.prec = max(len(digits), getcontext().prec)
+            return full_decimal.quantize(_PLACES_VALUE, rounding=ROUND_HALF_UP)
     else:
         return full_decimal

--- a/extra-requirements-yelp.txt
+++ b/extra-requirements-yelp.txt
@@ -1,4 +1,4 @@
-clusterman-metrics==2.0.1
+clusterman-metrics==2.2.1
 monk==0.6.5
 pysensu-yelp==0.4.1
 yelp-batch==8.0.0


### PR DESCRIPTION
### Description
When sending metrics, the `cluster_metrics_collector` batch kept crashing due to a `decimal.InvalidOperation` exception coming from the `clusterman-metrics` package, which I have patched in 2.2.1. This PR bumps the version in `clusterman` to pick up the patch.

### Testing Done
manual testing