### PR TITLE
fix AWS schema error and log when we can't load a resource group

### DIFF
--- a/clusterman/aws/auto_scaling_resource_group.py
+++ b/clusterman/aws/auto_scaling_resource_group.py
@@ -164,7 +164,7 @@ class AutoScalingResourceGroup(AWSResourceGroup):
         except KeyError:
             policy = self._group_config['MixedInstancesPolicy']
             template = policy['LaunchTemplate']['LaunchTemplateSpecification']
-            overrides = policy['Overrides']
+            overrides = policy['LaunchTemplate']['Overrides']
 
         launch_template_name = template['LaunchTemplateName']
         launch_template_version = template['Version']

--- a/clusterman/aws/aws_resource_group.py
+++ b/clusterman/aws/aws_resource_group.py
@@ -189,11 +189,15 @@ class AWSResourceGroup(ResourceGroup, metaclass=ABCMeta):
 
         for rg_id, tags in resource_group_tags.items():
             try:
-                identifier_tags = json.loads(tags[identifier_tag_label])
-                if identifier_tags['pool'] == pool and identifier_tags['paasta_cluster'] == cluster:
-                    rg = cls(rg_id, **kwargs)
-                    matching_resource_groups[rg_id] = rg
+                tag_json = tags.get(identifier_tag_label)
+                # Not every ASG/SFR/etc will have the right tags, because they belong to someone else
+                if tag_json:
+                    identifier_tags = json.loads(tag_json)
+                    if identifier_tags['pool'] == pool and identifier_tags['paasta_cluster'] == cluster:
+                        rg = cls(rg_id, **kwargs)
+                        matching_resource_groups[rg_id] = rg
             except KeyError:
+                logger.exception(f'Could not load resource group {rg_id}; skipping...')
                 continue
         return matching_resource_groups
 

--- a/clusterman/aws/response_types.py
+++ b/clusterman/aws/response_types.py
@@ -14,18 +14,18 @@ class LaunchTemplateConfig(TypedDict):
     Version: str
 
 
-class MixedInstancesPolicyLaunchTemplateConfig(TypedDict):
-    LaunchTemplateSpecification: LaunchTemplateConfig
-
-
 class InstanceOverrideConfig(TypedDict):
     InstanceType: str
     WeightedCapacity: str
 
 
+class MixedInstancesPolicyLaunchTemplateConfig(TypedDict):
+    LaunchTemplateSpecification: LaunchTemplateConfig
+    Overrides: List[InstanceOverrideConfig]
+
+
 class MixedInstancesPolicyConfig(TypedDict):
     LaunchTemplate: MixedInstancesPolicyLaunchTemplateConfig
-    Overrides: List[InstanceOverrideConfig]
 
 
 class AutoScalingGroupConfig(TypedDict):


### PR DESCRIPTION
### Description

I misread the AWS schema, and we couldn't tell why things were failing because we had a `try: ... except: continue` block.

### Testing Done

`make test`
manual testing on infrastage
we can't ship this until https://github.com/Yelp/terraform-code/pull/2310 is shipped.
