### PR TITLE
Output error msg if cluster, pool, or scheduler does not exist in CLI, cluster_metrics_collector, or drainer

### DIFF
--- a/clusterman/batch/cluster_metrics_collector.py
+++ b/clusterman/batch/cluster_metrics_collector.py
@@ -46,13 +46,13 @@ from clusterman.batch.util import suppress_request_limit_exceeded
 from clusterman.config import get_pool_config_path
 from clusterman.config import load_cluster_pool_config
 from clusterman.config import setup_config
+from clusterman.exceptions import ClusterNotFoundError
 from clusterman.mesos.metrics_generators import ClusterMetric
 from clusterman.mesos.metrics_generators import generate_framework_metadata
 from clusterman.mesos.metrics_generators import generate_kubernetes_metrics
 from clusterman.mesos.metrics_generators import generate_simple_metadata
 from clusterman.mesos.metrics_generators import generate_system_metrics
 from clusterman.util import All
-from clusterman.util import ClusterNotFoundError
 from clusterman.util import get_pool_name_list
 from clusterman.util import sensu_checkin
 from clusterman.util import setup_logging
@@ -104,7 +104,7 @@ class ClusterMetricsCollector(BatchDaemon, BatchLoggingMixin, BatchRunningSentin
                 self.pools[scheduler] = get_pool_name_list(self.options.cluster, scheduler)
             except ClusterNotFoundError as e:
                 logger.error(e)
-                raise SystemExit
+                raise
         for scheduler, pools in self.pools.items():
             for pool in pools:
                 watcher_config = {

--- a/clusterman/config.py
+++ b/clusterman/config.py
@@ -14,16 +14,18 @@
 import argparse
 import glob
 import os
+import sys
 from typing import Optional
 
+import colorlog
 import staticconf
-from colorama import Fore
-from colorama import Style
 
 CREDENTIALS_NAMESPACE = 'boto_cfg'
 DEFAULT_CLUSTER_DIRECTORY = '/nail/srv/configs/clusterman-clusters'
 LOG_STREAM_NAME = 'tmp_clusterman_autoscaler'
 POOL_NAMESPACE = '{pool}.{scheduler}_config'
+
+logger = colorlog.getLogger(__name__)
 
 
 def _load_module_configs(env_config_path: str):
@@ -111,8 +113,8 @@ def get_pool_config_path_if_exists(cluster, pool, scheduler):
                 msg = f"Pool '{pool}' does not exist in cluster '{cluster}'"
         else:
             msg = f"Cluster '{cluster}' does not exist"
-        print(Fore.RED + msg + Style.RESET_ALL)
-        raise SystemExit
+        logger.error(msg)
+        sys.exit(1)
 
 
 def get_cluster_config_directory(cluster):

--- a/clusterman/draining/queue.py
+++ b/clusterman/draining/queue.py
@@ -41,9 +41,9 @@ from clusterman.draining.mesos import down
 from clusterman.draining.mesos import drain
 from clusterman.draining.mesos import operator_api
 from clusterman.draining.mesos import up
+from clusterman.exceptions import ClusterNotFoundError
 from clusterman.interfaces.resource_group import InstanceMetadata
 from clusterman.kubernetes.kubernetes_cluster_connector import KubernetesClusterConnector
-from clusterman.util import ClusterNotFoundError
 from clusterman.util import get_pool_name_list
 
 
@@ -407,8 +407,8 @@ def main(args: argparse.Namespace) -> None:
         for pool in get_pool_name_list(args.cluster, 'kubernetes'):
             load_cluster_pool_config(args.cluster, pool, 'kubernetes', None)
     except ClusterNotFoundError as e:
-        logger.error(e)
-        raise SystemExit
+        logger.exception(e)
+        raise
     process_queues(args.cluster)
 
 

--- a/clusterman/draining/queue.py
+++ b/clusterman/draining/queue.py
@@ -43,6 +43,7 @@ from clusterman.draining.mesos import operator_api
 from clusterman.draining.mesos import up
 from clusterman.interfaces.resource_group import InstanceMetadata
 from clusterman.kubernetes.kubernetes_cluster_connector import KubernetesClusterConnector
+from clusterman.util import ClusterNotFoundError
 from clusterman.util import get_pool_name_list
 
 
@@ -400,10 +401,14 @@ def terminate_host(host: Host) -> None:
 
 def main(args: argparse.Namespace) -> None:
     setup_config(args)
-    for pool in get_pool_name_list(args.cluster, 'mesos'):
-        load_cluster_pool_config(args.cluster, pool, 'mesos', None)
-    for pool in get_pool_name_list(args.cluster, 'kubernetes'):
-        load_cluster_pool_config(args.cluster, pool, 'kubernetes', None)
+    try:
+        for pool in get_pool_name_list(args.cluster, 'mesos'):
+            load_cluster_pool_config(args.cluster, pool, 'mesos', None)
+        for pool in get_pool_name_list(args.cluster, 'kubernetes'):
+            load_cluster_pool_config(args.cluster, pool, 'kubernetes', None)
+    except ClusterNotFoundError as e:
+        logger.error(e)
+        raise SystemExit
     process_queues(args.cluster)
 
 

--- a/clusterman/exceptions.py
+++ b/clusterman/exceptions.py
@@ -64,3 +64,11 @@ class SimulationError(ClustermanException):
 
 class AllResourceGroupsAreStaleError(Exception):
     pass
+
+
+class ClusterNotFoundError(Exception):
+    def __init__(self, cluster):
+        self.cluster = cluster
+
+    def __str__(self):
+        return f"Cluster '{self.cluster}' does not exist"

--- a/clusterman/util.py
+++ b/clusterman/util.py
@@ -64,6 +64,14 @@ class ClustermanResources(NamedTuple):
     gpus: float = 0
 
 
+class ClusterNotFoundError(Exception):
+    def __init__(self, cluster):
+        self.cluster = cluster
+
+    def __str__(self):
+        return f"Cluster '{self.cluster}' does not exist"
+
+
 def setup_logging(log_level_str: str = 'info') -> None:
     EVENT_LOG_LEVEL = 25
     logging.addLevelName(EVENT_LOG_LEVEL, 'EVENT')
@@ -296,6 +304,8 @@ def read_int_or_inf(reader, param):
 
 def get_pool_name_list(cluster_name: str, scheduler: str) -> List[str]:
     cluster_config_directory = get_cluster_config_directory(cluster_name)
+    if not os.path.exists(cluster_config_directory):
+        raise ClusterNotFoundError(cluster_name)
     return [
         os.path.splitext(f)[0] for f in os.listdir(cluster_config_directory)
         if f[0] != '.' and f.endswith(scheduler)  # skip dotfiles and only read scheduler files

--- a/clusterman/util.py
+++ b/clusterman/util.py
@@ -37,6 +37,7 @@ from clusterman.aws.client import dynamodb
 from clusterman.config import get_cluster_config_directory
 from clusterman.config import LOG_STREAM_NAME
 from clusterman.config import POOL_NAMESPACE
+from clusterman.exceptions import ClusterNotFoundError
 
 
 logger = colorlog.getLogger(__name__)
@@ -62,14 +63,6 @@ class ClustermanResources(NamedTuple):
     mem: float = 0
     disk: float = 0
     gpus: float = 0
-
-
-class ClusterNotFoundError(Exception):
-    def __init__(self, cluster):
-        self.cluster = cluster
-
-    def __str__(self):
-        return f"Cluster '{self.cluster}' does not exist"
 
 
 def setup_logging(log_level_str: str = 'info') -> None:

--- a/tests/batch/cluster_metrics_collector_test.py
+++ b/tests/batch/cluster_metrics_collector_test.py
@@ -54,8 +54,14 @@ def mock_setup_config():
 def test_configure_initial(mock_ls, mock_mesos_pool_manager, mock_client_class, batch, mock_setup_config):
     pools = ['pool-1', 'pool-3', 'pool-4']
     mock_ls.return_value = [f'{p}.mesos' for p in pools[:2]] + [f'{p}.kubernetes' for p in pools[2:]]
-    with mock.patch('clusterman.batch.cluster_metrics_collector.load_cluster_pool_config') as mock_pool_config:
+    with mock.patch(
+        'clusterman.batch.cluster_metrics_collector.load_cluster_pool_config',
+    ) as mock_pool_config, mock.patch(
+        'clusterman.batch.cluster_metrics_collector.get_pool_name_list',
+        side_effect=[pools[:2], [pools[2]]],
+    ) as mock_get_pool_name_list:
         batch.configure_initial()
+        assert mock_get_pool_name_list.call_count == 2
         assert mock_pool_config.call_count == 3
 
     assert batch.run_interval == 120

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -162,6 +162,7 @@ def test_get_pool_name_list_cluster_exists_pass(tmpdir, mock_config_files):
     assert path == os.path.join(str(tmpdir), 'cluster-B', 'pool-1.mesos')
 
 
+@mock.patch('clusterman.config.logger')
 @pytest.mark.parametrize(
     'cluster,pool,scheduler,output',
     [
@@ -174,10 +175,9 @@ def test_get_pool_name_list_cluster_exists_pass(tmpdir, mock_config_files):
     ],
 )
 def test_get_pool_name_list_cluster_exists_fail(
-    mock_config_files, capsys, cluster, pool, scheduler, output,
+    mock_logger, mock_config_files, cluster, pool, scheduler, output,
 ):
     with pytest.raises(SystemExit):
         config.get_pool_config_path_if_exists(cluster, pool, scheduler)
 
-    captured = capsys.readouterr()
-    assert output in captured.out
+    assert mock.call(output) == mock_logger.error.call_args

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import io
+import os
 from contextlib import contextmanager
 
 import mock
@@ -45,6 +46,15 @@ def mock_open(filename, contents=None):
     mocked_file.start()
     yield
     mocked_file.stop()
+
+
+@contextmanager
+def mock_file(filename, contents=''):
+    os.makedirs(os.path.dirname(filename), exist_ok=True)
+    with open(filename, 'w') as fp:
+        fp.write(contents)
+    yield
+    os.remove(filename)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -20,11 +20,11 @@ import staticconf.testing
 from colorama import Fore
 from colorama import Style
 
+from clusterman.exceptions import ClusterNotFoundError
 from clusterman.util import any_of
 from clusterman.util import ask_for_choice
 from clusterman.util import ask_for_confirmation
 from clusterman.util import autoscaling_is_paused
-from clusterman.util import ClusterNotFoundError
 from clusterman.util import color_conditions
 from clusterman.util import get_cluster_name_list
 from clusterman.util import get_pool_name_list


### PR DESCRIPTION
### Description
This PR just adds a helpful log/output whenever a cluster, pool, or scheduler does not exist. In the cluster_metrics_collector and drainer, the cluster check is most relevant. For the CLI, we now also check if the specified pool exists and is scheduled by the given scheduler.

### Testing Done
manual testing against a bad cluster, pool, and scheduler on the CLI, drainer, and cluster_metrics_collector
`make test`
