### PR TITLE
fix handling of Decimal types from the metrics lib

### DIFF
--- a/clusterman/signals/pending_pods_signal.py
+++ b/clusterman/signals/pending_pods_signal.py
@@ -61,18 +61,20 @@ def _get_resource_request(metrics: Optional[Dict]) -> SignalResponseDict:
     if not metrics:
         return {r: None for r in RESOURCES}
 
-    resource_request = {}
+    resource_request: SignalResponseDict = {}
     for resource in RESOURCES:
         allocated = metrics.get(resource + '_allocated', [])
         pending = metrics.get(resource + '_pending', [])
         latest_allocated = max(allocated, default=(None, None))
         latest_pending = max(pending, default=(None, None))
 
+        # Stuff comes in from the metrics collector as Decimals so we have to convert to floats first
         if latest_allocated[1] is not None and latest_pending[1] is not None:
-            resource_request[resource] = latest_allocated[1] + latest_pending[1]
+            resource_request[resource] = float(latest_allocated[1]) + float(latest_pending[1])
+        elif latest_allocated[1] is not None:
+            resource_request[resource] = float(latest_allocated[1])
         else:
-            # This could be None but that's OK
-            resource_request[resource] = latest_allocated[1]
+            resource_request[resource] = None
     return resource_request
 
 

--- a/itests/steps/autoscaler.py
+++ b/itests/steps/autoscaler.py
@@ -147,31 +147,31 @@ def make_mock_scaling_metrics(allocated_cpus, pending_cpus, boost_factor):
     ):
         if metric_name == 'cpus_allocated':
             return {'cpus_allocated': [
-                (Decimal('100'), 10),
-                (Decimal('110'), 12),
-                (Decimal('130'), allocated_cpus),
+                (Decimal('100'), Decimal('10')),
+                (Decimal('110'), Decimal('12')),
+                (Decimal('130'), Decimal(allocated_cpus)),
             ]}
         elif metric_name == 'mem_allocated':
             return {'mem_allocated': [
-                (Decimal('100'), 15),
-                (Decimal('110'), 17),
-                (Decimal('130'), 16),
+                (Decimal('100'), Decimal('15')),
+                (Decimal('110'), Decimal('17')),
+                (Decimal('130'), Decimal('16')),
             ]}
         elif metric_name == 'disk_allocated':
             return {'disk_allocated': [
-                (Decimal('100'), 10),
-                (Decimal('110'), 10),
-                (Decimal('130'), 10),
+                (Decimal('100'), Decimal('10')),
+                (Decimal('110'), Decimal('10')),
+                (Decimal('130'), Decimal('10')),
             ]}
         elif metric_name == 'cpus_pending':
             return {'cpus_pending': [
-                (Decimal('100'), 0),
-                (Decimal('110'), 0),
-                (Decimal('130'), pending_cpus),
+                (Decimal('100'), Decimal('0')),
+                (Decimal('110'), Decimal('0')),
+                (Decimal('130'), Decimal(pending_cpus)),
             ]}
         elif metric_name == 'boost_factor|cluster=kube-test,pool=bar.kubernetes' and boost_factor:
             return {'boost_factor|cluster=kube-test,pool=bar.kubernetes': [
-                (Decimal('135'), boost_factor)
+                (Decimal('135'), Decimal(boost_factor))
             ]}
         else:
             return {metric_name: []}
@@ -201,9 +201,10 @@ def resources(context, cpus, mem, disk, gpus):
     '(?P<allocated_cpus>\d+) CPUs allocated, (?P<pending_cpus>\d+) CPUs pending, and (?P<boost>\d*) boost factor'
 )
 def resources_requested(context, allocated_cpus, pending_cpus, boost):
-    context.allocated_cpus = int(allocated_cpus)
-    context.pending_cpus = int(pending_cpus)
-    context.boost = int(boost) if boost else None
+    # These don't need to be parsed because they get passed to Decimal
+    context.allocated_cpus = allocated_cpus
+    context.pending_cpus = pending_cpus
+    context.boost = boost if boost else None
 
 
 @behave.given('a mesos autoscaler object')

--- a/tests/signals/pending_pods_signal_test.py
+++ b/tests/signals/pending_pods_signal_test.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 import arrow
 import mock
 import pytest
@@ -12,11 +14,11 @@ def pending_pods_signal():
 
 def test_most_recent_values(pending_pods_signal):
     metrics = {
-        'cpus_allocated': [(900, 250), (1000, 150)],
-        'mem_allocated': [(900, 1250), (1000, 1000)],
-        'disk_allocated': [(900, 600), (1000, 500)],
-        'gpus_allocated': [(900, 0), (1000, None)],
-        'cpus_pending': [(1000, 543)],
+        'cpus_allocated': [(Decimal('900'), Decimal('250')), (Decimal('1000'), Decimal('150'))],
+        'mem_allocated': [(Decimal('900'), Decimal('1250')), (Decimal('1000'), Decimal('1000'))],
+        'disk_allocated': [(Decimal('900'), Decimal('600')), (Decimal('1000'), Decimal('500'))],
+        'gpus_allocated': [(Decimal('900'), Decimal('0')), (Decimal('1000'), None)],
+        'cpus_pending': [(Decimal('1000'), Decimal('543'))],
     }
     with mock.patch(
         'clusterman.signals.pending_pods_signal.get_metrics_for_signal', return_value=metrics,
@@ -27,8 +29,10 @@ def test_most_recent_values(pending_pods_signal):
 @pytest.mark.parametrize('timestamp', [1234, 2234])
 def test_boost_factor(timestamp, pending_pods_signal):
     metrics = {
-        'cpus_allocated': [(900, 250), (1000, 150)],
-        'boost_factor|cluster=foo,pool=bar.kube': [(950, 3)] + ([(1500, 1)] if timestamp > 1500 else [])
+        'cpus_allocated': [(Decimal('900'), Decimal('250')), (Decimal('1000'), Decimal('150'))],
+        'boost_factor|cluster=foo,pool=bar.kube': [(Decimal('950'), Decimal('3'))] + (
+            [(Decimal('1500'), Decimal('1'))] if timestamp > 1500 else []
+        )
     }
     with mock.patch(
         'clusterman.signals.pending_pods_signal.get_metrics_for_signal', return_value=metrics,


### PR DESCRIPTION
### Description

The metrics lib returns Decimals which need to be converted to floats or they won't play nicely with the rest of the autoscaler.  This was failing in stagef.

### Testing Done

make test -- modified the itests so they would fail in the same way, and then confirmed that the changes fix them.
