### PR TITLE
take max_weight_to_remove into consideration when pruning excess fulfilled capacity

### DIFF
--- a/itests/prune_excess_fulfilled_capacity.feature
+++ b/itests/prune_excess_fulfilled_capacity.feature
@@ -13,7 +13,15 @@ Feature: make sure we're pruning the right instances on scale-down
          When we prune excess fulfilled capacity to 10
          Then 0 instances should be killed
 
-    Scenario: the killable instance would remove too much capacity
+    Scenario: the killable instance would remove too much cluster weight
+        Given a pool manager with 1 sfr resource group
+          And the fulfilled capacity of resource group 1 is 15
+          And the max weight to remove is 0
+         When we prune excess fulfilled capacity to 10
+         Then 0 instances should be killed
+          And the log should contain "would take us over our max_weight_to_remove"
+
+    Scenario: the killable instance would remove too much resource group capacity
         Given a pool manager with 1 sfr resource group
           And the fulfilled capacity of resource group 1 is 11
           And the killable instance has weight 2

--- a/itests/steps/prune_excess_fulfilled_capacity.py
+++ b/itests/steps/prune_excess_fulfilled_capacity.py
@@ -66,6 +66,11 @@ def killable_instance_with_weight(context, weight):
     ])
 
 
+@behave.given('the max weight to remove is (?P<weight>\d+)')
+def max_weight_to_remove(context, weight):
+    context.pool_manager.max_weight_to_remove = int(weight)
+
+
 @behave.given('the killable instance has (?P<tasks>\d+) tasks')
 def killable_instance_with_tasks(context, tasks):
     def get_tasks_and_frameworks():


### PR DESCRIPTION
Fixes a bug where pruning excess fulfilled capacity could still terminate nodes i=even if `max_weight_to_remove` was set to 0.