### PR TITLE
Implement Kubernetes versions of the acceptance tests using kind

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ docker-venv
 .cache
 .pytest_cache/
 .mypy_cache/
+acceptance/autoscaler_config.yaml
 package/itest/autoscaler_config.yaml
 package/itest/autoscaler_config.tmpl
 package/itest/run_instance.py
@@ -32,3 +33,4 @@ package/itest/trusty/*
 package/itest/xenial/*
 package/itest/bionic/*
 /completions/[a-zA-Z]*
+acceptance/.local*

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,16 @@ env:
     - TARGET: itest_bionic-external
 
 before_install:
-    - sudo apt-get install python3.7 python3.7-dev libfreetype6-dev
+    - eval $(gimme stable)  # install go
+    - sudo apt-get install python3.7 python3.7-dev
+    - curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+    - echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee -a /etc/apt/sources.list.d/kubernetes.list
+    - sudo apt-get update && sudo apt-get install kubectl
     - pip install tox
+    - GO111MODULE="on" go get sigs.k8s.io/kind@v0.8.1
+
+
+before_script:
+    - eval $(make -sC acceptance local-env)
+
 script: make $TARGET

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ itest: cook-image
 	./service-itest-runner clusterman.batch.spot_price_collector "--aws-region=us-west-1 "
 	./service-itest-runner clusterman.batch.cluster_metrics_collector "--cluster=local-dev"
 	./service-itest-runner clusterman.batch.autoscaler_bootstrap "" clusterman.batch.autoscaler
+	make -C acceptance local-cluster-clean && make -C acceptance acceptance-internal
 
 .PHONY: itest-external
 itest-external: cook-image-external
@@ -55,6 +56,7 @@ itest-external: cook-image-external
 	./service-itest-runner examples.batch.spot_price_collector "--aws-region=us-west-1 --env-config-path=acceptance/srv-configs/clusterman-external.yaml"
 	./service-itest-runner examples.batch.cluster_metrics_collector "--cluster=local-dev --env-config-path=acceptance/srv-configs/clusterman-external.yaml"
 	./service-itest-runner examples.batch.autoscaler_bootstrap "--env-config-path=acceptance/srv-configs/clusterman-external.yaml" examples.batch.autoscaler
+	make -C acceptance local-cluster-clean && make -C acceptance acceptance-external
 
 .PHONY: cook-image
 cook-image:

--- a/acceptance/Makefile
+++ b/acceptance/Makefile
@@ -1,0 +1,183 @@
+PROJECT_NAME ?= clusterman
+WHOAMI := $(shell whoami)
+KIND_CLUSTER ?= $(WHOAMI)-$(PROJECT_NAME)
+KUBECONFIG ?= .local-$(KIND_CLUSTER).conf
+DOCKER_IMAGE ?= $(PROJECT_NAME)-dev-$(WHOAMI)
+DOCKER_PORT ?= 31234
+DOCKER_REGISTRY ?= $(KIND_CLUSTER)-reg
+DOCKER_COMPOSE := COMPOSE_PROJECT_NAME=$(PROJECT_NAME)_k8s ../.tox/acceptance/bin/docker-compose -f docker-compose-k8s.yaml
+LOCAL_ENV ?= LOCAL_ENV_$(subst -,_,$(PROJECT_NAME))
+
+.PHONY: local-env-check
+local-env-check:
+	@which kind >/dev/null || (echo 'kind must be installed in PATH' && exit 1)
+	@which kubectl >/dev/null || (echo 'kubectl must be installed in PATH' && exit 1)
+	@test "$$$(LOCAL_ENV)" = "done" || (echo 'Please run `source <(make local-env)`.' && exit 1)
+
+.PHONY: local-env
+local-env:  ## Set env vars in current shell to do local cluster development: source <(make local-env)
+	@echo "export KIND_CLUSTER=$(KIND_CLUSTER)"
+	@echo "export KUBECONFIG=$(KUBECONFIG)"
+	@echo "export $(LOCAL_ENV)=done"
+
+.PHONY: local-cluster-internal
+local-cluster-internal: local-env-check .local-cluster.yaml .local-clusterman-internal.yaml .local-cluster-up
+	@echo Done.
+
+.PHONY: local-cluster-external
+local-cluster-external: local-env-check .local-cluster.yaml .local-clusterman-external.yaml .local-cluster-up
+	@echo Done.
+
+.local-cluster-up:
+	kind create cluster --name $(KIND_CLUSTER) --config .local-cluster.yaml --verbosity 2
+	kubectl -n kube-system get configmap/coredns -o yaml | \
+		sed "s|/etc/resolv.conf|$$(awk '/nameserver/ { print $$2; exit }' /etc/resolv.conf)|" | \
+		kubectl replace -f -
+	./k8s-local-docker-registry.sh $(DOCKER_REGISTRY) $(DOCKER_PORT) $(KIND_CLUSTER)
+	docker tag $(DOCKER_IMAGE) localhost:$(DOCKER_PORT)/$(DOCKER_IMAGE)
+	docker push localhost:$(DOCKER_PORT)/$(DOCKER_IMAGE)
+	docker exec $(KIND_CLUSTER)-control-plane mkdir -p /var/lib/clusterman
+	docker cp $(KUBECONFIG) $(KIND_CLUSTER)-control-plane:/var/lib/clusterman/clusterman.conf
+	docker exec $(KIND_CLUSTER)-control-plane chmod 644 /var/lib/clusterman/clusterman.conf
+	docker exec $(KIND_CLUSTER)-control-plane sed -i "s/\(.*server: \).*/\1https:\\/\\/127.0.0.1:6443/g" /var/lib/clusterman/clusterman.conf
+	$(DOCKER_COMPOSE) up -d moto-ec2 moto-s3 moto-dynamodb
+	sleep 10  # Give some time for the moto containers to come up
+	ACCEPTANCE_ROOT=. DISTRIB_CODENAME=bionic python run_instance.py \
+		$$($(DOCKER_COMPOSE) ps moto-ec2 | tail -n 1 | sed -e 's|^.*:\(.*\)->5000.*$$|http://127.0.0.1:\1|') \
+		$$($(DOCKER_COMPOSE) ps moto-s3 | tail -n 1 | sed -e 's|^.*:\(.*\)->5000.*$$|http://127.0.0.1:\1|') \
+		$$($(DOCKER_COMPOSE) ps moto-dynamodb | tail -n 1 | sed -e 's|^.*:\(.*\)->5000.*$$|http://127.0.0.1:\1|') \
+		172.27.0.0/24
+	touch .local-cluster-up
+
+.PHONY: acceptance-%
+acceptance-%: local-cluster-%
+	kubectl apply -f .local-clusterman-$*.yaml
+	echo "Checking to see if Clusterman is running..."
+	running=1; \
+	for count in 1 2 3 4 5 6 7 8 9 10; do \
+		echo "Not running yet, waiting 10 seconds and trying again (check $$count of 10)..."; \
+		sleep 10; \
+		kubectl describe pods; \
+		kubectl logs $$(kubectl get pods | grep clusterman | cut -f1 -d' '); \
+		if kubectl get pods | grep -q clusterman.*Running; then echo "Clusterman running successfully!"; running=0; break; fi; \
+	done; \
+	exit $$running
+
+define LOCAL_CLUSTER_YAML
+---
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    extraMounts:
+      - containerPath: /nail/srv/configs
+        hostPath: ./srv-configs
+        readOnly: true
+      - containerPath: /etc/boto_cfg/clusterman.json
+        hostPath: ./clusterman.json
+        readOnly: true
+      - containerPath: /etc/boto_cfg/clusterman.sh
+        hostPath: ./clusterman.json
+        readOnly: true
+      - containerPath: /etc/boto_cfg/clusterman_metrics.json
+        hostPath: ./clusterman.json
+        readOnly: true
+      - containerPath: /nail/etc/services/services.yaml
+        hostPath: /nail/etc/services/services.yaml
+        readOnly: true
+  - role: worker
+  - role: worker
+  - role: worker
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:$(DOCKER_PORT)"]
+    endpoint = ["http://$(DOCKER_REGISTRY):$(DOCKER_PORT)"]
+endef
+
+define LOCAL_CMAN_DEPLOYMENT
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: clusterman
+  labels:
+    app: clusterman
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: clusterman
+  template:
+    metadata:
+      labels:
+        app: clusterman
+    spec:
+      hostNetwork: true
+      nodeSelector:
+        kubernetes.io/hostname: $(KIND_CLUSTER)-control-plane
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: clusterman
+          image: localhost:$(DOCKER_PORT)/$(DOCKER_IMAGE)
+          command: ['python']
+          args: ['-m', $(CMD), $(EXTRA_ARGS)]
+          env:
+            - name: AWS_ENDPOINT_URL_ARGS
+              value: --endpoint-url http://moto-s3:5000
+            - name: CMAN_CLUSTER
+              value: local-dev
+            - name: CMAN_POOL
+              value: default
+            - name: CMAN_SCHEDULER
+              value: kubernetes
+          volumeMounts:
+            - name: services-yaml
+              mountPath: /nail/etc/services/services.yaml
+            - name: srvconfigs
+              mountPath: /nail/srv/configs
+            - name: botocfg
+              mountPath: /etc/boto_cfg
+            - name: kubeconfig
+              mountPath: /var/lib/clusterman/clusterman.conf
+      volumes:
+        - name: services-yaml
+          hostPath:
+            path: /nail/etc/services/services.yaml
+        - name: srvconfigs
+          hostPath:
+            path: /nail/srv/configs
+            type: Directory
+        - name: botocfg
+          hostPath:
+            path: /etc/boto_cfg
+            type: Directory
+        - name: kubeconfig
+          hostPath:
+            path: /var/lib/clusterman/clusterman.conf
+            type: File
+endef
+
+export LOCAL_CLUSTER_YAML
+.local-cluster.yaml:  ## Create config file for `kind` cluster manager
+	$(MAKE) local-cluster-clean || true
+	@echo "$$LOCAL_CLUSTER_YAML" > .local-cluster.yaml
+
+export LOCAL_CMAN_DEPLOYMENT
+export CMD="clusterman.batch.autoscaler_bootstrap"
+.local-clusterman-internal.yaml:  ## Create config file for `kind` cluster manager
+	@echo "$$LOCAL_CMAN_DEPLOYMENT" > .local-clusterman-internal.yaml
+
+export LOCAL_CMAN_DEPLOYMENT
+export EXTRA_ARGS="--env-config-path=/nail/srv/configs/clusterman-external.yaml"
+export CMD="examples.batch.autoscaler_bootstrap"
+.local-clusterman-external.yaml:  ## Create config file for `kind` cluster manager
+	@echo "$$LOCAL_CMAN_DEPLOYMENT" > .local-clusterman-external.yaml
+
+.PHONY: local-cluster-clean
+local-cluster-clean:  ## Run if your local cluster is having issues starting
+	-kind delete cluster --name $(KIND_CLUSTER) --verbosity 2
+	-docker stop $(DOCKER_REGISTRY)
+	-docker rm $(DOCKER_REGISTRY)
+	-../.tox/acceptance/bin/docker-compose -f docker-compose-k8s.yaml down
+	rm -f .local*

--- a/acceptance/docker-compose-k8s.yaml
+++ b/acceptance/docker-compose-k8s.yaml
@@ -1,0 +1,23 @@
+version: "2"
+
+services:
+  moto-ec2:
+    build: ./moto/
+    ports:
+      - 5000
+    command: 'ec2'
+  moto-s3:
+    build: ./moto/
+    ports:
+      - 5000
+    command: 's3'
+  moto-dynamodb:
+    build: ./moto/
+    ports:
+      - 5000
+    command: 'dynamodb2'
+
+networks:
+  default:
+    external:
+      name: kind

--- a/acceptance/k8s-local-docker-registry.sh
+++ b/acceptance/k8s-local-docker-registry.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -o errexit -x
+
+REG_NAME=$1
+REG_PORT=$2
+CLUSTER_NAME=$3
+
+# create registry container unless it already exists
+running="$(docker inspect -f '{{.State.Running}}' "${REG_NAME}" 2>/dev/null || true)"
+if [ "${running}" != 'true' ]; then
+    docker run -d --restart=always -e REGISTRY_HTTP_ADDR=0.0.0.0:${REG_PORT} -p "${REG_PORT}:${REG_PORT}" --name "${REG_NAME}" registry:2
+fi
+
+# connect the registry to the cluster network
+docker network connect "kind" "${REG_NAME}"
+
+# tell https://tilt.dev to use the registry
+# https://docs.tilt.dev/choosing_clusters.html#discovering-the-registry
+for node in $(kind get nodes --name ${CLUSTER_NAME}); do
+    kubectl annotate node "${node}" "kind.x-k8s.io/registry=localhost:${REG_PORT}";
+done

--- a/acceptance/run_instance.py
+++ b/acceptance/run_instance.py
@@ -13,18 +13,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+import sys
 
 import boto3
 import simplejson as json
 import yaml
 
+ec2_url = sys.argv[1]
+s3_url = sys.argv[2]
+ddb_url = sys.argv[3]
+cidr_block = sys.argv[4]
+
 root = os.environ['ACCEPTANCE_ROOT']
 session = boto3.session.Session('foo', 'bar', region_name='us-west-2')
-ec2 = session.client('ec2', endpoint_url='http://moto-ec2:5000')
-s3 = session.client('s3', endpoint_url='http://moto-s3:5000')
-dynamodb = session.client('dynamodb', endpoint_url='http://moto-dynamodb:5000')
+ec2 = session.client('ec2', endpoint_url=ec2_url)
+s3 = session.client('s3', endpoint_url=s3_url)
+dynamodb = session.client('dynamodb', endpoint_url=ddb_url)
 
-cidr_block = '10.0.0.0/24' if os.environ['DISTRIB_CODENAME'] == 'xenial' else '11.0.0.0/24'
 vpc_response = ec2.create_vpc(CidrBlock=cidr_block)
 subnet_response = ec2.create_subnet(
     CidrBlock=cidr_block,

--- a/acceptance/srv-configs/clusterman-clusters/local-dev/default.kubernetes
+++ b/acceptance/srv-configs/clusterman-clusters/local-dev/default.kubernetes
@@ -1,0 +1,17 @@
+---
+resource_groups:
+  - sfr:
+      s3:
+        bucket: clusterman-resource-groups
+        prefix: acceptance
+
+scaling_limits:
+  min_capacity: 10
+  max_capacity: 60
+  max_tasks_to_kill: 100
+  max_weight_to_add: 10
+  max_weight_to_remove: 10
+
+autoscale_signal:
+  internal: true
+  period_minutes: 1

--- a/acceptance/srv-configs/clusterman-external.yaml
+++ b/acceptance/srv-configs/clusterman-external.yaml
@@ -12,6 +12,7 @@ clusters:
     local-dev:
         aws_region: us-west-2
         mesos_master_fqdn: mesosmaster
+        kubeconfig_path: /var/lib/clusterman/clusterman.conf
 
 aws:
     endpoint_url: http://moto-{svc}:5000

--- a/acceptance/srv-configs/clusterman.yaml
+++ b/acceptance/srv-configs/clusterman.yaml
@@ -24,6 +24,7 @@ clusters:
     local-dev:
         aws_region: us-west-2
         mesos_master_fqdn: mesosmaster
+        kubeconfig_path: /var/lib/clusterman/clusterman.conf
 
 aws:
     endpoint_url: http://moto-{svc}:5000

--- a/clusterman/batch/cluster_metrics_collector.py
+++ b/clusterman/batch/cluster_metrics_collector.py
@@ -117,8 +117,12 @@ class ClusterMetricsCollector(BatchDaemon, BatchLoggingMixin, BatchRunningSentin
         self.pool_managers: Mapping[str, PoolManager] = {}
         for scheduler, pools in self.pools.items():
             for pool in pools:
-                logger.info(f'Loading resource groups for {pool}.{scheduler} on {self.options.cluster}')
-                self.pool_managers[f'{pool}.{scheduler}'] = PoolManager(self.options.cluster, pool, scheduler)
+                try:
+                    logger.info(f'Loading resource groups for {pool}.{scheduler} on {self.options.cluster}')
+                    self.pool_managers[f'{pool}.{scheduler}'] = PoolManager(self.options.cluster, pool, scheduler)
+                except Exception as e:
+                    logger.exception(e)
+                    continue
 
     @suppress_request_limit_exceeded()
     def run(self) -> None:

--- a/examples/batch/cluster_metrics_collector.py
+++ b/examples/batch/cluster_metrics_collector.py
@@ -103,8 +103,12 @@ class ClusterMetricsCollector(BatchRunningSentinelMixin):
         self.pool_managers: Mapping[str, PoolManager] = {}
         for scheduler, pools in self.pools.items():
             for pool in pools:
-                logger.info(f'Loading resource groups for {pool}.{scheduler} on {self.options.cluster}')
-                self.pool_managers[f'{pool}.{scheduler}'] = PoolManager(self.options.cluster, pool, scheduler)
+                try:
+                    logger.info(f'Loading resource groups for {pool}.{scheduler} on {self.options.cluster}')
+                    self.pool_managers[f'{pool}.{scheduler}'] = PoolManager(self.options.cluster, pool, scheduler)
+                except Exception as e:
+                    logger.exception(e)
+                    continue
 
     @suppress_request_limit_exceeded()
     def run(self) -> None:

--- a/service-itest-runner
+++ b/service-itest-runner
@@ -12,6 +12,13 @@ docker inspect --type=image "${IMAGE_NAME}" > /dev/null || \
     IMAGE_NAME="docker-paasta.yelpcorp.com:443/services-clusterman:paasta-$(git rev-parse HEAD)"
 DISTRIB_CODENAME=$(docker run -t "${IMAGE_NAME}" lsb_release -cs | tr -d '\n\r')
 
+# Sometimes our acceptance tests run in parallel on the same box, so we need to use different CIDR ranges
+if [ "${DISTRIB_CODENAME}" = "xenial" ]; then
+    CIDR_BLOCK="10.0.0.0/24"
+else
+    CIDR_BLOCK="11.0.0.0/24"
+fi
+
 if [ "${EXTRA_VOLUME_MOUNTS}" ]; then
     EXTRA_FLAGS="-v ${EXTRA_VOLUME_MOUNTS}"
 fi
@@ -27,7 +34,12 @@ docker run -t -v "$(pwd)/acceptance/srv-configs:/nail/srv/configs:ro" \
 while [ -z "${CONTAINER}" ]; do CONTAINER=$(docker ps | egrep "${IMAGE_NAME}" | cut -d' ' -f1); done
 docker network connect "clusterman_${DISTRIB_CODENAME}_default" "${CONTAINER}"
 docker network connect "clusterman_${DISTRIB_CODENAME}_acceptance" "${CONTAINER}"
-docker exec -e "DISTRIB_CODENAME=${DISTRIB_CODENAME}" -e ACCEPTANCE_ROOT=/code/acceptance --user=0 "${CONTAINER}" python acceptance/run_instance.py
+docker exec -e "DISTRIB_CODENAME=${DISTRIB_CODENAME}" -e ACCEPTANCE_ROOT=/code/acceptance --user=0 "${CONTAINER}" python acceptance/run_instance.py \
+    http://moto-ec2:5000/ \
+    http://moto-s3:5000/ \
+    http://moto-dynamodb:5000/ \
+    "${CIDR_BLOCK}"
+
 docker exec -t --user=0 \
     -e CMAN_CLUSTER=local-dev \
     -e CMAN_POOL=default \


### PR DESCRIPTION
### Description

The pre-existing acceptance testing was running against a Dockerized
Mesos cluster, which is going to start causing problems as we want to
test Kubernetes-specific functionality.  This change adds in a
Kubernetes cluster via `kind`, and runs the autoscaler acceptence tests
against it.

We also fix a small issue where the metrics collector crashes if it
can't load a PoolManager for a particular pool; now it will just log the
error and continue.

### How it works

Adapted from @keymone's acceptance testing for the various operators; we use kind to create a local Kubernetes cluster, and then we apply the Clusterman deployment to the kind cluster.  The Clusterman docker image is uploaded to a local (testing) Docker registry, as described [in the kind docs](https://kind.sigs.k8s.io/docs/user/local-registry/).  We're able to use a slightly modified version of the `run_instances.py` script to launch some fake EC2 instances via `moto`, and then we just use `kubectl` to watch for the Clusterman autoscaler pod to successfully start.

There are some minor differences between the internal and external builds based on what files are present and where in Travis versus internally.

### Testing Done

`make itest`
`make itest-external`

### Note

We'll need to roll out an updated version of `kind` everywhere before this will pass internal testing pipelines.
