### PR TITLE
Account for scenarios where target_capacity is outside limit when constraining requested capacity

### DIFF
--- a/clusterman/autoscaler/autoscaler.py
+++ b/clusterman/autoscaler/autoscaler.py
@@ -123,7 +123,7 @@ class Autoscaler:
         timestamp = timestamp or arrow.utcnow()
         logger.info(f'Autoscaling run starting at {timestamp}')
         if self._is_paused(timestamp):
-            logger.info(f'Autoscaling is currently paused; doing nothing')
+            logger.info('Autoscaling is currently paused; doing nothing')
             return
 
         try:

--- a/clusterman/cli/simulate.py
+++ b/clusterman/cli/simulate.py
@@ -89,7 +89,7 @@ def _populate_autoscaling_events(simulator, start_time, end_time):
 
 def _populate_cluster_size_events(simulator, start_time, end_time):
     capacity_metrics = simulator.metrics_client.get_metric_values(
-        f'fulfilled_capacity',
+        'fulfilled_capacity',
         METADATA,
         start_time.timestamp,
         end_time.timestamp,
@@ -113,7 +113,7 @@ def _populate_cluster_size_events(simulator, start_time, end_time):
 
 def _populate_allocated_resources(simulator, start_time, end_time):
     allocated_metrics = simulator.metrics_client.get_metric_values(
-        f'cpus_allocated',
+        'cpus_allocated',
         SYSTEM_METRICS,
         start_time.timestamp,
         end_time.timestamp,
@@ -136,7 +136,7 @@ def _populate_allocated_resources(simulator, start_time, end_time):
 def _populate_price_changes(simulator, start_time, end_time, discount):
     for market in simulator.markets:
         market_prices = simulator.metrics_client.get_metric_values(
-            f'spot_prices',
+            'spot_prices',
             METADATA,
             start_time.timestamp,
             end_time.timestamp,

--- a/clusterman/draining/queue.py
+++ b/clusterman/draining/queue.py
@@ -367,11 +367,11 @@ def process_queues(cluster_name: str) -> None:
     try:
         kube_operator_client = KubernetesClusterConnector(cluster_name, None)
     except Exception:
-        logger.error(f'Cluster specified is mesos specific. Skipping kubernetes operator')
+        logger.error('Cluster specified is mesos specific. Skipping kubernetes operator')
     if cluster_manager_name == 'mesos':
         try:
             mesos_master_url = staticconf.read_string(f'clusters.{cluster_name}.mesos_master_fqdn')
-            mesos_secret_path = staticconf.read_string(f'mesos.mesos_agent_secret_path', default=None)
+            mesos_secret_path = staticconf.read_string('mesos.mesos_agent_secret_path', default=None)
             mesos_operator_client = operator_api(mesos_master_url, mesos_secret_path)
         except Exception:
             logger.error('Cluster specified is kubernetes specific. Skipping mesos operator')

--- a/clusterman/mesos/util.py
+++ b/clusterman/mesos/util.py
@@ -103,7 +103,7 @@ def mesos_post(url: str, endpoint: str) -> requests.Response:
                 f'Response Text: {response.text}\n'
             )
         logger.critical(log_message)
-        raise PoolConnectionError(f'Mesos master unreachable: check the logs for details') from e
+        raise PoolConnectionError('Mesos master unreachable: check the logs for details') from e
 
     return response
 

--- a/clusterman/tools/dynamodb_rename.py
+++ b/clusterman/tools/dynamodb_rename.py
@@ -59,7 +59,7 @@ def main(args):
             print(f'Updating {old} to {new}')
             for page in query.paginate(
                     TableName=table_name,
-                    KeyConditionExpression=f'#key = :val',
+                    KeyConditionExpression='#key = :val',
                     ExpressionAttributeNames={'#key': 'key'},
                     ExpressionAttributeValues={':val': {'S': old}}
             ):

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -151,4 +151,4 @@ def test_load_cluster_pool_config(cluster, pool, pool_other_config, mock_config_
 
     pool_namespace = POOL_NAMESPACE.format(pool=pool, scheduler='mesos')
     assert staticconf.read_int('other_config', namespace=pool_namespace) == pool_other_config
-    assert staticconf.read_string(f'resource_groups', namespace=pool_namespace) == cluster
+    assert staticconf.read_string('resource_groups', namespace=pool_namespace) == cluster


### PR DESCRIPTION
### Description
There are some cases where an existing target_capacity will be outside the max and min capacity limits, either due to manual scaling or because the limits move. In this case, capacity requests can result in bad deltas when constraining the target capacity. This PR patches that math to account for that case.

### Testing done
`make test`