### PR TITLE
Make cli args parsing more repl friendly

### DIFF
--- a/clusterman/args.py
+++ b/clusterman/args.py
@@ -152,8 +152,8 @@ def help_formatter(prog):  # pragma: no cover
     return argparse.ArgumentDefaultsHelpFormatter(prog, max_help_position=35, width=100)
 
 
-def _get_validated_args(parser):
-    args = parser.parse_args()
+def _get_validated_args(argv, parser):
+    args = parser.parse_args(args=argv)
 
     if args.subcommand is None:
         logger.error('missing subcommand')
@@ -213,7 +213,7 @@ def get_parser(description=''):  # pragma: no cover
     return root_parser
 
 
-def parse_args(description):  # pragma: no cover
+def parse_args(argv, description):  # pragma: no cover
     """Parse arguments for the CLI too and any subcommands
 
     :param description: a string descripting the tool
@@ -221,5 +221,5 @@ def parse_args(description):  # pragma: no cover
     """
     root_parser = get_parser(description)
 
-    args = _get_validated_args(root_parser)
+    args = _get_validated_args(argv, root_parser)
     return args

--- a/clusterman/run.py
+++ b/clusterman/run.py
@@ -11,17 +11,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import sys
+
 from clusterman.args import parse_args
 from clusterman.config import setup_config
 from clusterman.util import setup_logging
 
 
-def main():
-    args = parse_args('Mesos cluster scaling and management')
+def main(argv):
+    args = parse_args(argv, 'Mesos cluster scaling and management')
     setup_logging(args.log_level)
     setup_config(args)
     args.entrypoint(args)
 
 
 if __name__ == '__main__':
-    main()
+    main(sys.argv[1:])

--- a/tests/args_test.py
+++ b/tests/args_test.py
@@ -32,17 +32,17 @@ class TestArgumentParser:
         mock_args.subcommand = None
         mock_parser.parse_args.return_value = mock_args
         with pytest.raises(SystemExit):
-            _get_validated_args(mock_parser)
+            _get_validated_args(None, mock_parser)
 
     def test_no_entrypoint(self, mock_parser, mock_args):
         mock_args.subcommand = 'foo'
         mock_parser.parse_args.return_value = mock_args
         with pytest.raises(SystemExit):
-            _get_validated_args(mock_parser)
+            _get_validated_args(None, mock_parser)
 
     def test_no_cluster(self, mock_parser, mock_args):
         mock_args.subcommand = 'foo'
         mock_args.cluster = None
         mock_parser.parse_args.return_value = mock_args
         with pytest.raises(SystemExit):
-            _get_validated_args(mock_parser)
+            _get_validated_args(None, mock_parser)


### PR DESCRIPTION
During recent debugging session I had to do something like `sys.argv = ['things', 'i', 'need', 'to', 'test']`, which isn't pretty. Lets not rely on implicit args from `sys` and just pass them explicitly.