### PR TITLE
separate logs between mesos and k8s

### DIFF
--- a/clusterman/batch/autoscaler.py
+++ b/clusterman/batch/autoscaler.py
@@ -119,7 +119,7 @@ class AutoscalerBatch(BatchDaemon, BatchLoggingMixin, BatchRunningSentinelMixin)
         # This controls the name of the scribe log for this batch. Without this, the log
         # conflicts with other batches (like the Kew autoscaler).  We create a separate log for each
         # cluster and (non-default) pool, for easy distinguishmentability
-        return get_autoscaler_scribe_stream(self.options.cluster, self.options.pool)
+        return get_autoscaler_scribe_stream(self.options.cluster, self.options.pool, self.options.scheduler)
 
     @sensu_alert_triage()
     def _autoscale(self):

--- a/clusterman/batch/autoscaler_bootstrap.py
+++ b/clusterman/batch/autoscaler_bootstrap.py
@@ -96,7 +96,7 @@ class AutoscalerBootstrapBatch(BatchDaemon, BatchLoggingMixin):
 
     def _get_local_log_stream(self, clog_prefix=None):
         # Ensure that the bootstrap logs go to the same scribe stream as the autoscaler
-        return get_autoscaler_scribe_stream(self.options.cluster, self.options.pool)
+        return get_autoscaler_scribe_stream(self.options.cluster, self.options.pool, self.options.scheduler)
 
     def run(self):
         env = os.environ.copy()

--- a/clusterman/cli/manage.py
+++ b/clusterman/cli/manage.py
@@ -94,7 +94,7 @@ def main(args: argparse.Namespace) -> None:
 
         print(log_message)
         if not args.dry_run:
-            scribe_stream = get_autoscaler_scribe_stream(args.cluster, args.pool)
+            scribe_stream = get_autoscaler_scribe_stream(args.cluster, args.pool, args.scheduler)
             log_to_scribe(scribe_stream, f'{LOG_TEMPLATE} {log_message}')
 
 

--- a/clusterman/util.py
+++ b/clusterman/util.py
@@ -82,10 +82,12 @@ def setup_logging(log_level_str: str = 'info') -> None:
     logging.getLogger('boto3').setLevel(max(logging.INFO, log_level))
 
 
-def get_autoscaler_scribe_stream(cluster, pool):
+def get_autoscaler_scribe_stream(cluster, pool, scheduler):
     scribe_stream = f'{LOG_STREAM_NAME}_{cluster}'
     if pool != 'default':
         scribe_stream += f'_{pool}'
+    if scheduler == 'kubernetes':
+        scribe_stream += '_k8s'
     return scribe_stream
 
 


### PR DESCRIPTION
As we discussed on Monday, mesos log goes to the same place, while k8s logs goes to the stream with k8s suffix.