### PR TITLE
fix the "no annotations" bug

### DIFF
--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -103,7 +103,8 @@ class KubernetesClusterConnector(ClusterConnector):
     def _is_node_safe_to_kill(self, node_ip: str) -> bool:
         safe_to_evict_key = self.pool_config.read_string('safe_to_evict_key', default='clusterman.com/safe_to_evict')
         for pod in self._pods_by_ip[node_ip]:
-            pod_safe_to_evict = strtobool(pod.metadata.annotations.get(safe_to_evict_key, 'true'))
+            annotations = pod.metadata.annotations or dict()
+            pod_safe_to_evict = strtobool(annotations.get(safe_to_evict_key, 'true'))
             if not pod_safe_to_evict:
                 return False
         return True

--- a/tests/kubernetes/kubernetes_cluster_connector_test.py
+++ b/tests/kubernetes/kubernetes_cluster_connector_test.py
@@ -32,7 +32,7 @@ from clusterman.kubernetes.kubernetes_cluster_connector import KubernetesCluster
 @pytest.fixture
 def pod1():
     return V1Pod(
-        metadata=V1ObjectMeta(name='pod1', annotations=dict()),
+        metadata=V1ObjectMeta(name='pod1'),
         status=V1PodStatus(phase='Running'),
         spec=V1PodSpec(containers=[
                V1Container(


### PR DESCRIPTION
This was causing crashes for pods that didn't have any annotations.

Confirmed that the change to the test fixes the issue.

Also made the cluster metrics batch produce a traceback, resolving CLUSTERMAN-457