### PR TITLE
Implement kube drain and delete node logic in drainer queue

### DIFF
--- a/clusterman/draining/kubernetes.py
+++ b/clusterman/draining/kubernetes.py
@@ -1,0 +1,27 @@
+# Copyright 2019 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import colorlog
+
+logger = colorlog.getLogger(__name__)
+
+
+def kube_drain(operator_client, host):
+    operator_client.reload_state()
+    operator_client.set_node_unschedulable(host.ip)
+    operator_client.evict_pods_on_node(host.ip)
+
+
+def kube_delete_node(operator_client, host):
+    operator_client.reload_state()
+    operator_client.delete_node(host.ip)

--- a/clusterman/draining/queue.py
+++ b/clusterman/draining/queue.py
@@ -37,11 +37,14 @@ from clusterman.aws.util import RESOURCE_GROUPS_REV
 from clusterman.config import load_cluster_pool_config
 from clusterman.config import POOL_NAMESPACE
 from clusterman.config import setup_config
+from clusterman.draining.kubernetes import kube_delete_node
+from clusterman.draining.kubernetes import kube_drain
 from clusterman.draining.mesos import down
 from clusterman.draining.mesos import drain
 from clusterman.draining.mesos import operator_api
 from clusterman.draining.mesos import up
 from clusterman.interfaces.resource_group import InstanceMetadata
+from clusterman.kubernetes.kubernetes_cluster_connector import KubernetesClusterConnector
 from clusterman.util import get_pool_name_list
 
 
@@ -226,13 +229,14 @@ class DrainingClient():
 
     def process_termination_queue(
         self,
-        mesos_operator_client: Callable[..., Callable[[str], Callable[..., None]]],
+        mesos_operator_client: Optional[Callable[..., Callable[[str], Callable[..., None]]]],
+        kube_operator_client: Optional[KubernetesClusterConnector],
     ) -> None:
         host_to_terminate = self.get_host_to_terminate()
         if host_to_terminate:
             # as for draining if it has a hostname we should down + up around the termination
-            if host_to_terminate.hostname:
-                logger.info(f'Hosts to down+terminate+up: {host_to_terminate}')
+            if host_to_terminate.scheduler == 'mesos':
+                logger.info(f'Mesos hosts to down+terminate+up: {host_to_terminate}')
                 hostname_ip = f'{host_to_terminate.hostname}|{host_to_terminate.ip}'
                 try:
                     down(mesos_operator_client, [hostname_ip])
@@ -243,19 +247,27 @@ class DrainingClient():
                     up(mesos_operator_client, [hostname_ip])
                 except Exception as e:
                     logger.error(f'Failed to up {hostname_ip} continuing to terminate anyway: {e}')
+            elif host_to_terminate.scheduler == 'kubernetes':
+                logger.info(f'Kubernetes hosts to delete k8s node and terminate: {host_to_terminate}')
+                try:
+                    logger.info(f'Deleting kubernetes node')
+                    kube_delete_node(kube_operator_client, host_to_terminate)
+                except Exception as e:
+                    logger.warning(f'Failed to delete {host_to_terminate.ip} node continuing to terminate anyway: {e}')
+                terminate_host(host_to_terminate)
             else:
-                logger.info(f'Host to terminate: {host_to_terminate}')
+                logger.info(f'Host to terminate immediately: {host_to_terminate}')
                 terminate_host(host_to_terminate)
             self.delete_terminate_messages([host_to_terminate])
 
     def process_drain_queue(
         self,
-        mesos_operator_client: Callable[..., Callable[[str], Callable[..., None]]],
+        mesos_operator_client: Optional[Callable[..., Callable[[str], Callable[..., None]]]],
+        kube_operator_client: Optional[KubernetesClusterConnector],
     ) -> None:
         host_to_process = self.get_host_to_drain()
         if host_to_process and host_to_process.instance_id not in self.draining_host_ttl_cache:
             self.draining_host_ttl_cache[host_to_process.instance_id] = arrow.now().shift(seconds=DRAIN_CACHE_SECONDS)
-
             if host_to_process.scheduler == 'mesos':
                 logger.info(f'Mesos host to drain and submit for termination: {host_to_process}')
                 try:
@@ -271,6 +283,7 @@ class DrainingClient():
                     self.submit_host_for_termination(host_to_process)
             elif host_to_process.scheduler == 'kubernetes':
                 logger.info(f'Kubernetes host to drain and submit for termination: {host_to_process}')
+                kube_drain(kube_operator_client, host_to_process)
                 self.submit_host_for_termination(host_to_process, delay=0)
             else:
                 logger.info(f'Host to submit for termination immediately: {host_to_process}')
@@ -357,18 +370,31 @@ def host_from_instance_id(
 
 def process_queues(cluster_name: str) -> None:
     draining_client = DrainingClient(cluster_name)
-    mesos_master_url = staticconf.read_string(f'clusters.{cluster_name}.mesos_master_fqdn')
-    mesos_secret_path = staticconf.read_string(f'mesos.mesos_agent_secret_path', default=None)
-    operator_client = operator_api(mesos_master_url, mesos_secret_path)
+    cluster_manager_name = staticconf.read_string(f'clusters.{cluster_name}.cluster_manager')
+    mesos_operator_client = kube_operator_client = None
+    try:
+        kube_operator_client = KubernetesClusterConnector(cluster_name, None)
+    except Exception:
+        logger.error(f'Cluster specified is mesos specific. Skipping kubernetes operator')
+    if cluster_manager_name == 'mesos':
+        try:
+            mesos_master_url = staticconf.read_string(f'clusters.{cluster_name}.mesos_master_fqdn')
+            mesos_secret_path = staticconf.read_string(f'mesos.mesos_agent_secret_path', default=None)
+            mesos_operator_client = operator_api(mesos_master_url, mesos_secret_path)
+        except Exception:
+            logger.error('Cluster specified is kubernetes specific. Skipping mesos operator')
+
     logger.info('Polling SQS for messages every 5s')
     while True:
         draining_client.clean_processing_hosts_cache()
         draining_client.process_warning_queue()
         draining_client.process_drain_queue(
-            mesos_operator_client=operator_client,
+            mesos_operator_client=mesos_operator_client,
+            kube_operator_client=kube_operator_client,
         )
         draining_client.process_termination_queue(
-            mesos_operator_client=operator_client,
+            mesos_operator_client=mesos_operator_client,
+            kube_operator_client=kube_operator_client,
         )
         time.sleep(5)
 
@@ -383,7 +409,9 @@ def terminate_host(host: Host) -> None:
 def main(args: argparse.Namespace) -> None:
     setup_config(args)
     for pool in get_pool_name_list(args.cluster, 'mesos'):
-        load_cluster_pool_config(args.cluster, pool, 'mesos', None)  # drainer only supported for mesos
+        load_cluster_pool_config(args.cluster, pool, 'mesos', None)
+    for pool in get_pool_name_list(args.cluster, 'kubernetes'):
+        load_cluster_pool_config(args.cluster, pool, 'kubernetes', None)
     process_queues(args.cluster)
 
 

--- a/clusterman/interfaces/cluster_connector.py
+++ b/clusterman/interfaces/cluster_connector.py
@@ -43,7 +43,7 @@ class AgentMetadata(NamedTuple):
 class ClusterConnector(metaclass=ABCMeta):
     SCHEDULER: str
 
-    def __init__(self, cluster: str, pool: str) -> None:
+    def __init__(self, cluster: str, pool: Optional[str]) -> None:
         self.cluster = cluster
         self.pool = pool
         self.pool_config = staticconf.NamespaceReaders(POOL_NAMESPACE.format(pool=self.pool, scheduler=self.SCHEDULER))

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -15,6 +15,7 @@ from collections import defaultdict
 from distutils.util import strtobool
 from typing import List
 from typing import Mapping
+from typing import Optional
 
 import colorlog
 import kubernetes
@@ -39,7 +40,7 @@ class KubernetesClusterConnector(ClusterConnector):
     _nodes_by_ip: Mapping[str, KubernetesNode]
     _pods_by_ip: Mapping[str, List[KubernetesPod]]
 
-    def __init__(self, cluster: str, pool: str) -> None:
+    def __init__(self, cluster: str, pool: Optional[str]) -> None:
         super().__init__(cluster, pool)
         self.kubeconfig_path = f'clusters.{cluster}.kubeconfig_path'
         self._safe_to_evict_annotation = staticconf.read_string(
@@ -51,7 +52,6 @@ class KubernetesClusterConnector(ClusterConnector):
         logger.info('Reloading nodes')
         kubernetes.config.load_kube_config(staticconf.read_string(f'{self.kubeconfig_path}'))
         self._core_api = kubernetes.client.CoreV1Api()
-        self._pods = self._get_all_pods()
         self._nodes_by_ip = self._get_nodes_by_ip()
         self._pods_by_ip = self._get_pods_by_ip()
 
@@ -82,9 +82,38 @@ class KubernetesClusterConnector(ClusterConnector):
         return unschedulable_pods
 
     def _get_pending_pods(self) -> List[KubernetesPod]:
-        pool_label_key = self.pool_config.read_string('pool_label_key', default='clusterman.com/pool')
-        node_selector = {pool_label_key: self.pool}
+        node_selector = {self.pool_label_key: self.pool}
         return [pod for pod in self._pods if pod.spec.node_selector == node_selector and pod.status.phase == 'Pending']
+
+    def set_node_unschedulable(self, node_ip: str):
+        try:
+            agent_metadata = self._get_agent_metadata(node_ip)
+            self._core_api.patch_node(
+                name=agent_metadata.agent_id,
+                body={'spec': {'unschedulable': True}}
+            )
+        except Exception as e:
+            logger.warning(f'error when unscheduling pod: {e}')
+
+    def evict_pods_on_node(self, node_ip: str):
+        pods = self._pods_by_ip[node_ip]
+        for pod in pods:
+            try:
+                self._core_api.create_namespaced_pod_eviction(
+                    name=pod.metadata.name,
+                    namespace=pod.metadata.namespace,
+                    body=kubernetes.client.V1beta1Eviction()
+                )
+            except Exception as e:
+                logger.warning(f'error when evict pod: {e}')
+
+    def delete_node(self, node_ip: str):
+        agent_metadata = self._get_agent_metadata(node_ip)
+        self._core_api.delete_node(
+            name=agent_metadata.agent_id,
+            grace_period_seconds=0,
+            body=kubernetes.client.V1DeleteOptions()
+        )
 
     def _get_agent_metadata(self, node_ip: str) -> AgentMetadata:
         node = self._nodes_by_ip.get(node_ip)
@@ -93,8 +122,8 @@ class KubernetesClusterConnector(ClusterConnector):
         return AgentMetadata(
             agent_id=node.metadata.name,
             allocated_resources=allocated_node_resources(self._pods_by_ip[node_ip]),
-            batch_task_count=self._count_batch_tasks(node_ip),
             is_safe_to_kill=self._is_node_safe_to_kill(node_ip),
+            batch_task_count=self._count_batch_tasks(node_ip),
             state=(AgentState.RUNNING if self._pods_by_ip[node_ip] else AgentState.IDLE),
             task_count=len(self._pods_by_ip[node_ip]),
             total_resources=total_node_resources(node),
@@ -110,25 +139,24 @@ class KubernetesClusterConnector(ClusterConnector):
         return True
 
     def _get_nodes_by_ip(self) -> Mapping[str, KubernetesNode]:
-        pool_label_selector = self.pool_config.read_string('pool_label_key', default='clusterman.com/pool') \
-            + '=' + self.pool
-        pool_nodes = self._core_api.list_node(label_selector=pool_label_selector).items
+        if self.pool is not None:
+            pool_label_selector = self.pool_config.read_string('pool_label_key', default='clusterman.com/pool') \
+                                  + '=' + self.pool
+            pool_nodes = self._core_api.list_node(label_selector=pool_label_selector).items
+        else:
+            pool_nodes = self._core_api.list_node().items
         return {
             get_node_ip(node): node
             for node in pool_nodes
         }
 
     def _get_pods_by_ip(self) -> Mapping[str, List[KubernetesPod]]:
-        all_pods = self._pods
+        all_pods = self._core_api.list_pod_for_all_namespaces().items
         pods_by_ip: Mapping[str, List[KubernetesPod]] = defaultdict(list)
         for pod in all_pods:
             if pod.status.phase == 'Running' and pod.status.host_ip in self._nodes_by_ip:
                 pods_by_ip[pod.status.host_ip].append(pod)
         return pods_by_ip
-
-    def _get_all_pods(self) -> List[KubernetesPod]:
-        all_pods = self._core_api.list_pod_for_all_namespaces().items
-        return all_pods
 
     def _count_batch_tasks(self, node_ip: str) -> int:
         count = 0
@@ -140,3 +168,11 @@ class KubernetesClusterConnector(ClusterConnector):
                     count += (not strtobool(value))  # if it's safe to evict, it's NOT a batch task
                     break
         return count
+
+    @property
+    def pool_label_key(self):
+        return self.pool_config.read_string('pool_label_key', default='clusterman.com/pool')
+
+    @property
+    def safe_to_evict_key(self):
+        return self.pool_config.read_string('safe_to_evict_key', default='clusterman.com/safe_to_evict')

--- a/itests/steps/draining.py
+++ b/itests/steps/draining.py
@@ -95,12 +95,12 @@ def drain_queue_process(context):
     ), staticconf.testing.PatchConfiguration(
         {'drain_termination_timeout_seconds': {'sfr': 0}},
     ):
-        context.draining_client.process_drain_queue(mock.Mock())
+        context.draining_client.process_drain_queue(mock.Mock(), mock.Mock())
 
 
 @behave.when('the termination queue is processed')
 def termination_queue_process(context):
-    context.draining_client.process_termination_queue(mock.Mock())
+    context.draining_client.process_termination_queue(mock.Mock(), mock.Mock())
 
 
 @behave.when('the warning queue is processed')

--- a/tests/draining/queue_test.py
+++ b/tests/draining/queue_test.py
@@ -344,10 +344,13 @@ def test_process_termination_queue(mock_draining_client):
         'clusterman.draining.queue.DrainingClient.get_host_to_terminate', autospec=True,
     ) as mock_get_host_to_terminate, mock.patch(
         'clusterman.draining.queue.DrainingClient.delete_terminate_messages', autospec=True,
-    ) as mock_delete_terminate_messages:
+    ) as mock_delete_terminate_messages, mock.patch(
+        'clusterman.draining.queue.kube_delete_node', autospec=True,
+    ) as mock_kube_delete_node:
         mock_mesos_client = mock.Mock()
+        mock_kubernetes_client = mock.Mock()
         mock_get_host_to_terminate.return_value = None
-        mock_draining_client.process_termination_queue(mock_mesos_client)
+        mock_draining_client.process_termination_queue(mock_mesos_client, mock_kubernetes_client)
         assert mock_draining_client.get_host_to_terminate.called
         assert not mock_terminate.called
         assert not mock_delete_terminate_messages.called
@@ -355,21 +358,31 @@ def test_process_termination_queue(mock_draining_client):
         mock_host = mock.Mock(hostname='', instance_id='i123')
         mock_draining_client.draining_host_ttl_cache[mock_host.instance_id] = arrow.now()
         mock_get_host_to_terminate.return_value = mock_host
-        mock_draining_client.process_termination_queue(mock_mesos_client)
+        mock_draining_client.process_termination_queue(mock_mesos_client, mock_kubernetes_client)
         assert mock_draining_client.get_host_to_terminate.called
         mock_terminate.assert_called_with(mock_host)
         assert not mock_down.called
         assert not mock_up.called
         mock_delete_terminate_messages.assert_called_with(mock_draining_client, [mock_host])
 
-        mock_host = mock.Mock(hostname='host1', ip='10.1.1.1', instance_id='i123')
+        mock_host = mock.Mock(hostname='host1', ip='10.1.1.1', instance_id='i123', scheduler='mesos')
         mock_draining_client.draining_host_ttl_cache[mock_host.instance_id] = arrow.now()
         mock_get_host_to_terminate.return_value = mock_host
-        mock_draining_client.process_termination_queue(mock_mesos_client)
+        mock_draining_client.process_termination_queue(mock_mesos_client, mock_kubernetes_client)
         assert mock_draining_client.get_host_to_terminate.called
         mock_terminate.assert_called_with(mock_host)
         mock_down.assert_called_with(mock_mesos_client, ['host1|10.1.1.1'])
         mock_up.assert_called_with(mock_mesos_client, ['host1|10.1.1.1'])
+        mock_delete_terminate_messages.assert_called_with(mock_draining_client, [mock_host])
+
+        mock_host = mock.Mock(hostname='', ip='10.1.1.1', instance_id='i123', scheduler='kubernetes')
+        mock_draining_client.draining_host_ttl_cache[mock_host.instance_id] = arrow.now()
+        mock_get_host_to_terminate.return_value = mock_host
+        mock_kube_delete_node.return_value = None
+        mock_draining_client.process_termination_queue(mock_mesos_client, mock_kubernetes_client)
+        assert mock_draining_client.get_host_to_terminate.called
+        assert mock_kube_delete_node.called
+        mock_terminate.assert_called_with(mock_host)
         mock_delete_terminate_messages.assert_called_with(mock_draining_client, [mock_host])
 
 
@@ -387,15 +400,16 @@ def test_process_drain_queue(mock_draining_client):
     ) as mock_arrow:
         mock_arrow.now = mock.Mock(return_value=mock.Mock(timestamp=1))
         mock_mesos_client = mock.Mock()
+        mock_kubernetes_client = mock.Mock()
         mock_get_host_to_drain.return_value = None
-        mock_draining_client.process_drain_queue(mock_mesos_client)
+        mock_draining_client.process_drain_queue(mock_mesos_client, mock_kubernetes_client)
         assert mock_draining_client.get_host_to_drain.called
         assert not mock_drain.called
         assert not mock_submit_host_for_termination.called
 
         mock_host = mock.Mock(hostname='')
         mock_get_host_to_drain.return_value = mock_host
-        mock_draining_client.process_drain_queue(mock_mesos_client)
+        mock_draining_client.process_drain_queue(mock_mesos_client, mock_kubernetes_client)
         mock_submit_host_for_termination.assert_called_with(mock_draining_client, mock_host, delay=0)
         mock_delete_drain_messages.assert_called_with(mock_draining_client, [mock_host])
         assert not mock_drain.called
@@ -409,7 +423,7 @@ def test_process_drain_queue(mock_draining_client):
             receipt_handle='aaaaa',
         )
         mock_get_host_to_drain.return_value = mock_host
-        mock_draining_client.process_drain_queue(mock_mesos_client)
+        mock_draining_client.process_drain_queue(mock_mesos_client, mock_kubernetes_client)
         assert mock_draining_client.get_host_to_drain.called
         mock_drain.assert_called_with(
             mock_mesos_client,
@@ -432,7 +446,7 @@ def test_process_drain_queue(mock_draining_client):
         mock_drain.reset_mock()
         mock_submit_host_for_termination.reset_mock()
         mock_get_host_to_drain.return_value = mock_host
-        mock_draining_client.process_drain_queue(mock_mesos_client)
+        mock_draining_client.process_drain_queue(mock_mesos_client, mock_kubernetes_client)
         assert mock_draining_client.get_host_to_drain.called
         assert not mock_drain.called
         assert not mock_submit_host_for_termination.called
@@ -483,9 +497,11 @@ def test_process_queues():
     with mock.patch(
         'clusterman.draining.queue.DrainingClient', autospec=True,
     ) as mock_draining_client, staticconf.testing.PatchConfiguration(
-        {'clusters': {'westeros-prod': {'mesos_master_fqdn': 'westeros-prod'}}},
+        {'clusters': {'westeros-prod': {'mesos_master_fqdn': 'westeros-prod', 'cluster_manager': 'mesos'}}},
     ), mock.patch(
         'clusterman.draining.queue.time.sleep', autospec=True, side_effect=LoopBreak
+    ), mock.patch(
+        'clusterman.draining.queue.KubernetesClusterConnector', autospec=True,
     ):
         with pytest.raises(LoopBreak):
             process_queues('westeros-prod')

--- a/tests/kubernetes/kubernetes_cluster_connector_test.py
+++ b/tests/kubernetes/kubernetes_cluster_connector_test.py
@@ -142,3 +142,36 @@ def test_get_unschedulable_pods(mock_cluster_connector):
 
 def test_pending_cpus(mock_cluster_connector):
     assert mock_cluster_connector.get_resource_pending('cpus') == 1.5
+
+
+def test_evict_pods_on_node(mock_cluster_connector):
+    with mock.patch(
+            'clusterman.kubernetes.kubernetes_cluster_connector.KubernetesClusterConnector.evict_pods_on_node',
+            autospec=True,
+    ) as mock_evict_pods_on_node:
+        mock_node = mock.Mock()
+        mock_evict_pods_on_node.return_value = None
+        mock_cluster_connector.evict_pods_on_node(mock_node)
+        assert mock_evict_pods_on_node.called
+
+
+def test_set_node_unscheduable(mock_cluster_connector):
+    with mock.patch(
+            'clusterman.kubernetes.kubernetes_cluster_connector.KubernetesClusterConnector.set_node_unschedulable',
+            autospec=True,
+    ) as mock_set_node_unschedulable:
+        mock_node = mock.Mock()
+        mock_set_node_unschedulable.return_value = None
+        mock_cluster_connector.set_node_unschedulable(mock_node)
+        assert mock_set_node_unschedulable.called
+
+
+def test_delete_node(mock_cluster_connector):
+    with mock.patch(
+            'clusterman.kubernetes.kubernetes_cluster_connector.KubernetesClusterConnector.delete_node',
+            autospec=True,
+    ) as mock_delete_node:
+        mock_node = mock.Mock()
+        mock_delete_node.return_value = None
+        mock_cluster_connector.delete_node(mock_node)
+        assert mock_delete_node.called


### PR DESCRIPTION
The following code is a fix for https://github.com/Yelp/clusterman/pull/21 by adding back all references of `get_resource_pending()` for kubernetes metrics tracking.