### PR TITLE
don't terminate nodes with the safe-to-evict annotation

### DIFF
--- a/clusterman/autoscaler/pool_manager.py
+++ b/clusterman/autoscaler/pool_manager.py
@@ -93,15 +93,15 @@ class PoolManager:
 
     def mark_stale(self, dry_run: bool) -> None:
         if dry_run:
-            logger.warn('Running in "dry-run" mode; cluster state will not be modified')
+            logger.warning('Running in "dry-run" mode; cluster state will not be modified')
 
         for group_id, group in self.resource_groups.items():
             logger.info(f'Marking {group_id} as stale!')
             try:
                 group.mark_stale(dry_run)
             except NotImplementedError as e:
-                logger.warn(f'Skipping {group_id} because of error:')
-                logger.warn(str(e))
+                logger.warning(f'Skipping {group_id} because of error:')
+                logger.warning(str(e))
 
     def modify_target_capacity(
         self,
@@ -436,6 +436,8 @@ class PoolManager:
 
     def _is_node_killable(self, node_metadata: ClusterNodeMetadata) -> bool:
         if node_metadata.agent.state == AgentState.UNKNOWN:
+            return False
+        elif not node_metadata.agent.is_safe_to_kill:
             return False
         elif self.max_tasks_to_kill > node_metadata.agent.task_count:
             return True

--- a/clusterman/interfaces/cluster_connector.py
+++ b/clusterman/interfaces/cluster_connector.py
@@ -34,6 +34,7 @@ class AgentMetadata(NamedTuple):
     agent_id: str = ''
     allocated_resources: ClustermanResources = ClustermanResources()
     batch_task_count: int = 0
+    is_safe_to_kill: bool = True
     state: AgentState = AgentState.UNKNOWN
     task_count: int = 0
     total_resources: ClustermanResources = ClustermanResources()


### PR DESCRIPTION
After this change, you should be able to stick the `clusterman.com/safe_to_evict=false` annotation on a pod, and it will prevent the node that it's running on from getting terminated.