### PR TITLE
CLUSTERMAN-478 Add support for ASG weights

### DIFF
--- a/acceptance/moto/Dockerfile
+++ b/acceptance/moto/Dockerfile
@@ -22,7 +22,7 @@ RUN  python3 -m ensurepip && \
      #
      # We can unpin boto3 and botocore once botocore fixes its pin
      # (see https://github.com/boto/botocore/commit/e87e7a745fd972815b235a9ee685232745aa94f9)
-     pip3 install botocore==1.13.8 boto3==1.10.8 "moto[server]"
+     pip3 install botocore==1.14.11 boto3==1.11.11 "moto[server]"
 
 ENTRYPOINT ["/usr/bin/moto_server", "-H", "0.0.0.0"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 arrow==0.14.6
-boto3==1.9.249
-botocore==1.12.249
+boto3==1.11.11
+botocore==1.14.11
 cached-property==1.5.1
 cachetools==3.1.1
 certifi==2019.9.11
@@ -36,7 +36,7 @@ requests==2.22.0
 requests-oauthlib==1.2.0
 retry==0.9.2
 rsa==4.0
-s3transfer==0.2.1
+s3transfer==0.3.2
 setuptools==41.4.0
 signalfx==1.1.1
 simplejson==3.16.0

--- a/tests/aws/auto_scaling_resource_group_test.py
+++ b/tests/aws/auto_scaling_resource_group_test.py
@@ -118,12 +118,9 @@ def test_launch_config_retry(mock_asrg, mock_launch_config):
 
 
 @pytest.mark.parametrize('instance_type', ['t2.2xlarge', 'm5.large'])
-@mock.patch('clusterman.aws.auto_scaling_resource_group.logger', autospec=True)
-def test_market_weight(mock_logger, mock_asrg, instance_type):
+def test_market_weight(mock_asrg, instance_type):
     market_weight = mock_asrg.market_weight(InstanceMarket(instance_type, 'us-west-2a'))
-
     assert market_weight == 1.0
-    assert mock_logger.warning.call_count == (1 if instance_type == 'm5.large' else 0)
 
 
 @pytest.mark.parametrize('dry_run', [True, False])


### PR DESCRIPTION
This change adds support for instance weights in regular ASGs.
Note that I had to bump boto, botocore and s3transfer versions for this, as the weight parameter is not supported on previous versions.

Manual tests:
```
# Given an ASG with 2 instances, each one having a weight of 2:
$ python -m clusterman.run status --cluster xxxxx --pool gabrielv-test

Current status for the gabrielv-test pool in the xxxxx cluster:

Resource groups (target capacity: 3, fulfilled: 4, non-orphan: 4):
	xxxxx-gabrielv-weighted: active (4 / 3)

Cluster statistics:
	CPU allocation: 1.0 CPUs allocated to tasks, 2.0 total
	Memory allocation: 1 GB memory allocated to tasks, 9.46 GB total
	Disk allocation: 5.12 GB disk space allocated to tasks, 161.05 GB total
	GPUs allocation: 0.0 GPUs allocated to tasks, 0.0 total



$ python -m clusterman.batch.autoscaler_bootstrap
...
INFO:clusterman.autoscaler.autoscaler:Autoscaling run starting at 2020-02-17T17:19:09.098047+00:00
INFO:clusterman_metrics.boto_client:Querying datastore for cpus_allocated between 1581959829 and 1581959949 (is_regex=False)
INFO:clusterman_metrics.boto_client:Querying datastore for cpus_allocated between 1581959829 and 1581959949 (is_regex=False)
INFO:clusterman_metrics.boto_client:Querying datastore for mem_allocated between 1581959829 and 1581959949 (is_regex=False)
INFO:clusterman_metrics.boto_client:Querying datastore for mem_allocated between 1581959829 and 1581959949 (is_regex=False)
INFO:clusterman_metrics.boto_client:Querying datastore for disk_allocated between 1581959829 and 1581959949 (is_regex=False)
INFO:clusterman_metrics.boto_client:Querying datastore for disk_allocated between 1581959829 and 1581959949 (is_regex=False)
Received 103 bytes, expected 103 bytes
Last 103 bytes received: b'{"metrics": {"cpus_allocated": [], "mem_allocated": [], "disk_allocated": []}, "timestamp": 1581959949}'
INFO:clusterman.autoscaler.signals:b'{"Resources": {"cpus": null, "mem": null, "disk": null}}'
INFO:clusterman.autoscaler.autoscaler:Signal MostRecentResources requested {'cpus': None, 'mem': None, 'disk': None}
INFO:clusterman.autoscaler.pool_manager:Reloading cluster connector state
INFO:clusterman.mesos.mesos_cluster_connector:Reloading agents
INFO:clusterman.mesos.mesos_cluster_connector:Reloading frameworks and tasks
INFO:clusterman.autoscaler.pool_manager:Reloading resource groups
INFO:clusterman.aws.spot_fleet_resource_group:Merged ec2 & s3 SFRs: []
INFO:clusterman.autoscaler.pool_manager:Loaded resource groups: ['xxxxx-gabrielv-weighted']
INFO:clusterman.autoscaler.pool_manager:Recalculating non-orphan fulfilled capacity
INFO:clusterman.autoscaler.autoscaler:Currently at target_capacity of 3
INFO:clusterman.autoscaler.autoscaler:Currently non-orphan fulfilled capacity is 4
INFO:clusterman.autoscaler.autoscaler:Current cluster total resources: ClustermanResources(cpus=2.0, mem=9460.0, disk=161052.0, gpus=0.0)
INFO:clusterman.autoscaler.autoscaler:Current cluster allocated resources: ClustermanResources(cpus=1.0, mem=1000.0, disk=5120.0, gpus=0.0)
INFO:clusterman.autoscaler.autoscaler:No data from signal, not changing capacity
INFO:clusterman.aws.auto_scaling_resource_group:Setting target capacity for ASG with arguments:
{'AutoScalingGroupName': 'xxxxx-gabrielv-weighted',
 'DesiredCapacity': 3,
 'HonorCooldown': False}
INFO:clusterman.autoscaler.pool_manager:Killable instance IDs in kill order:
['i-xxxxx', 'i-yyyyy']
INFO:clusterman.autoscaler.pool_manager:Resource group xxxxx-gabrielv-weighted is at target capacity; skipping i-xxxxx
INFO:clusterman.autoscaler.pool_manager:Resource group xxxxx-gabrielv-weighted is at target capacity; skipping i-yyyyy
INFO:clusterman.autoscaler.pool_manager:Target capacity for gabrielv-test changed from 3 to 3
```