### PR TITLE
Protect clusterman against malformed ec2 json tags

### DIFF
--- a/clusterman/aws/aws_resource_group.py
+++ b/clusterman/aws/aws_resource_group.py
@@ -195,6 +195,11 @@ class AWSResourceGroup(ResourceGroup, metaclass=ABCMeta):
                     matching_resource_groups[rg_id] = rg
             except KeyError:
                 continue
+            except Exception as e:
+                logger.error(
+                    f'Failed to parse the identifier tags on {rg_id}, continuing anyway: {e}.\nThe tags were: {tags}'
+                )
+                continue
         return matching_resource_groups
 
     @classmethod


### PR DESCRIPTION
I'm not super sure if this should be merged. I see ec2 tags as "user generated input" and I think clusterman should protect itself against that.

At the same time, bad tags are a bug *somewhere*, is a warning in the log good enough to get that feedback?