### PR TITLE
Update the pending pods signal to use data directly from Kubernetes

### DIFF
--- a/acceptance/Makefile
+++ b/acceptance/Makefile
@@ -2,6 +2,7 @@ PROJECT_NAME ?= clusterman
 WHOAMI := $(shell whoami)
 KIND_CLUSTER ?= $(WHOAMI)-$(PROJECT_NAME)
 KUBECONFIG ?= .local-$(KIND_CLUSTER).conf
+KUBECTL = KUBECONFIG=$(KUBECONFIG) kubectl
 DOCKER_TAG ?= $(PROJECT_NAME)-dev-$(WHOAMI)
 DOCKER_IMAGE := $(shell echo -n $(DOCKER_TAG) | sed 's|docker-paasta.yelpcorp.com:443/\(.*\):.*|\1|')
 DOCKER_PORT ?= 31234
@@ -17,11 +18,11 @@ local-cluster-external: .local-cluster.yaml .local-clusterman-external.yaml .loc
 	@echo Done.
 
 .local-cluster-up:
-	kind create cluster --name $(KIND_CLUSTER) --config .local-cluster.yaml --verbosity 2
-	kubectl -n kube-system get configmap/coredns -o yaml | \
+	KUBECONFIG=$(KUBECONFIG) kind create cluster --name $(KIND_CLUSTER) --config .local-cluster.yaml --verbosity 2
+	$(KUBECTL) -n kube-system get configmap/coredns -o yaml | \
 		sed "s|/etc/resolv.conf|$$(awk '/nameserver/ { print $$2; exit }' /etc/resolv.conf)|" | \
-		kubectl replace -f -
-	./k8s-local-docker-registry.sh $(DOCKER_REGISTRY) $(DOCKER_PORT) $(KIND_CLUSTER)
+		$(KUBECTL) replace -f -
+	KUBECONFIG=$(KUBECONFIG) ./k8s-local-docker-registry.sh $(DOCKER_REGISTRY) $(DOCKER_PORT) $(KIND_CLUSTER)
 	docker tag $(DOCKER_TAG) localhost:$(DOCKER_PORT)/$(DOCKER_IMAGE)
 	docker push localhost:$(DOCKER_PORT)/$(DOCKER_IMAGE)
 	docker exec $(KIND_CLUSTER)-control-plane mkdir -p /var/lib/clusterman
@@ -38,18 +39,16 @@ local-cluster-external: .local-cluster.yaml .local-clusterman-external.yaml .loc
 	touch .local-cluster-up
 
 .PHONY: acceptance-%
-export KIND_CLUSTER
-export KUBECONFIG
 acceptance-%: local-cluster-%
-	kubectl apply -f .local-clusterman-$*.yaml
+	$(KUBECTL) apply -f .local-clusterman-$*.yaml
 	echo "Checking to see if Clusterman is running..."
 	running=1; \
 	for count in 1 2 3 4 5 6 7 8 9 10; do \
 		echo "Not running yet, waiting 10 seconds and trying again (check $$count of 10)..."; \
 		sleep 10; \
-		kubectl describe pods; \
-		kubectl logs $$(kubectl get pods | grep clusterman | cut -f1 -d' '); \
-		if kubectl get pods | grep -q clusterman.*Running; then echo "Clusterman running successfully!"; running=0; break; fi; \
+		$(KUBECTL) describe pods; \
+		$(KUBECTL) logs $$($(KUBECTL) get pods | grep clusterman | cut -f1 -d' '); \
+		if $(KUBECTL) get pods | grep -q clusterman.*Running; then echo "Clusterman running successfully!"; running=0; break; fi; \
 	done; \
 	exit $$running
 
@@ -83,6 +82,7 @@ containerdConfigPatches:
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:$(DOCKER_PORT)"]
     endpoint = ["http://$(DOCKER_REGISTRY):$(DOCKER_PORT)"]
 endef
+export LOCAL_CLUSTER_YAML
 
 define LOCAL_CMAN_DEPLOYMENT
 ---
@@ -111,7 +111,7 @@ spec:
         - name: clusterman
           image: localhost:$(DOCKER_PORT)/$(DOCKER_IMAGE)
           command: ['python']
-          args: ['-m', $(CMD), $(EXTRA_ARGS)]
+          args: ['-m', $(CMD)$(EXTRA_ARGS)]
           env:
             - name: AWS_ENDPOINT_URL_ARGS
               value: --endpoint-url http://moto-s3:5000
@@ -147,20 +147,18 @@ spec:
             path: /var/lib/clusterman/clusterman.conf
             type: File
 endef
+export LOCAL_CMAN_DEPLOYMENT
 
-export LOCAL_CLUSTER_YAML
 .local-cluster.yaml:  ## Create config file for `kind` cluster manager
 	$(MAKE) local-cluster-clean || true
 	@echo "$$LOCAL_CLUSTER_YAML" > .local-cluster.yaml
 
-export LOCAL_CMAN_DEPLOYMENT
-export CMD="clusterman.batch.autoscaler_bootstrap"
+.local-clusterman-internal.yaml: export CMD="clusterman.batch.autoscaler_bootstrap"
 .local-clusterman-internal.yaml:  ## Create config file for `kind` cluster manager
 	@echo "$$LOCAL_CMAN_DEPLOYMENT" > .local-clusterman-internal.yaml
 
-export LOCAL_CMAN_DEPLOYMENT
-export EXTRA_ARGS="--env-config-path=/nail/srv/configs/clusterman-external.yaml"
-export CMD="examples.batch.autoscaler_bootstrap"
+.local-clusterman-external.yaml: export EXTRA_ARGS=, "--env-config-path=/nail/srv/configs/clusterman-external.yaml"
+.local-clusterman-external.yaml: export CMD="examples.batch.autoscaler_bootstrap"
 .local-clusterman-external.yaml:  ## Create config file for `kind` cluster manager
 	@echo "$$LOCAL_CMAN_DEPLOYMENT" > .local-clusterman-external.yaml
 

--- a/acceptance/srv-configs/clusterman-external.yaml
+++ b/acceptance/srv-configs/clusterman-external.yaml
@@ -32,7 +32,8 @@ autoscaling:
     target_capacity_margin: 0.05
 
 autoscale_signal:
-    internal: True
+    name: ConstantSignal
+    branch_or_tag: acceptance
     period_minutes: 1
 
 sensu_config:

--- a/acceptance/srv-configs/clusterman.yaml
+++ b/acceptance/srv-configs/clusterman.yaml
@@ -44,7 +44,8 @@ autoscaling:
     target_capacity_margin: 0.05
 
 autoscale_signal:
-    internal: True
+    name: ConstantSignal
+    branch_or_tag: acceptance
     period_minutes: 1
 
 sensu_config:

--- a/clusterman/interfaces/signal.py
+++ b/clusterman/interfaces/signal.py
@@ -16,7 +16,6 @@ from abc import abstractmethod
 from collections import defaultdict
 from typing import Dict
 from typing import List
-from typing import Optional
 from typing import Union
 
 import arrow
@@ -30,8 +29,7 @@ from mypy_extensions import TypedDict
 from clusterman.exceptions import MetricsError
 from clusterman.exceptions import SignalValidationError
 from clusterman.util import get_cluster_dimensions
-
-SignalResponseDict = Dict[str, Optional[float]]
+from clusterman.util import SignalResourceRequest
 
 
 class MetricsConfigDict(TypedDict):
@@ -90,7 +88,7 @@ class Signal(metaclass=ABCMeta):
             self,
             timestamp: arrow.Arrow,
             retry_on_broken_pipe: bool = True,
-     ) -> Union[SignalResponseDict, List[SignalResponseDict]]:
+     ) -> Union[SignalResourceRequest, List[SignalResourceRequest]]:
         """ Compute a signal and return either a single response (representing an aggregate resource request), or a
         list of responses (representing per-pod resource requests)
 

--- a/clusterman/signals/external_signal.py
+++ b/clusterman/signals/external_signal.py
@@ -36,7 +36,7 @@ from clusterman.exceptions import NoSignalConfiguredException
 from clusterman.exceptions import SignalConnectionError
 from clusterman.interfaces.signal import get_metrics_for_signal
 from clusterman.interfaces.signal import Signal
-from clusterman.interfaces.signal import SignalResponseDict
+from clusterman.util import SignalResourceRequest
 
 logger = colorlog.getLogger(__name__)
 
@@ -90,7 +90,7 @@ class ExternalSignal(Signal):
         self,
         timestamp: arrow.Arrow,
         retry_on_broken_pipe: bool = True,
-    ) -> Union[SignalResponseDict, List[SignalResponseDict]]:
+    ) -> Union[SignalResourceRequest, List[SignalResourceRequest]]:
         """ Communicate over a Unix socket with the signal to evaluate its result
 
         :param timestamp: a Unix timestamp to pass to the signal as the "current time"
@@ -132,7 +132,7 @@ class ExternalSignal(Signal):
             response = response[1:] or self._signal_conn.recv(SOCKET_MESG_SIZE)
             logger.info(response)
 
-            return json.loads(response)['Resources']
+            return SignalResourceRequest(**json.loads(response)['Resources'])
 
         except JSONDecodeError as e:
             raise ClustermanSignalError('Signal evaluation failed') from e

--- a/clusterman/signals/pending_pods_signal.py
+++ b/clusterman/signals/pending_pods_signal.py
@@ -1,6 +1,7 @@
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Tuple
 from typing import Union
 
 import arrow
@@ -9,27 +10,25 @@ from clusterman_metrics import APP_METRICS
 from clusterman_metrics import ClustermanMetricsBotoClient
 from clusterman_metrics import generate_key_with_dimensions
 from clusterman_metrics import SYSTEM_METRICS
+from kubernetes.client.models.v1_pod import V1Pod as KubernetesPod
 
 from clusterman.interfaces.signal import get_metrics_for_signal
 from clusterman.interfaces.signal import MetricsConfigDict
+from clusterman.interfaces.signal import MetricsValuesDict
 from clusterman.interfaces.signal import Signal
-from clusterman.interfaces.signal import SignalResponseDict
+from clusterman.kubernetes.kubernetes_cluster_connector import KubernetesClusterConnector
+from clusterman.kubernetes.util import PodUnschedulableReason
+from clusterman.kubernetes.util import total_pod_resources
+from clusterman.util import SignalResourceRequest
 
 logger = colorlog.getLogger(__name__)
-RESOURCES = ['cpus', 'mem', 'disk', 'gpus']
 
 
 def _get_required_metrics(cluster: str, pool: str, scheduler: str, minute_range: int = 240) -> List[MetricsConfigDict]:
     required_metrics = []
-    for resource in RESOURCES:
+    for resource in SignalResourceRequest._fields:
         required_metrics.append(MetricsConfigDict(
             name=f'{resource}_allocated',
-            type=SYSTEM_METRICS,
-            minute_range=minute_range,
-            regex=False,
-        ))
-        required_metrics.append(MetricsConfigDict(
-            name=f'{resource}_pending',
             type=SYSTEM_METRICS,
             minute_range=minute_range,
             regex=False,
@@ -43,38 +42,46 @@ def _get_required_metrics(cluster: str, pool: str, scheduler: str, minute_range:
     return required_metrics
 
 
-def _get_max_resources(*args: SignalResponseDict) -> SignalResponseDict:
+def _get_max_allocated_resource(resource: str, metrics: MetricsValuesDict) -> Optional[float]:
+    val = max(metrics.get(f'{resource}_allocated', []), default=(None, None))[1]
+    return float(val) if val else None
+
+
+def _get_max_resources(*args: SignalResourceRequest) -> SignalResourceRequest:
     """ given two (or more) resource request dicts, merge them together by taking
     the maximum value from each for each resource.  If no dict specifies anything for that
     resource, set it to None
     """
+    return SignalResourceRequest(**{
+        r: max([getattr(rdict, r) for rdict in args if getattr(rdict, r) is not None], default=None)
+        for r in SignalResourceRequest._fields
+    })
 
-    return {
-        r: max([rdict.get(r) for rdict in args if rdict.get(r) is not None], default=None)
-        for r in RESOURCES
-    }
 
-
-def _get_resource_request(metrics: Optional[Dict]) -> SignalResponseDict:
+def _get_resource_request(
+    metrics: Optional[MetricsValuesDict],
+    pending_pods: Optional[List[Tuple[KubernetesPod, PodUnschedulableReason]]] = None,
+) -> SignalResourceRequest:
     """ Given a list of metrics, construct a resource request based on the most recent
     data for allocated and pending pods """
-    if not metrics:
-        return {r: None for r in RESOURCES}
+    resource_request = SignalResourceRequest()
+    if not metrics and not pending_pods:
+        return resource_request
 
-    resource_request: SignalResponseDict = {}
-    for resource in RESOURCES:
-        allocated = metrics.get(resource + '_allocated', [])
-        pending = metrics.get(resource + '_pending', [])
-        latest_allocated = max(allocated, default=(None, None))
-        latest_pending = max(pending, default=(None, None))
+    pending_pods = pending_pods or []
+    if pending_pods:
+        for pod, reason in pending_pods:
+            if reason == PodUnschedulableReason.InsufficientResources:
+                # This is a temporary measure to try to improve scaling behaviour when Clusterman thinks
+                # there are enough resources but no single box can hold a new pod.  The goal is to replace
+                # this with a more intelligent solution in the future.
+                resource_request += total_pod_resources(pod) * 2
 
-        # Stuff comes in from the metrics collector as Decimals so we have to convert to floats first
-        if latest_allocated[1] is not None and latest_pending[1] is not None:
-            resource_request[resource] = float(latest_allocated[1]) + float(latest_pending[1])
-        elif latest_allocated[1] is not None:
-            resource_request[resource] = float(latest_allocated[1])
-        else:
-            resource_request[resource] = None
+    if metrics:
+        resource_request += SignalResourceRequest(**{
+            r: _get_max_allocated_resource(r, metrics)
+            for r in SignalResourceRequest._fields
+        })
     return resource_request
 
 
@@ -86,17 +93,19 @@ class PendingPodsSignal(Signal):
         scheduler: str,
         app: str,
         config_namespace: str,
-        metrics_client: ClustermanMetricsBotoClient
+        metrics_client: ClustermanMetricsBotoClient,
+        cluster_connector: KubernetesClusterConnector,
     ) -> None:
         super().__init__(self.__class__.__name__, cluster, pool, scheduler, app, config_namespace)
         self.required_metrics = _get_required_metrics(self.cluster, self.pool, self.scheduler)
         self.metrics_client = metrics_client
+        self.cluster_connector = cluster_connector
 
     def evaluate(
             self,
             timestamp: arrow.Arrow,
             retry_on_broken_pipe: bool = True,
-     ) -> Union[SignalResponseDict, List[SignalResponseDict]]:
+     ) -> Union[SignalResourceRequest, List[SignalResourceRequest]]:
         metrics = get_metrics_for_signal(
             self.cluster,
             self.pool,
@@ -107,14 +116,16 @@ class PendingPodsSignal(Signal):
             timestamp,
         )
 
+        pending_pods = self.cluster_connector.get_unschedulable_pods()
+
         # Get the most recent metrics _now_ and when the boost was set (if any) and merge them
-        current_resource_request = _get_resource_request(metrics)
+        current_resource_request = _get_resource_request(metrics, pending_pods)
         boosted_metrics = self._get_boosted_metrics(metrics)
         boosted_resource_request = _get_resource_request(boosted_metrics)
 
         return _get_max_resources(current_resource_request, boosted_resource_request)
 
-    def _get_boosted_metrics(self, metrics: Dict) -> Optional[Dict]:
+    def _get_boosted_metrics(self, metrics: Dict) -> Optional[MetricsValuesDict]:
         """ Given a list of metrics, check to see if a boost_factor has been set,
         and then apply that boost_factor to the most recent metrics *at the time it was set*
         """
@@ -126,13 +137,13 @@ class PendingPodsSignal(Signal):
             boost_time, boost_factor = metrics[boost_key][-1]
 
             # Get the metrics at the time of the boost
-            return {
+            return MetricsValuesDict(list, {
                 key: [
                     (t, v * boost_factor)
                     for t, v in values if t < boost_time
                 ]
                 for key, values in metrics.items()
-            }
+            })
         except (IndexError, KeyError):
             # No boost factor found in the datastore
             return None

--- a/clusterman/util.py
+++ b/clusterman/util.py
@@ -63,6 +63,40 @@ class ClustermanResources(NamedTuple):
     disk: float = 0
     gpus: float = 0
 
+    def __mul__(self, scalar: float) -> 'ClustermanResources':
+        return ClustermanResources(
+            cpus=self.cpus * scalar,
+            mem=self.mem * scalar,
+            disk=self.disk * scalar,
+            gpus=self.gpus * scalar,
+        )
+
+
+class SignalResourceRequest(NamedTuple):
+    cpus: Optional[float] = None
+    mem: Optional[float] = None
+    disk: Optional[float] = None
+    gpus: Optional[float] = None
+
+    def __add__(self, other) -> 'SignalResourceRequest':
+        return SignalResourceRequest(
+            cpus=add_maybe_none(self.cpus, other.cpus),
+            mem=add_maybe_none(self.mem, other.mem),
+            disk=add_maybe_none(self.disk, other.disk),
+            gpus=add_maybe_none(self.gpus, other.gpus),
+        )
+
+
+def add_maybe_none(f1: Optional[float], f2: Optional[float]) -> Optional[float]:
+    if f1 is None and f2 is None:
+        return None
+    elif f1 is None:
+        return f2
+    elif f2 is None:
+        return f1
+    else:
+        return f1 + f2
+
 
 def setup_logging(log_level_str: str = 'info') -> None:
     EVENT_LOG_LEVEL = 25

--- a/itests/autoscaler_scaling.feature
+++ b/itests/autoscaler_scaling.feature
@@ -81,7 +81,7 @@ Feature: make sure the autoscaler scales to the proper amount
       Examples:
         | pending   | boost | rg1_target | rg2_target |
         | 0         |       | 10         | 10         |
-        | 14        |       | 13         | 12         |
+        | 14        |       | 16         | 15         |
         | 1000      |       | 50         | 50         |
         | 0         | 2     | 20         | 20         |
-        | 50        | 2     | 38         | 38         |
+        | 50        | 2     | 28         | 28         |

--- a/itests/environment.py
+++ b/itests/environment.py
@@ -85,7 +85,7 @@ def setup_configurations(context):
             }
         ],
         'autoscale_signal': {
-            'internal': True,
+            'name': 'FooSignal',
             'period_minutes': 10,
         }
     }
@@ -148,6 +148,10 @@ def setup_configurations(context):
                 'runbook': 'y/their-runbook',
             }
         ],
+        'autoscale_signal': {
+            'internal': True,
+            'period_minutes': 7,
+        }
     }
     with staticconf.testing.MockConfiguration(boto_config, namespace=CREDENTIALS_NAMESPACE), \
             staticconf.testing.MockConfiguration(main_clusterman_config), \

--- a/tests/signals/external_signal_test.py
+++ b/tests/signals/external_signal_test.py
@@ -26,6 +26,7 @@ from clusterman.exceptions import SignalConnectionError
 from clusterman.signals.external_signal import ACK
 from clusterman.signals.external_signal import ExternalSignal
 from clusterman.signals.external_signal import setup_signals_environment
+from clusterman.util import SignalResourceRequest
 
 
 @pytest.fixture
@@ -78,7 +79,7 @@ def test_evaluate_restart_dead_signal(mock_signal):
         'clusterman.signals.external_signal.get_metrics_for_signal', return_value={}
     ):
         mock_connect.return_value = mock_signal._signal_conn
-        assert mock_signal.evaluate(arrow.get(12345678)) == {'cpus': 1}
+        assert mock_signal.evaluate(arrow.get(12345678)) == SignalResourceRequest(cpus=1)
         assert mock_connect.call_count == 1
 
 
@@ -113,7 +114,7 @@ def test_evaluate_signal_sending_message(mock_signal, signal_recv):
         resp = mock_signal.evaluate(arrow.get(12345678))
     assert mock_signal._signal_conn.send.call_count == num_messages
     assert mock_signal._signal_conn.recv.call_count == len(signal_recv)
-    assert resp == {'cpus': 5.2}
+    assert resp == SignalResourceRequest(cpus=5.2)
 
 
 def test_setup_signals_namespace():

--- a/tests/signals/pending_pods_signal_test.py
+++ b/tests/signals/pending_pods_signal_test.py
@@ -3,27 +3,149 @@ from decimal import Decimal
 import arrow
 import mock
 import pytest
+from kubernetes.client import V1Container
+from kubernetes.client import V1ObjectMeta
+from kubernetes.client import V1Pod
+from kubernetes.client import V1PodCondition
+from kubernetes.client import V1PodSpec
+from kubernetes.client import V1PodStatus
+from kubernetes.client import V1ResourceRequirements
 
+from clusterman.kubernetes.util import PodUnschedulableReason
+from clusterman.signals.pending_pods_signal import _get_max_resources
+from clusterman.signals.pending_pods_signal import _get_resource_request
 from clusterman.signals.pending_pods_signal import PendingPodsSignal
+from clusterman.util import SignalResourceRequest
 
 
 @pytest.fixture
 def pending_pods_signal():
-    return PendingPodsSignal('foo', 'bar', 'kube', 'app1', 'bar.kube_config', mock.Mock())
+    return PendingPodsSignal(
+        'foo',
+        'bar',
+        'kube',
+        'app1',
+        'bar.kube_config',
+        mock.Mock(),
+        mock.Mock(get_unschedulable_pods=mock.Mock(return_value=[])),
+    )
 
 
-def test_most_recent_values(pending_pods_signal):
-    metrics = {
+@pytest.fixture
+def allocated_metrics():
+    return {
         'cpus_allocated': [(Decimal('900'), Decimal('250')), (Decimal('1000'), Decimal('150'))],
         'mem_allocated': [(Decimal('900'), Decimal('1250')), (Decimal('1000'), Decimal('1000'))],
         'disk_allocated': [(Decimal('900'), Decimal('600')), (Decimal('1000'), Decimal('500'))],
         'gpus_allocated': [(Decimal('900'), Decimal('0')), (Decimal('1000'), None)],
-        'cpus_pending': [(Decimal('1000'), Decimal('543'))],
     }
+
+
+@pytest.fixture
+def pending_pods():
+    return [
+        (
+            V1Pod(
+                metadata=V1ObjectMeta(name='pod1'),
+                status=V1PodStatus(
+                    phase='Pending',
+                    conditions=[
+                        V1PodCondition(status='False', type='PodScheduled', reason='Unschedulable')
+                    ],
+                ),
+                spec=V1PodSpec(containers=[
+                    V1Container(
+                        name='container1',
+                        resources=V1ResourceRequirements(requests={'cpu': '1.5', 'memory': '150MB'})
+                    ),
+                    V1Container(
+                        name='container1',
+                        resources=V1ResourceRequirements(requests={'cpu': '1.5', 'memory': '350MB'})
+                    )
+                ]),
+            ),
+            PodUnschedulableReason.InsufficientResources,
+        ),
+        (
+            V1Pod(
+                metadata=V1ObjectMeta(name='pod2'),
+                status=V1PodStatus(
+                    phase='Pending',
+                    conditions=[
+                        V1PodCondition(status='False', type='PodScheduled', reason='Unschedulable')
+                    ],
+                ),
+                spec=V1PodSpec(containers=[
+                    V1Container(
+                        name='container1',
+                        resources=V1ResourceRequirements(requests={'cpu': '1.5'})
+                    ),
+                    V1Container(
+                        name='container1',
+                        resources=V1ResourceRequirements(requests={'cpu': '1.5', 'mem': '300MB'})
+                    )
+                ]),
+            ),
+            PodUnschedulableReason.Unknown,
+        )
+    ]
+
+
+def test_get_resource_request_empty():
+    assert _get_resource_request(None) == SignalResourceRequest()
+
+
+def test_get_resource_request_no_pending_pods(allocated_metrics):
+    assert _get_resource_request(allocated_metrics) == SignalResourceRequest(
+        cpus=150,
+        mem=1000,
+        disk=500,
+    )
+
+
+def test_get_resource_request_only_pending_pods(pending_pods):
+    assert _get_resource_request(None, pending_pods) == SignalResourceRequest(cpus=6, mem=1000, disk=0, gpus=0)
+
+
+def test_get_resource_request_pending_pods_and_metrics(allocated_metrics, pending_pods):
+    assert _get_resource_request(allocated_metrics, pending_pods) == SignalResourceRequest(
+        cpus=156,
+        mem=2000,
+        disk=500,
+        gpus=0,
+    )
+
+
+def test_get_max_resources():
+    assert _get_max_resources(
+        SignalResourceRequest(
+            cpus=100,
+            mem=50,
+        ),
+        SignalResourceRequest(
+            cpus=20,
+            mem=100,
+            gpus=1,
+        ),
+    ) == SignalResourceRequest(
+        cpus=100,
+        mem=100,
+        disk=None,
+        gpus=1,
+    )
+
+
+def test_most_recent_values(allocated_metrics, pending_pods_signal):
     with mock.patch(
-        'clusterman.signals.pending_pods_signal.get_metrics_for_signal', return_value=metrics,
+        'clusterman.signals.pending_pods_signal.get_metrics_for_signal',
+        return_value=allocated_metrics,
     ):
-        assert pending_pods_signal.evaluate(arrow.get(1234)) == dict(cpus=693, mem=1000, disk=500, gpus=None)
+        assert pending_pods_signal.evaluate(arrow.get(1234)) == SignalResourceRequest(
+            cpus=150,
+            mem=1000,
+            disk=500,
+            gpus=None,
+        )
 
 
 @pytest.mark.parametrize('timestamp', [1234, 2234])
@@ -38,7 +160,7 @@ def test_boost_factor(timestamp, pending_pods_signal):
         'clusterman.signals.pending_pods_signal.get_metrics_for_signal', return_value=metrics,
     ):
         expected_cpus = 750 if timestamp < 1500 else 150
-        assert pending_pods_signal.evaluate(arrow.get(timestamp)) == dict(
+        assert pending_pods_signal.evaluate(arrow.get(timestamp)) == SignalResourceRequest(
             cpus=expected_cpus,
             mem=None,
             disk=None,
@@ -51,4 +173,9 @@ def test_empty_metric_cache(pending_pods_signal):
     with mock.patch(
         'clusterman.signals.pending_pods_signal.get_metrics_for_signal', return_value=metrics,
     ):
-        assert pending_pods_signal.evaluate(arrow.get(1234)) == dict(cpus=None, mem=None, disk=None, gpus=None)
+        assert pending_pods_signal.evaluate(arrow.get(1234)) == SignalResourceRequest(
+            cpus=None,
+            mem=None,
+            disk=None,
+            gpus=None,
+        )


### PR DESCRIPTION
### Description

This code makes a few changes:

1) We read the list of pending pods directly from the Kubernetes
apiserver instead of it having to round-trip through the metrics
collector and back.  In theory this will improve Clusterman's
responsiveness to unschedulable pods.

2) We classify the reason for a pod being unschedulable.  Kubernetes
doesn't (seem to) provide this information, so we have to figure it out
ourselves.  Right now, the only two options are `InsufficientResources`
and `Unknown`, but this lays the groundwork for supporting other types
of "unschedulable" scenarios.

3) For any pods that are unschedulable because of
`InsufficientResources` we now request *double* the amount of resources
for them.  This obviously isn't the long-term solution that we want, but
hopefully in the short term it will alleviate some of the bin-packing
issues we've seen in various pools.

4) `paasta boost` will _no longer_ consider pending pods when it boosts,
just allocated resources... I'm not sure if this is the correct behavior
or not but `paasta boost` doesn't work right now anyways.  :)

5) fixed some issues with the acceptance testing pipeline

### Testing Done

`make test` passes; added new tests for the `PendingPodSignal`
