### PR TITLE
taint node and evict pods for draining clusterman nodes

### DIFF
--- a/clusterman/autoscaler/pool_manager.py
+++ b/clusterman/autoscaler/pool_manager.py
@@ -100,8 +100,8 @@ class PoolManager:
             try:
                 group.mark_stale(dry_run)
             except NotImplementedError as e:
-                logger.warn(f'Skipping {group_id} because of error:')
-                logger.warn(str(e))
+                logger.warning(f'Skipping {group_id} because of error:')
+                logger.warning(str(e))
 
     def modify_target_capacity(
         self,

--- a/clusterman/draining/kubernetes.py
+++ b/clusterman/draining/kubernetes.py
@@ -1,0 +1,4 @@
+def kube_drain(operator_client, host):
+    operator_client.reload_state()
+    operator_client.set_node_unschedulable(host.ip)
+    operator_client.evict_pods_on_node(host.ip)

--- a/clusterman/interfaces/cluster_connector.py
+++ b/clusterman/interfaces/cluster_connector.py
@@ -42,7 +42,7 @@ class AgentMetadata(NamedTuple):
 class ClusterConnector(metaclass=ABCMeta):
     SCHEDULER: str
 
-    def __init__(self, cluster: str, pool: str) -> None:
+    def __init__(self, cluster: str, pool: Optional[str]) -> None:
         self.cluster = cluster
         self.pool = pool
         self.pool_config = staticconf.NamespaceReaders(POOL_NAMESPACE.format(pool=self.pool, scheduler=self.SCHEDULER))

--- a/itests/steps/draining.py
+++ b/itests/steps/draining.py
@@ -95,12 +95,12 @@ def drain_queue_process(context):
     ), staticconf.testing.PatchConfiguration(
         {'drain_termination_timeout_seconds': {'sfr': 0}},
     ):
-        context.draining_client.process_drain_queue(mock.Mock())
+        context.draining_client.process_drain_queue(mock.Mock(), mock.Mock())
 
 
 @behave.when('the termination queue is processed')
 def termination_queue_process(context):
-    context.draining_client.process_termination_queue(mock.Mock())
+    context.draining_client.process_termination_queue(mock.Mock(), mock.Mock())
 
 
 @behave.when('the warning queue is processed')

--- a/tests/draining/queue_test.py
+++ b/tests/draining/queue_test.py
@@ -346,8 +346,9 @@ def test_process_termination_queue(mock_draining_client):
         'clusterman.draining.queue.DrainingClient.delete_terminate_messages', autospec=True,
     ) as mock_delete_terminate_messages:
         mock_mesos_client = mock.Mock()
+        mock_kubernetes_client = mock.Mock()
         mock_get_host_to_terminate.return_value = None
-        mock_draining_client.process_termination_queue(mock_mesos_client)
+        mock_draining_client.process_termination_queue(mock_mesos_client, mock_kubernetes_client)
         assert mock_draining_client.get_host_to_terminate.called
         assert not mock_terminate.called
         assert not mock_delete_terminate_messages.called
@@ -355,7 +356,7 @@ def test_process_termination_queue(mock_draining_client):
         mock_host = mock.Mock(hostname='', instance_id='i123')
         mock_draining_client.draining_host_ttl_cache[mock_host.instance_id] = arrow.now()
         mock_get_host_to_terminate.return_value = mock_host
-        mock_draining_client.process_termination_queue(mock_mesos_client)
+        mock_draining_client.process_termination_queue(mock_mesos_client, mock_kubernetes_client)
         assert mock_draining_client.get_host_to_terminate.called
         mock_terminate.assert_called_with(mock_host)
         assert not mock_down.called
@@ -365,7 +366,7 @@ def test_process_termination_queue(mock_draining_client):
         mock_host = mock.Mock(hostname='host1', ip='10.1.1.1', instance_id='i123')
         mock_draining_client.draining_host_ttl_cache[mock_host.instance_id] = arrow.now()
         mock_get_host_to_terminate.return_value = mock_host
-        mock_draining_client.process_termination_queue(mock_mesos_client)
+        mock_draining_client.process_termination_queue(mock_mesos_client, mock_kubernetes_client)
         assert mock_draining_client.get_host_to_terminate.called
         mock_terminate.assert_called_with(mock_host)
         mock_down.assert_called_with(mock_mesos_client, ['host1|10.1.1.1'])
@@ -387,15 +388,16 @@ def test_process_drain_queue(mock_draining_client):
     ) as mock_arrow:
         mock_arrow.now = mock.Mock(return_value=mock.Mock(timestamp=1))
         mock_mesos_client = mock.Mock()
+        mock_kubernetes_client = mock.Mock()
         mock_get_host_to_drain.return_value = None
-        mock_draining_client.process_drain_queue(mock_mesos_client)
+        mock_draining_client.process_drain_queue(mock_mesos_client, mock_kubernetes_client)
         assert mock_draining_client.get_host_to_drain.called
         assert not mock_drain.called
         assert not mock_submit_host_for_termination.called
 
         mock_host = mock.Mock(hostname='')
         mock_get_host_to_drain.return_value = mock_host
-        mock_draining_client.process_drain_queue(mock_mesos_client)
+        mock_draining_client.process_drain_queue(mock_mesos_client, mock_kubernetes_client)
         mock_submit_host_for_termination.assert_called_with(mock_draining_client, mock_host, delay=0)
         mock_delete_drain_messages.assert_called_with(mock_draining_client, [mock_host])
         assert not mock_drain.called
@@ -409,7 +411,7 @@ def test_process_drain_queue(mock_draining_client):
             receipt_handle='aaaaa',
         )
         mock_get_host_to_drain.return_value = mock_host
-        mock_draining_client.process_drain_queue(mock_mesos_client)
+        mock_draining_client.process_drain_queue(mock_mesos_client, mock_kubernetes_client)
         assert mock_draining_client.get_host_to_drain.called
         mock_drain.assert_called_with(
             mock_mesos_client,
@@ -432,7 +434,7 @@ def test_process_drain_queue(mock_draining_client):
         mock_drain.reset_mock()
         mock_submit_host_for_termination.reset_mock()
         mock_get_host_to_drain.return_value = mock_host
-        mock_draining_client.process_drain_queue(mock_mesos_client)
+        mock_draining_client.process_drain_queue(mock_mesos_client, mock_kubernetes_client)
         assert mock_draining_client.get_host_to_drain.called
         assert not mock_drain.called
         assert not mock_submit_host_for_termination.called
@@ -486,6 +488,8 @@ def test_process_queues():
         {'clusters': {'westeros-prod': {'mesos_master_fqdn': 'westeros-prod'}}},
     ), mock.patch(
         'clusterman.draining.queue.time.sleep', autospec=True, side_effect=LoopBreak
+    ), mock.patch(
+        'clusterman.draining.queue.KubernetesClusterConnector', autospec=True,
     ):
         with pytest.raises(LoopBreak):
             process_queues('westeros-prod')

--- a/tests/kubernetes/kubernetes_cluster_connector_test.py
+++ b/tests/kubernetes/kubernetes_cluster_connector_test.py
@@ -117,11 +117,3 @@ def test_allocation(mock_cluster_connector):
 
 def test_total_cpus(mock_cluster_connector):
     assert mock_cluster_connector.get_resource_total('cpus') == 12
-
-
-def test_get_pending_pods(mock_cluster_connector):
-    assert len(mock_cluster_connector._get_pending_pods()) == 1
-
-
-def test_get_unschedulable_pods(mock_cluster_connector):
-    assert mock_cluster_connector.get_unschedulable_pods() == 1


### PR DESCRIPTION
I've tested this at stagef, and it works fine.

If the node has been in draining queue, it would do 2 things currently:
  1) taint the node as no-schedule
  2) evict all pods running on this node
After that, it would be in termination queue for terminating.

Also, I don't expect to ship this until I go back from PTO. So take your time to review this.