### PR TITLE
revert an accidental change to autoscaler.run_frequency

### DIFF
--- a/clusterman/autoscaler/autoscaler.py
+++ b/clusterman/autoscaler/autoscaler.py
@@ -111,7 +111,7 @@ class Autoscaler:
 
     @property
     def run_frequency(self) -> int:
-        return 60
+        return self.signal.period_minutes * 60
 
     def run(self, dry_run: bool = False, timestamp: Optional[arrow.Arrow] = None) -> None:
         """ Do a single check to scale the fleet up or down if necessary.


### PR DESCRIPTION
Sometimes when testing drmorr will make the autoscaler run every minute.  Apparently at one point one of these changes got committed.