### PR TITLE
CLUSTERMAN-382 Add system metrics for k8s pending resources

### DIFF
--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -54,6 +54,9 @@ class KubernetesClusterConnector(ClusterConnector):
         self._nodes_by_ip = self._get_nodes_by_ip()
         self._pods_by_ip = self._get_pods_by_ip()
 
+    def get_resource_pending(self, resource_name: str) -> float:
+        return getattr(allocated_node_resources(self.get_unschedulable_pods()), resource_name)
+
     def get_resource_allocation(self, resource_name: str) -> float:
         return sum(
             getattr(allocated_node_resources(self._pods_by_ip[node_ip]), resource_name)
@@ -66,7 +69,7 @@ class KubernetesClusterConnector(ClusterConnector):
             for node in self._nodes_by_ip.values()
         )
 
-    def get_unschedulable_pods(self) -> int:
+    def get_unschedulable_pods(self) -> List[KubernetesPod]:
         unschedulable_pods = []
         for pod in self._get_pending_pods():
             is_unschedulable = False
@@ -75,7 +78,7 @@ class KubernetesClusterConnector(ClusterConnector):
                     is_unschedulable = True
             if is_unschedulable:
                 unschedulable_pods.append(pod)
-        return len(unschedulable_pods)
+        return unschedulable_pods
 
     def _get_pending_pods(self) -> List[KubernetesPod]:
         pool_label_key = self.pool_config.read_string('pool_label_key', default='clusterman.com/pool')

--- a/clusterman/mesos/metrics_generators.py
+++ b/clusterman/mesos/metrics_generators.py
@@ -42,7 +42,11 @@ SIMPLE_METADATA = {
     'non_orphan_fulfilled_capacity': lambda manager: manager.non_orphan_fulfilled_capacity,
 }
 KUBERNETES_METRICS = {
-    'unschedulable_pods': lambda manager: manager.cluster_connector.get_unschedulable_pods(),
+    'unschedulable_pods': lambda manager: len(manager.cluster_connector.get_unschedulable_pods()),
+    'cpus_pending': lambda manager: manager.cluster_connector.get_resource_pending('cpus'),
+    'mem_pending': lambda manager: manager.cluster_connector.get_resource_pending('mem'),
+    'disk_pending': lambda manager: manager.cluster_connector.get_resource_pending('disk'),
+    'gpus_pending': lambda manager: manager.cluster_connector.get_resource_pending('gpus'),
 }
 
 

--- a/tests/kubernetes/kubernetes_cluster_connector_test.py
+++ b/tests/kubernetes/kubernetes_cluster_connector_test.py
@@ -124,4 +124,8 @@ def test_get_pending_pods(mock_cluster_connector):
 
 
 def test_get_unschedulable_pods(mock_cluster_connector):
-    assert mock_cluster_connector.get_unschedulable_pods() == 1
+    assert len(mock_cluster_connector.get_unschedulable_pods()) == 1
+
+
+def test_pending_cpus(mock_cluster_connector):
+    assert mock_cluster_connector.get_resource_pending('cpus') == 1.5


### PR DESCRIPTION
This change is to add the following system metrics for k8s clusters:
- cpus_pending
- mem_pending
- disk_pending
- gpus_pending

The idea is to complement the metric **unschedulable_pods**, and use this data to write new scaling signals.

Tests performed:
- Running the metrics_collector batch on a given cluster
```
# python -m clusterman.batch.cluster_metrics_collector --cluster xxxx
...
INFO:__main__:Writing value 1 for metric unschedulable_pods|cluster=xxxx,pool=yyyy to metric store
INFO:__main__:Writing value 0.2 for metric cpus_pending|cluster=xxxx,pool=yyyy to metric store
INFO:__main__:Writing value 300200.0 for metric mem_pending|cluster=xxxx,pool=yyyy to metric store
INFO:__main__:Writing value 10000.0 for metric disk_pending|cluster=xxxx,pool=yyyy to metric store
INFO:__main__:Writing value 0 for metric gpus_pending|cluster=xxxx,pool=yyyy to metric store
```
- make test & make itest