### PR TITLE
Add timestamp to autoscaler pause entry in DynamoDB

### DIFF
--- a/clusterman/cli/toggle.py
+++ b/clusterman/cli/toggle.py
@@ -32,6 +32,7 @@ def disable(args: argparse.Namespace) -> None:
     state = {
         'state': {'S': AUTOSCALER_PAUSED},
         'entity': {'S': f'{args.cluster}.{args.pool}.{args.scheduler}'},
+        'timestamp': {'N':  str(int(time.time()))},
     }
     if args.until:
         state['expiration_timestamp'] = {'N': str(parse_time_string(args.until).timestamp)}


### PR DESCRIPTION
### Description
This PR adds a Sensu alert that tickets if an autoscaler is paused for too long. By default, "too long" is 24 hours or 86400 seconds. 

### Testing Done
make test
dry-run manual testing against a a dynamodb entry created manually

### Notes
**update** - I've reduced this PR to adding a timestamp to the pause entry in DynamoDB. The alert will be created elsewhere, outside of Clusterman.