### PR TITLE
Prevent connection errrors from crashing the autoscaler

### DIFF
--- a/clusterman/exceptions.py
+++ b/clusterman/exceptions.py
@@ -33,6 +33,11 @@ class PoolManagerError(ClustermanException):
     pass
 
 
+class PoolConnectionError(PoolManagerError):
+    """Raised when the pool master cannot be reached"""
+    pass
+
+
 class NoSignalConfiguredException(ClustermanException):
     pass
 

--- a/clusterman/mesos/util.py
+++ b/clusterman/mesos/util.py
@@ -20,7 +20,7 @@ import colorlog
 import requests
 from mypy_extensions import TypedDict
 
-from clusterman.exceptions import PoolManagerError
+from clusterman.exceptions import PoolConnectionError
 from clusterman.util import ClustermanResources
 
 logger = colorlog.getLogger(__name__)
@@ -103,7 +103,7 @@ def mesos_post(url: str, endpoint: str) -> requests.Response:
                 f'Response Text: {response.text}\n'
             )
         logger.critical(log_message)
-        raise PoolManagerError(f'Mesos master unreachable: check the logs for details') from e
+        raise PoolConnectionError(f'Mesos master unreachable: check the logs for details') from e
 
     return response
 

--- a/tests/mesos/util_test.py
+++ b/tests/mesos/util_test.py
@@ -14,7 +14,7 @@
 import mock
 import pytest
 
-from clusterman.exceptions import PoolManagerError
+from clusterman.exceptions import PoolConnectionError
 from clusterman.mesos.util import agent_pid_to_ip
 from clusterman.mesos.util import allocated_agent_resources
 from clusterman.mesos.util import mesos_post
@@ -57,6 +57,6 @@ class TestMesosPost:
 
     def test_failure(self, wrapped_post):
         with mock.patch('clusterman.mesos.util.requests') as mock_requests, \
-                pytest.raises(PoolManagerError):
+                pytest.raises(PoolConnectionError):
             mock_requests.post.side_effect = Exception('something bad happened')
             wrapped_post('http://the.mesos.master/', 'an-endpoint')


### PR DESCRIPTION
### Description
We've had some flappy alerts whenever Clusterman crashes when it fails to contact a Mesos master, causing a `clusterman.exceptions.PoolManagerError`, or talk to AWS, causing a `botocore.exceptions.EndpointConnectionError, due to a DNS error. These alerts don't really mean much since Clusterman will just try to autoscale again after crashing, and the alerts go away once DNS rises like a mangled phoenix. I've made it so that it doesn't crash on these errors.

### Testing done
make test