### PR TITLE
Improve information display around enabling and disabling the autoscaler

### DIFF
--- a/clusterman/autoscaler/autoscaler.py
+++ b/clusterman/autoscaler/autoscaler.py
@@ -30,18 +30,16 @@ from clusterman.autoscaler.config import get_autoscaling_config
 from clusterman.autoscaler.pool_manager import PoolManager
 from clusterman.autoscaler.signals import Signal
 from clusterman.autoscaler.signals import SignalResponseDict
-from clusterman.aws.client import dynamodb
 from clusterman.config import POOL_NAMESPACE
 from clusterman.exceptions import NoSignalConfiguredException
 from clusterman.exceptions import ResourceRequestError
 from clusterman.monitoring_lib import get_monitoring_client
+from clusterman.util import autoscaling_is_paused
 from clusterman.util import ClustermanResources
 from clusterman.util import get_cluster_dimensions
 from clusterman.util import sensu_checkin
 from clusterman.util import Status
 
-CLUSTERMAN_STATE_TABLE = 'clusterman_cluster_state'
-AUTOSCALER_PAUSED = 'autoscaler_paused'
 SIGNAL_LOAD_CHECK_NAME = 'signal_configuration_failed'
 TARGET_CAPACITY_GAUGE_NAME = 'clusterman.autoscaler.target_capacity'
 RESOURCE_GAUGE_BASE_NAME = 'clusterman.autoscaler.requested_{resource}'
@@ -122,7 +120,7 @@ class Autoscaler:
 
         timestamp = timestamp or arrow.utcnow()
         logger.info(f'Autoscaling run starting at {timestamp}')
-        if self._is_paused(timestamp):
+        if autoscaling_is_paused(self.cluster, self.pool, self.scheduler, timestamp):
             logger.info('Autoscaling is currently paused; doing nothing')
             return
 
@@ -148,26 +146,6 @@ class Autoscaler:
         if exception:
             logger.error(f'The client signal failed with:\n{tb}')
             raise exception
-
-    def _is_paused(self, timestamp: arrow.Arrow) -> bool:
-        response = dynamodb.get_item(
-            TableName=CLUSTERMAN_STATE_TABLE,
-            Key={
-                'state': {'S': AUTOSCALER_PAUSED},
-                'entity': {'S': f'{self.cluster}.{self.pool}.{self.scheduler}'},
-            },
-            ConsistentRead=True,
-        )
-        if 'Item' not in response:
-            return False
-
-        if (
-            'expiration_timestamp' in response['Item'] and
-            timestamp.timestamp > int(response['Item']['expiration_timestamp']['N'])
-        ):
-            return False
-
-        return True
 
     def _emit_requested_resource_metrics(self, resource_request: SignalResponseDict, dry_run: bool) -> None:
         for resource_type, resource_gauge in self.resource_request_gauges.items():

--- a/clusterman/cli/status.py
+++ b/clusterman/cli/status.py
@@ -14,6 +14,9 @@
 import argparse
 import sys
 
+import arrow
+from colorama import Fore
+from colorama import Style
 from humanfriendly import format_size
 from humanfriendly import format_timespan
 
@@ -26,6 +29,7 @@ from clusterman.autoscaler.pool_manager import ClusterNodeMetadata
 from clusterman.autoscaler.pool_manager import PoolManager
 from clusterman.interfaces.cluster_connector import AgentState
 from clusterman.util import any_of
+from clusterman.util import autoscaling_is_paused
 from clusterman.util import color_conditions
 
 
@@ -107,6 +111,9 @@ def _write_summary(manager: PoolManager) -> None:
 def print_status(manager: PoolManager, args) -> None:
     sys.stdout.write('\n')
     print(f'Current status for the {manager.pool} pool in the {manager.cluster} cluster:\n')
+    if autoscaling_is_paused(manager.cluster, manager.pool, manager.scheduler, arrow.now()):
+        print(Fore.RED + 'Autoscaling is currently PAUSED!!!\n' + Style.RESET_ALL)
+
     print(
         f'Resource groups (target capacity: {manager.target_capacity}, fulfilled: {manager.fulfilled_capacity}, '
         f'non-orphan: {manager.non_orphan_fulfilled_capacity}):'

--- a/itests/steps/autoscaler.py
+++ b/itests/steps/autoscaler.py
@@ -23,12 +23,12 @@ from hamcrest import equal_to
 from moto import mock_dynamodb2
 
 from clusterman.autoscaler.autoscaler import Autoscaler
-from clusterman.autoscaler.autoscaler import AUTOSCALER_PAUSED
-from clusterman.autoscaler.autoscaler import CLUSTERMAN_STATE_TABLE
 from clusterman.autoscaler.pool_manager import PoolManager
 from clusterman.autoscaler.signals import ACK
 from clusterman.aws.client import dynamodb
 from clusterman.aws.spot_fleet_resource_group import SpotFleetResourceGroup
+from clusterman.util import AUTOSCALER_PAUSED
+from clusterman.util import CLUSTERMAN_STATE_TABLE
 from itests.environment import boto_patches
 
 

--- a/tests/autoscaler/autoscaler_test.py
+++ b/tests/autoscaler/autoscaler_test.py
@@ -135,8 +135,10 @@ def test_autoscaler_run(dry_run, mock_autoscaler, run_timestamp):
     mock_autoscaler._compute_target_capacity = mock.Mock(return_value=100)
     mock_autoscaler.signal.evaluate.side_effect = ValueError
     mock_autoscaler.default_signal.evaluate.return_value = {'cpus': 100000}
-    mock_autoscaler._is_paused = mock.Mock(return_value=False)
-    with pytest.raises(ValueError):
+    with mock.patch(
+        'clusterman.autoscaler.autoscaler.autoscaling_is_paused',
+        return_value=False,
+    ), pytest.raises(ValueError):
         mock_autoscaler.run(dry_run=dry_run, timestamp=run_timestamp)
 
     assert mock_autoscaler.target_capacity_gauge.set.call_args == mock.call(100, {'dry_run': dry_run})
@@ -152,7 +154,11 @@ def test_autoscaler_run_paused(mock_autoscaler, run_timestamp):
     mock_autoscaler._compute_target_capacity = mock.Mock(return_value=100)
     mock_autoscaler._is_paused = mock.Mock(return_value=True)
 
-    mock_autoscaler.run(timestamp=run_timestamp)
+    with mock.patch(
+        'clusterman.autoscaler.autoscaler.autoscaling_is_paused',
+        return_value=True,
+    ):
+        mock_autoscaler.run(timestamp=run_timestamp)
 
     assert mock_autoscaler.signal.evaluate.call_count == 0
     assert mock_autoscaler.target_capacity_gauge.set.call_count == 0
@@ -162,30 +168,6 @@ def test_autoscaler_run_paused(mock_autoscaler, run_timestamp):
     assert mock_autoscaler.resource_request_gauges['cpus'].set.call_count == 0
     assert mock_autoscaler.resource_request_gauges['mem'].set.call_count == 0
     assert mock_autoscaler.resource_request_gauges['disk'].set.call_count == 0
-
-
-def test_is_paused_no_data_for_cluster(mock_autoscaler, run_timestamp):
-    with mock.patch('clusterman.autoscaler.autoscaler.dynamodb') as mock_dynamo:
-        mock_dynamo.get_item.return_value = {'ResponseMetadata': {'foo': 'asdf'}}
-        assert not mock_autoscaler._is_paused(run_timestamp)
-
-
-@pytest.mark.parametrize('exp_timestamp', [None, '100', '400'])
-def test_is_paused_with_expiration_timestamp(exp_timestamp, mock_autoscaler, run_timestamp):
-    with mock.patch('clusterman.autoscaler.autoscaler.dynamodb') as mock_dynamo:
-        mock_dynamo.get_item.return_value = {
-            'ResponseMetadata': {'foo': 'asdf'},
-            'Item': {
-                'state': {'S': 'autoscaler_paused'},
-                'entity': {'S': 'mesos-test.bar.mesos'},
-            }
-        }
-        if exp_timestamp:
-            mock_dynamo.get_item.return_value['Item']['expiration_timestamp'] = {'N': exp_timestamp}
-        assert mock_autoscaler._is_paused(run_timestamp) == (
-            not exp_timestamp or
-            int(exp_timestamp) > run_timestamp.timestamp
-        )
 
 
 class TestComputeTargetCapacity:


### PR DESCRIPTION
### Description
1) If a cluster has autoscaling paused, `clusterman status` will print that info.
2) The `clusterman enable|disable` commands now print a response indicating success or failure.

### Testing done
manual testing on stagef
updated unit tests