### PR TITLE
bump metrics check TTL to hopefully make this less noisy

### DIFF
--- a/clusterman/batch/cluster_metrics_collector.py
+++ b/clusterman/batch/cluster_metrics_collector.py
@@ -147,7 +147,7 @@ class ClusterMetricsCollector(BatchDaemon, BatchLoggingMixin, BatchRunningSentin
                         output='OK: clusterman cluster_metrics was successful',
                         check_every='1m',
                         source=self.options.cluster,
-                        ttl='10m',
+                        ttl='20m',
                         noop=self.options.disable_sensu,
                     )
                     sensu_checkin(**sensu_args)


### PR DESCRIPTION
### Description

The metrics collector alert has been firing a lot in pnw-prod, this increases the timeout (everywhere, unfortunately, since it's not quite that fine-grained).

### Testing Done

n/a