### PR TITLE
suppress modify_target_capacity calls when new = old

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,6 @@ Please fill out!
 
 ### Testing Done
 
-Please fill out!  Generally speaking any new features should include 
+Please fill out!  Generally speaking any new features should include
 additional unit or integration tests to ensure the behaviour is
 working correctly.

--- a/clusterman/autoscaler/pool_manager.py
+++ b/clusterman/autoscaler/pool_manager.py
@@ -139,6 +139,9 @@ class PoolManager:
 
         res_group_targets = self._compute_new_resource_group_targets(new_target_capacity)
         for group_id, target in res_group_targets.items():
+            if self.resource_groups[group_id].target_capacity == target:
+                continue
+
             try:
                 self.resource_groups[group_id].modify_target_capacity(
                     target,

--- a/itests/steps/autoscaler.py
+++ b/itests/steps/autoscaler.py
@@ -200,13 +200,16 @@ def signal_resource_request(context, value):
 @behave.then('the autoscaler should scale rg(?P<rg>[12]) to (?P<target>\d+) capacity')
 def rg_capacity_change(context, rg, target):
     groups = list(context.autoscaler.pool_manager.resource_groups.values())
-    assert_that(
-        groups[int(rg) - 1].modify_target_capacity.call_args_list,
-        contains(
-            mock.call(int(target), dry_run=False),
-            mock.call(int(target), dry_run=False),
-        ),
-    )
+    if int(target) != groups[int(rg) - 1].target_capacity:
+        assert_that(
+            groups[int(rg) - 1].modify_target_capacity.call_args_list,
+            contains(
+                mock.call(int(target), dry_run=False),
+                mock.call(int(target), dry_run=False),
+            ),
+        )
+    else:
+        assert_that(groups[int(rg) - 1].modify_target_capacity.call_count, equal_to(0))
 
 
 @behave.then('the autoscaler should do nothing')


### PR DESCRIPTION
### Description

When the autoscaler is running very frequently, we can be spamming AWS with `modify_target_capacity` calls even when the new target capacity hasn't changed.
Here we suppress those calls when the new target capacity = the old target capacity.

### Testing Done

Fixed the integration tests to catch this case.
