### PR TITLE
CLUSTERMAN-511 Add support for pod.affinity on metrics_collector.

### DIFF
--- a/tests/kubernetes/kubernetes_cluster_connector_test.py
+++ b/tests/kubernetes/kubernetes_cluster_connector_test.py
@@ -23,7 +23,13 @@ from kubernetes.client import V1PodCondition
 from kubernetes.client import V1PodSpec
 from kubernetes.client import V1PodStatus
 from kubernetes.client import V1ResourceRequirements
+from kubernetes.client.models.v1_affinity import V1Affinity
 from kubernetes.client.models.v1_node import V1Node as KubernetesNode
+from kubernetes.client.models.v1_node_affinity import V1NodeAffinity
+from kubernetes.client.models.v1_node_selector import V1NodeSelector
+from kubernetes.client.models.v1_node_selector_requirement import V1NodeSelectorRequirement
+from kubernetes.client.models.v1_node_selector_term import V1NodeSelectorTerm
+from kubernetes.client.models.v1_preferred_scheduling_term import V1PreferredSchedulingTerm
 
 from clusterman.interfaces.cluster_connector import AgentState
 from clusterman.kubernetes.kubernetes_cluster_connector import KubernetesClusterConnector
@@ -84,7 +90,7 @@ def pod3():
 @pytest.fixture
 def pod5():
     return V1Pod(
-        metadata=V1ObjectMeta(name='pod3', annotations=dict()),
+        metadata=V1ObjectMeta(name='pod5', annotations=dict()),
         status=V1PodStatus(
             phase='Pending',
             conditions=None,
@@ -97,6 +103,81 @@ def pod5():
                 )
             ],
             node_selector={'clusterman.com/pool': 'bar'}
+        )
+    )
+
+
+@pytest.fixture
+def pod6():
+    return V1Pod(
+        spec=V1PodSpec(
+            containers=[
+                V1Container(
+                    name='container',
+                    resources=V1ResourceRequirements(requests={'cpu': '1.5'})
+                )
+            ],
+            affinity=V1Affinity(
+                node_affinity=V1NodeAffinity(
+                    required_during_scheduling_ignored_during_execution=V1NodeSelector(
+                        node_selector_terms=[
+                            V1NodeSelectorTerm(
+                                match_expressions=[
+                                    V1NodeSelectorRequirement(
+                                        key='clusterman.com/pool',
+                                        operator='In',
+                                        values=['bar']
+                                    )
+                                ]
+                            )
+                        ]
+                    )
+                )
+            )
+        )
+    )
+
+
+@pytest.fixture
+def pod7():
+    return V1Pod(
+        spec=V1PodSpec(
+            containers=[
+                V1Container(
+                    name='container',
+                    resources=V1ResourceRequirements(requests={'cpu': '1.5'})
+                )
+            ],
+            affinity=V1Affinity(
+                node_affinity=V1NodeAffinity(
+                    required_during_scheduling_ignored_during_execution=V1NodeSelector(
+                        node_selector_terms=[
+                            V1NodeSelectorTerm(
+                                match_expressions=[
+                                    V1NodeSelectorRequirement(
+                                        key='clusterman.com/scheduler',
+                                        operator='Exists'
+                                    )
+                                ]
+                            )
+                        ]
+                    ),
+                    preferred_during_scheduling_ignored_during_execution=[
+                        V1PreferredSchedulingTerm(
+                            weight=10,
+                            preference=V1NodeSelectorTerm(
+                                match_expressions=[
+                                    V1NodeSelectorRequirement(
+                                        key='clusterman.com/pool',
+                                        operator='In',
+                                        values=['bar']
+                                    )
+                                ]
+                            )
+                        )
+                    ]
+                )
+            )
         )
     )
 
@@ -195,3 +276,40 @@ def test_delete_node(mock_cluster_connector):
         mock_delete_node.return_value = None
         mock_cluster_connector.delete_node(mock_node)
         assert mock_delete_node.called
+
+
+def test_pod_matches_node_selector_or_affinity(mock_cluster_connector, pod2, pod5, pod6, pod7):
+    pod8 = deepcopy(pod6)
+    pod8.spec.node_selector = {'clusterman.com/pool': 'not-bar'}
+    pod9 = deepcopy(pod6)
+    pod9.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution \
+        .node_selector_terms[0].match_expressions[0] \
+        .values = ['not-bar']
+    assert not mock_cluster_connector._pod_matches_node_selector_or_affinity(pod2)
+    assert mock_cluster_connector._pod_matches_node_selector_or_affinity(pod5)
+    assert mock_cluster_connector._pod_matches_node_selector_or_affinity(pod6)
+    assert mock_cluster_connector._pod_matches_node_selector_or_affinity(pod7)
+    assert not mock_cluster_connector._pod_matches_node_selector_or_affinity(pod8)
+    assert not mock_cluster_connector._pod_matches_node_selector_or_affinity(pod9)
+
+
+def test_selector_term_matches_requirement(mock_cluster_connector):
+    selector_term = V1NodeSelectorTerm(
+        match_expressions=[
+            V1NodeSelectorRequirement(
+                key='clusterman.com/scheduler',
+                operator='Exists'
+            ),
+            V1NodeSelectorRequirement(
+                key='clusterman.com/pool',
+                operator='In',
+                values=['bar']
+            )
+        ]
+    )
+    selector_requirement = V1NodeSelectorRequirement(
+        key='clusterman.com/pool',
+        operator='In',
+        values=['bar']
+    )
+    assert mock_cluster_connector._selector_term_matches_requirement(selector_term, selector_requirement)


### PR DESCRIPTION
The metrics_collector uses **pod.node_selector** to determine the pool where a pod is supposed to run. But cassandra pods are using **pod.affinity**, so I'm adding some changes to the metrics_collector to support that.

@Rob-Johnson suggested to use a similar approach to what the k8s-scheduler is doing:
- https://github.com/kubernetes/kubernetes/blob/2f08dc1b876c9c32db6a98114b25988b961d37c2/pkg/scheduler/framework/plugins/helper/node_affinity.go#L28
- https://github.com/kubernetes/kubernetes/blob/2f08dc1b876c9c32db6a98114b25988b961d37c2/pkg/apis/core/v1/helper/helpers.go#L314

I'm using some of that, but I didn't replicate the whole logic as the k8s-scheduler:
1- can accept pods with no node_selector and no affinity (which means that the pod will be scheduled anywhere)
2- If a pod has both a node_selector and affinity, the scheduler will try to satisfy both. But on our case, we will never have a pool label in both places at the same time. And we certainly would never have two different pool labels.

Tests:
- Manual run of the metrics_collector batch, having a pending cassandra pod:
```
$ python -m clusterman.batch.cluster_metrics_collector --cluster xxxx
...
INFO:__main__:Writing value 1 for metric unschedulable_pods|cluster=xxxx,pool=cassandra.kubernetes to metric store
INFO:__main__:Writing value 1.6 for metric cpus_pending|cluster=xxxx,pool=cassandra.kubernetes to metric store
INFO:__main__:Writing value 4640.0 for metric mem_pending|cluster=xxxx,pool=cassandra.kubernetes to metric store
INFO:__main__:Writing value 1792.0 for metric disk_pending|cluster=xxxx,pool=cassandra.kubernetes to metric store
INFO:__main__:Writing value 0 for metric gpus_pending|cluster=xxxx,pool=cassandra.kubernetes to metric store
...
```