### PR TITLE
Add k8s draining and node deletion on terminate queue

### DIFF
--- a/clusterman/draining/kubernetes.py
+++ b/clusterman/draining/kubernetes.py
@@ -1,0 +1,27 @@
+# Copyright 2019 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import colorlog
+
+logger = colorlog.getLogger(__name__)
+
+
+def kube_drain(operator_client, host):
+    operator_client.reload_state()
+    operator_client.set_node_unschedulable(host.ip)
+    operator_client.evict_pods_on_node(host.ip)
+
+
+def kube_delete_node(operator_client, host):
+    operator_client.reload_state()
+    operator_client.delete_node(host.ip)

--- a/clusterman/interfaces/cluster_connector.py
+++ b/clusterman/interfaces/cluster_connector.py
@@ -43,7 +43,7 @@ class AgentMetadata(NamedTuple):
 class ClusterConnector(metaclass=ABCMeta):
     SCHEDULER: str
 
-    def __init__(self, cluster: str, pool: str) -> None:
+    def __init__(self, cluster: str, pool: Optional[str]) -> None:
         self.cluster = cluster
         self.pool = pool
         self.pool_config = staticconf.NamespaceReaders(POOL_NAMESPACE.format(pool=self.pool, scheduler=self.SCHEDULER))

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -15,6 +15,7 @@ from collections import defaultdict
 from distutils.util import strtobool
 from typing import List
 from typing import Mapping
+from typing import Optional
 
 import colorlog
 import kubernetes
@@ -39,7 +40,7 @@ class KubernetesClusterConnector(ClusterConnector):
     _nodes_by_ip: Mapping[str, KubernetesNode]
     _pods_by_ip: Mapping[str, List[KubernetesPod]]
 
-    def __init__(self, cluster: str, pool: str) -> None:
+    def __init__(self, cluster: str, pool: Optional[str]) -> None:
         super().__init__(cluster, pool)
         self.kubeconfig_path = f'clusters.{cluster}.kubeconfig_path'
         self._safe_to_evict_annotation = staticconf.read_string(
@@ -51,12 +52,8 @@ class KubernetesClusterConnector(ClusterConnector):
         logger.info('Reloading nodes')
         kubernetes.config.load_kube_config(staticconf.read_string(f'{self.kubeconfig_path}'))
         self._core_api = kubernetes.client.CoreV1Api()
-        self._pods = self._get_all_pods()
         self._nodes_by_ip = self._get_nodes_by_ip()
         self._pods_by_ip = self._get_pods_by_ip()
-
-    def get_resource_pending(self, resource_name: str) -> float:
-        return getattr(allocated_node_resources(self.get_unschedulable_pods()), resource_name)
 
     def get_resource_allocation(self, resource_name: str) -> float:
         return sum(
@@ -70,21 +67,35 @@ class KubernetesClusterConnector(ClusterConnector):
             for node in self._nodes_by_ip.values()
         )
 
-    def get_unschedulable_pods(self) -> List[KubernetesPod]:
-        unschedulable_pods = []
-        for pod in self._get_pending_pods():
-            is_unschedulable = False
-            for condition in pod.status.conditions:
-                if condition.reason == 'Unschedulable':
-                    is_unschedulable = True
-            if is_unschedulable:
-                unschedulable_pods.append(pod)
-        return unschedulable_pods
+    def set_node_unschedulable(self, node_ip: str):
+        try:
+            agent_metadata = self._get_agent_metadata(node_ip)
+            self._core_api.patch_node(
+                name=agent_metadata.agent_id,
+                body={'spec': {'unschedulable': True}}
+            )
+        except Exception as e:
+            logger.warning(f'error when unscheduling pod: {e}')
 
-    def _get_pending_pods(self) -> List[KubernetesPod]:
-        pool_label_key = self.pool_config.read_string('pool_label_key', default='clusterman.com/pool')
-        node_selector = {pool_label_key: self.pool}
-        return [pod for pod in self._pods if pod.spec.node_selector == node_selector and pod.status.phase == 'Pending']
+    def evict_pods_on_node(self, node_ip: str):
+        pods = self._pods_by_ip[node_ip]
+        for pod in pods:
+            try:
+                self._core_api.create_namespaced_pod_eviction(
+                    name=pod.metadata.name,
+                    namespace=pod.metadata.namespace,
+                    body=kubernetes.client.V1beta1Eviction()
+                )
+            except Exception as e:
+                logger.warning(f'error when evict pod: {e}')
+
+    def delete_node(self, node_ip: str):
+        agent_metadata = self._get_agent_metadata(node_ip)
+        self._core_api.delete_node(
+            name=agent_metadata.agent_id,
+            grace_period_seconds=0,
+            body=kubernetes.client.V1DeleteOptions()
+        )
 
     def _get_agent_metadata(self, node_ip: str) -> AgentMetadata:
         node = self._nodes_by_ip.get(node_ip)
@@ -93,8 +104,8 @@ class KubernetesClusterConnector(ClusterConnector):
         return AgentMetadata(
             agent_id=node.metadata.name,
             allocated_resources=allocated_node_resources(self._pods_by_ip[node_ip]),
-            batch_task_count=self._count_batch_tasks(node_ip),
             is_safe_to_kill=self._is_node_safe_to_kill(node_ip),
+            batch_task_count=self._count_batch_tasks(node_ip),
             state=(AgentState.RUNNING if self._pods_by_ip[node_ip] else AgentState.IDLE),
             task_count=len(self._pods_by_ip[node_ip]),
             total_resources=total_node_resources(node),
@@ -110,25 +121,24 @@ class KubernetesClusterConnector(ClusterConnector):
         return True
 
     def _get_nodes_by_ip(self) -> Mapping[str, KubernetesNode]:
-        pool_label_selector = self.pool_config.read_string('pool_label_key', default='clusterman.com/pool') \
-            + '=' + self.pool
-        pool_nodes = self._core_api.list_node(label_selector=pool_label_selector).items
+        if self.pool is not None:
+            pool_label_selector = self.pool_config.read_string('pool_label_key', default='clusterman.com/pool') \
+                                  + '=' + self.pool
+            pool_nodes = self._core_api.list_node(label_selector=pool_label_selector).items
+        else:
+            pool_nodes = self._core_api.list_node().items
         return {
             get_node_ip(node): node
             for node in pool_nodes
         }
 
     def _get_pods_by_ip(self) -> Mapping[str, List[KubernetesPod]]:
-        all_pods = self._pods
+        all_pods = self._core_api.list_pod_for_all_namespaces().items
         pods_by_ip: Mapping[str, List[KubernetesPod]] = defaultdict(list)
         for pod in all_pods:
             if pod.status.phase == 'Running' and pod.status.host_ip in self._nodes_by_ip:
                 pods_by_ip[pod.status.host_ip].append(pod)
         return pods_by_ip
-
-    def _get_all_pods(self) -> List[KubernetesPod]:
-        all_pods = self._core_api.list_pod_for_all_namespaces().items
-        return all_pods
 
     def _count_batch_tasks(self, node_ip: str) -> int:
         count = 0
@@ -140,3 +150,11 @@ class KubernetesClusterConnector(ClusterConnector):
                     count += (not strtobool(value))  # if it's safe to evict, it's NOT a batch task
                     break
         return count
+
+    @property
+    def pool_label_key(self):
+        return self.pool_config.read_string('pool_label_key', default='clusterman.com/pool')
+
+    @property
+    def safe_to_evict_key(self):
+        return self.pool_config.read_string('safe_to_evict_key', default='clusterman.com/safe_to_evict')

--- a/itests/steps/draining.py
+++ b/itests/steps/draining.py
@@ -95,12 +95,12 @@ def drain_queue_process(context):
     ), staticconf.testing.PatchConfiguration(
         {'drain_termination_timeout_seconds': {'sfr': 0}},
     ):
-        context.draining_client.process_drain_queue(mock.Mock())
+        context.draining_client.process_drain_queue(mock.Mock(), mock.Mock())
 
 
 @behave.when('the termination queue is processed')
 def termination_queue_process(context):
-    context.draining_client.process_termination_queue(mock.Mock())
+    context.draining_client.process_termination_queue(mock.Mock(), mock.Mock())
 
 
 @behave.when('the warning queue is processed')

--- a/tests/draining/queue_test.py
+++ b/tests/draining/queue_test.py
@@ -344,10 +344,13 @@ def test_process_termination_queue(mock_draining_client):
         'clusterman.draining.queue.DrainingClient.get_host_to_terminate', autospec=True,
     ) as mock_get_host_to_terminate, mock.patch(
         'clusterman.draining.queue.DrainingClient.delete_terminate_messages', autospec=True,
-    ) as mock_delete_terminate_messages:
+    ) as mock_delete_terminate_messages, mock.patch(
+        'clusterman.draining.queue.kube_delete_node', autospec=True,
+    ) as mock_kube_delete_node:
         mock_mesos_client = mock.Mock()
+        mock_kubernetes_client = mock.Mock()
         mock_get_host_to_terminate.return_value = None
-        mock_draining_client.process_termination_queue(mock_mesos_client)
+        mock_draining_client.process_termination_queue(mock_mesos_client, mock_kubernetes_client)
         assert mock_draining_client.get_host_to_terminate.called
         assert not mock_terminate.called
         assert not mock_delete_terminate_messages.called
@@ -355,21 +358,31 @@ def test_process_termination_queue(mock_draining_client):
         mock_host = mock.Mock(hostname='', instance_id='i123')
         mock_draining_client.draining_host_ttl_cache[mock_host.instance_id] = arrow.now()
         mock_get_host_to_terminate.return_value = mock_host
-        mock_draining_client.process_termination_queue(mock_mesos_client)
+        mock_draining_client.process_termination_queue(mock_mesos_client, mock_kubernetes_client)
         assert mock_draining_client.get_host_to_terminate.called
         mock_terminate.assert_called_with(mock_host)
         assert not mock_down.called
         assert not mock_up.called
         mock_delete_terminate_messages.assert_called_with(mock_draining_client, [mock_host])
 
-        mock_host = mock.Mock(hostname='host1', ip='10.1.1.1', instance_id='i123')
+        mock_host = mock.Mock(hostname='host1', ip='10.1.1.1', instance_id='i123', scheduler='mesos')
         mock_draining_client.draining_host_ttl_cache[mock_host.instance_id] = arrow.now()
         mock_get_host_to_terminate.return_value = mock_host
-        mock_draining_client.process_termination_queue(mock_mesos_client)
+        mock_draining_client.process_termination_queue(mock_mesos_client, mock_kubernetes_client)
         assert mock_draining_client.get_host_to_terminate.called
         mock_terminate.assert_called_with(mock_host)
         mock_down.assert_called_with(mock_mesos_client, ['host1|10.1.1.1'])
         mock_up.assert_called_with(mock_mesos_client, ['host1|10.1.1.1'])
+        mock_delete_terminate_messages.assert_called_with(mock_draining_client, [mock_host])
+
+        mock_host = mock.Mock(hostname='', ip='10.1.1.1', instance_id='i123', scheduler='kubernetes')
+        mock_draining_client.draining_host_ttl_cache[mock_host.instance_id] = arrow.now()
+        mock_get_host_to_terminate.return_value = mock_host
+        mock_kube_delete_node.return_value = None
+        mock_draining_client.process_termination_queue(mock_mesos_client, mock_kubernetes_client)
+        assert mock_draining_client.get_host_to_terminate.called
+        assert mock_kube_delete_node.called
+        mock_terminate.assert_called_with(mock_host)
         mock_delete_terminate_messages.assert_called_with(mock_draining_client, [mock_host])
 
 
@@ -387,15 +400,16 @@ def test_process_drain_queue(mock_draining_client):
     ) as mock_arrow:
         mock_arrow.now = mock.Mock(return_value=mock.Mock(timestamp=1))
         mock_mesos_client = mock.Mock()
+        mock_kubernetes_client = mock.Mock()
         mock_get_host_to_drain.return_value = None
-        mock_draining_client.process_drain_queue(mock_mesos_client)
+        mock_draining_client.process_drain_queue(mock_mesos_client, mock_kubernetes_client)
         assert mock_draining_client.get_host_to_drain.called
         assert not mock_drain.called
         assert not mock_submit_host_for_termination.called
 
         mock_host = mock.Mock(hostname='')
         mock_get_host_to_drain.return_value = mock_host
-        mock_draining_client.process_drain_queue(mock_mesos_client)
+        mock_draining_client.process_drain_queue(mock_mesos_client, mock_kubernetes_client)
         mock_submit_host_for_termination.assert_called_with(mock_draining_client, mock_host, delay=0)
         mock_delete_drain_messages.assert_called_with(mock_draining_client, [mock_host])
         assert not mock_drain.called
@@ -409,7 +423,7 @@ def test_process_drain_queue(mock_draining_client):
             receipt_handle='aaaaa',
         )
         mock_get_host_to_drain.return_value = mock_host
-        mock_draining_client.process_drain_queue(mock_mesos_client)
+        mock_draining_client.process_drain_queue(mock_mesos_client, mock_kubernetes_client)
         assert mock_draining_client.get_host_to_drain.called
         mock_drain.assert_called_with(
             mock_mesos_client,
@@ -432,7 +446,7 @@ def test_process_drain_queue(mock_draining_client):
         mock_drain.reset_mock()
         mock_submit_host_for_termination.reset_mock()
         mock_get_host_to_drain.return_value = mock_host
-        mock_draining_client.process_drain_queue(mock_mesos_client)
+        mock_draining_client.process_drain_queue(mock_mesos_client, mock_kubernetes_client)
         assert mock_draining_client.get_host_to_drain.called
         assert not mock_drain.called
         assert not mock_submit_host_for_termination.called
@@ -483,9 +497,11 @@ def test_process_queues():
     with mock.patch(
         'clusterman.draining.queue.DrainingClient', autospec=True,
     ) as mock_draining_client, staticconf.testing.PatchConfiguration(
-        {'clusters': {'westeros-prod': {'mesos_master_fqdn': 'westeros-prod'}}},
+        {'clusters': {'westeros-prod': {'mesos_master_fqdn': 'westeros-prod', 'cluster_manager': 'mesos'}}},
     ), mock.patch(
         'clusterman.draining.queue.time.sleep', autospec=True, side_effect=LoopBreak
+    ), mock.patch(
+        'clusterman.draining.queue.KubernetesClusterConnector', autospec=True,
     ):
         with pytest.raises(LoopBreak):
             process_queues('westeros-prod')

--- a/tests/kubernetes/kubernetes_cluster_connector_test.py
+++ b/tests/kubernetes/kubernetes_cluster_connector_test.py
@@ -132,13 +132,34 @@ def test_total_cpus(mock_cluster_connector):
     assert mock_cluster_connector.get_resource_total('cpus') == 12
 
 
-def test_get_pending_pods(mock_cluster_connector):
-    assert len(mock_cluster_connector._get_pending_pods()) == 1
+def test_evict_pods_on_node(mock_cluster_connector):
+    with mock.patch(
+            'clusterman.kubernetes.kubernetes_cluster_connector.KubernetesClusterConnector.evict_pods_on_node',
+            autospec=True,
+    ) as mock_evict_pods_on_node:
+        mock_node = mock.Mock()
+        mock_evict_pods_on_node.return_value = None
+        mock_cluster_connector.evict_pods_on_node(mock_node)
+        assert mock_evict_pods_on_node.called
 
 
-def test_get_unschedulable_pods(mock_cluster_connector):
-    assert len(mock_cluster_connector.get_unschedulable_pods()) == 1
+def test_set_node_unscheduable(mock_cluster_connector):
+    with mock.patch(
+            'clusterman.kubernetes.kubernetes_cluster_connector.KubernetesClusterConnector.set_node_unschedulable',
+            autospec=True,
+    ) as mock_set_node_unschedulable:
+        mock_node = mock.Mock()
+        mock_set_node_unschedulable.return_value = None
+        mock_cluster_connector.set_node_unschedulable(mock_node)
+        assert mock_set_node_unschedulable.called
 
 
-def test_pending_cpus(mock_cluster_connector):
-    assert mock_cluster_connector.get_resource_pending('cpus') == 1.5
+def test_delete_node(mock_cluster_connector):
+    with mock.patch(
+            'clusterman.kubernetes.kubernetes_cluster_connector.KubernetesClusterConnector.delete_node',
+            autospec=True,
+    ) as mock_delete_node:
+        mock_node = mock.Mock()
+        mock_delete_node.return_value = None
+        mock_cluster_connector.delete_node(mock_node)
+        assert mock_delete_node.called


### PR DESCRIPTION
Description:
The following code is for CLUSTERMAN-468 and CLUSTERMAN-456. Currently, we only have any logic to do draining for mesos instances so this PR includes unscheduling and evicting k8s pods as part of a step in the draining queue. In addition, we also delete a k8s node immediately when the EC2 instance is terminated during the last step of the termination process queue. 

Testing Done:
* `make test`
* Unit tests
* End to end testing: Created clusterman autoscaler and drainer on kubestage and tested draining nodes with `clusterman manage`.
