### PR TITLE
CLUSTERMAN-504 Calculate node resources using node.status.allocatable

### DIFF
--- a/clusterman/kubernetes/util.py
+++ b/clusterman/kubernetes/util.py
@@ -81,8 +81,8 @@ def get_node_ip(node: KubernetesNode) -> str:
 
 def total_node_resources(node: KubernetesNode) -> ClustermanResources:
     return ClustermanResources(
-        cpus=ResourceParser.cpus(node.status.capacity),
-        mem=ResourceParser.mem(node.status.capacity),
-        disk=ResourceParser.disk(node.status.capacity),
-        gpus=ResourceParser.gpus(node.status.capacity),
+        cpus=ResourceParser.cpus(node.status.allocatable),
+        mem=ResourceParser.mem(node.status.allocatable),
+        disk=ResourceParser.disk(node.status.allocatable),
+        gpus=ResourceParser.gpus(node.status.allocatable),
     )

--- a/tests/kubernetes/kubernetes_cluster_connector_test.py
+++ b/tests/kubernetes/kubernetes_cluster_connector_test.py
@@ -129,7 +129,7 @@ def test_allocation(mock_cluster_connector):
 
 
 def test_total_cpus(mock_cluster_connector):
-    assert mock_cluster_connector.get_resource_total('cpus') == 12
+    assert mock_cluster_connector.get_resource_total('cpus') == 10.5
 
 
 def test_get_pending_pods(mock_cluster_connector):


### PR DESCRIPTION
Currently clusterman calculates node resources by looking at
`node.status.capacity`. But the k8s scheduler uses
`node.status.allocatable` when evaluating pod fitness. So let's make
clusterman use the same value.

For reference, check out [this doc](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/)

Tests:
```
$ python -m clusterman.run status --cluster xxxx --pool yyyy --scheduler kubernetes
...
Cluster statistics:
        CPU allocation: 11.0 CPUs allocated to tasks, 12.0 total
        Memory allocation: 32.6 GB memory allocated to tasks, 59.59 GB total
        Disk allocation: 111.27 GB disk space allocated to tasks, 539.48 GB total
        GPUs allocation: 0 GPUs allocated to tasks, 0 total

$ kubectl-xxxx get node yyyyyy -o json | jq .status.allocatable.cpu -r
6
$ kubectl-xxxx get node xxxxxx -o json | jq .status.allocatable.cpu -r
6
```