### PR TITLE
Small-ish change to stick a little glue in place for the PendingPods signal

### DIFF
--- a/clusterman/interfaces/signal.py
+++ b/clusterman/interfaces/signal.py
@@ -24,6 +24,7 @@ from clusterman_metrics import APP_METRICS
 from clusterman_metrics import ClustermanMetricsBotoClient
 from clusterman_metrics import MetricsValuesDict
 from clusterman_metrics import SYSTEM_METRICS
+from kubernetes.client.models.v1_pod import V1Pod as KubernetesPod
 from mypy_extensions import TypedDict
 
 from clusterman.exceptions import MetricsError
@@ -88,7 +89,7 @@ class Signal(metaclass=ABCMeta):
             self,
             timestamp: arrow.Arrow,
             retry_on_broken_pipe: bool = True,
-     ) -> Union[SignalResourceRequest, List[SignalResourceRequest]]:
+     ) -> Union[SignalResourceRequest, List[KubernetesPod]]:
         """ Compute a signal and return either a single response (representing an aggregate resource request), or a
         list of responses (representing per-pod resource requests)
 


### PR DESCRIPTION
### Description

The pending pods signal will now optionally just return a list of the
unscheduled pods in the cluster (protip: don't do this yet or
literally nothing will autoscale at all).

If you pass in the `per_pod_resource_requests` parameter to the signal,
it will just find the unschedulable pods and return them in a list.
This list should get passed in to the
`_compute_new_resource_group_actions` function from
https://github.com/Yelp/clusterman/pull/51.

That function will then call the
`PoolManager._filter_scale_up_options_for_pod` in order to determine
what nodes options the pod could run on (note that, by passing in a
`ClusterNodeMetadata` object with `allocated_resources` set we can
determine if the pod will fit on a pre-existing node).

### Testing Done

`make test` passes.  In general I didn't really add any tests here yet because none of these code paths are used.
