### PR TITLE
don't use external PyPI internally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ test-external: clean-cache
 .PHONY: itest
 itest: export EXTRA_VOLUME_MOUNTS=/nail/etc/services/services.yaml:/nail/etc/services/services.yaml:ro
 itest: cook-image
-	COMPOSE_PROJECT_NAME=clusterman_xenial tox -e acceptance
+	COMPOSE_PROJECT_NAME=clusterman_xenial PIP_INDEX_URL=https://pypi.yelpcorp.com/simple tox -e acceptance
 	./service-itest-runner clusterman.batch.spot_price_collector "--aws-region=us-west-1 "
 	./service-itest-runner clusterman.batch.cluster_metrics_collector "--cluster=local-dev"
 	./service-itest-runner clusterman.batch.autoscaler_bootstrap "" clusterman.batch.autoscaler

--- a/acceptance/Makefile
+++ b/acceptance/Makefile
@@ -6,26 +6,13 @@ DOCKER_IMAGE ?= $(PROJECT_NAME)-dev-$(WHOAMI)
 DOCKER_PORT ?= 31234
 DOCKER_REGISTRY ?= $(KIND_CLUSTER)-reg
 DOCKER_COMPOSE := COMPOSE_PROJECT_NAME=$(PROJECT_NAME)_k8s ../.tox/acceptance/bin/docker-compose -f docker-compose-k8s.yaml
-LOCAL_ENV ?= LOCAL_ENV_$(subst -,_,$(PROJECT_NAME))
-
-.PHONY: local-env-check
-local-env-check:
-	@which kind >/dev/null || (echo 'kind must be installed in PATH' && exit 1)
-	@which kubectl >/dev/null || (echo 'kubectl must be installed in PATH' && exit 1)
-	@test "$$$(LOCAL_ENV)" = "done" || (echo 'Please run `source <(make local-env)`.' && exit 1)
-
-.PHONY: local-env
-local-env:  ## Set env vars in current shell to do local cluster development: source <(make local-env)
-	@echo "export KIND_CLUSTER=$(KIND_CLUSTER)"
-	@echo "export KUBECONFIG=$(KUBECONFIG)"
-	@echo "export $(LOCAL_ENV)=done"
 
 .PHONY: local-cluster-internal
-local-cluster-internal: local-env-check .local-cluster.yaml .local-clusterman-internal.yaml .local-cluster-up
+local-cluster-internal: .local-cluster.yaml .local-clusterman-internal.yaml .local-cluster-up
 	@echo Done.
 
 .PHONY: local-cluster-external
-local-cluster-external: local-env-check .local-cluster.yaml .local-clusterman-external.yaml .local-cluster-up
+local-cluster-external: .local-cluster.yaml .local-clusterman-external.yaml .local-cluster-up
 	@echo Done.
 
 .local-cluster-up:
@@ -50,6 +37,8 @@ local-cluster-external: local-env-check .local-cluster.yaml .local-clusterman-ex
 	touch .local-cluster-up
 
 .PHONY: acceptance-%
+export KIND_CLUSTER
+export KUBECONFIG
 acceptance-%: local-cluster-%
 	kubectl apply -f .local-clusterman-$*.yaml
 	echo "Checking to see if Clusterman is running..."

--- a/package/itest/ubuntu.sh
+++ b/package/itest/ubuntu.sh
@@ -35,7 +35,7 @@ dpkg -i /dist/${DISTRIB_CODENAME}/clusterman_${PACKAGE_VERSION}_amd64.deb || tru
 apt-get install -y --force-yes --fix-broken
 
 export ACCEPTANCE_ROOT=/itest
-pip3 install boto3 simplejson
+pip3 --index-url https://pypi.yelpcorp.com/simple install boto3 simplejson
 python3 /itest/run_instance.py
 
 # Run the critical clusterman CLI commands

--- a/tox.ini
+++ b/tox.ini
@@ -69,7 +69,7 @@ commands =
 [testenv:acceptance]
 basepython = /usr/bin/python3.6
 envdir = .tox/acceptance
-passenv = COMPOSE_PROJECT_NAME
+passenv = COMPOSE_PROJECT_NAME PIP_INDEX_URL
 deps =
     docker-compose
 commands =


### PR DESCRIPTION
### Description

Make sure we're not using the external PyPI for internal builds.

Also, fix the internal build: In order to run the itests you need the environment variables set, but there's no way to run `source <(make local-env)` on Jenkins without creating a custom Jenkinsfile, which I didn't want to do. So instead I just export the two variables right before the appropriate Make target, which should allow the build to pass internally.

### Testing Done

I'll double-check the Jenkins logs after I push this.
