### PR TITLE
Implement checks to see if a pod can be scheduled on a node

### DIFF
--- a/clusterman/interfaces/types.py
+++ b/clusterman/interfaces/types.py
@@ -1,8 +1,11 @@
 import enum
+from typing import List
+from typing import Mapping
 from typing import NamedTuple
 from typing import Optional
 
 import arrow
+from kubernetes.client.models.v1_taint import V1Taint as KubernetesTaint
 
 from clusterman.aws.markets import InstanceMarket
 from clusterman.util import ClustermanResources
@@ -20,9 +23,13 @@ class AgentMetadata(NamedTuple):
     allocated_resources: ClustermanResources = ClustermanResources()
     batch_task_count: int = 0
     is_safe_to_kill: bool = True
+    labels: Mapping[str, str] = {}
+    max_tasks: Optional[int] = None
     state: AgentState = AgentState.UNKNOWN
+    taints: List[KubernetesTaint] = []
     task_count: int = 0
     total_resources: ClustermanResources = ClustermanResources()
+    unschedulable: bool = False
 
 
 class InstanceMetadata(NamedTuple):

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -180,11 +180,15 @@ class KubernetesClusterConnector(ClusterConnector):
         return AgentMetadata(
             agent_id=node.metadata.name,
             allocated_resources=allocated_node_resources(self._pods_by_ip[node_ip]),
-            is_safe_to_kill=self._is_node_safe_to_kill(node_ip),
             batch_task_count=self._count_batch_tasks(node_ip),
+            is_safe_to_kill=self._is_node_safe_to_kill(node_ip),
+            labels=node.metadata.labels,
+            max_tasks=int(node.status.allocatable['pods']),
             state=(AgentState.RUNNING if self._pods_by_ip[node_ip] else AgentState.IDLE),
+            taints=node.spec.taints,
             task_count=len(self._pods_by_ip[node_ip]),
             total_resources=total_node_resources(node),
+            unschedulable=strtobool(node.spec.unschedulable),
         )
 
     def _is_node_safe_to_kill(self, node_ip: str) -> bool:

--- a/tests/kubernetes/util_test.py
+++ b/tests/kubernetes/util_test.py
@@ -1,0 +1,54 @@
+import pytest
+from kubernetes.client.models import V1Taint
+from kubernetes.client.models import V1Toleration
+
+from clusterman.kubernetes.util import is_node_tolerable
+
+
+def test_is_node_tolerable_no_taints(pod1):
+    assert is_node_tolerable(pod1, [])
+
+
+def test_is_node_tolerable_with_taint(pod1):
+    taint = V1Taint(effect='NoExecute', key='clusterman.com/tainted', value='true')
+    assert not is_node_tolerable(pod1, [taint])
+
+
+@pytest.mark.parametrize('key', ['', 'clusterman.com/tainted'])
+@pytest.mark.parametrize('operator,value,effect', [
+    ('', 'true', ''),
+    ('Equal', 'true', 'NoExecute'),
+    ('Exists', '', ''),
+    ('Exists', '', 'NoExecute'),
+])
+def test_is_node_tolerable_with_taint_and_matching_toleration(pod1, key, value, effect, operator):
+    taint = V1Taint(effect='NoExecute', key='clusterman.com/tainted', value='true')
+    pod1.spec.tolerations = [V1Toleration(key=key, value=value, effect=effect, operator=operator)]
+    assert is_node_tolerable(pod1, [taint])
+
+
+@pytest.mark.parametrize('key,operator,value,effect', [
+    ('clusterman.com/other', '', 'true', ''),
+    ('clusterman.com/other', 'Exists', '', ''),
+    ('clusterman.com/tainted', '', 'false', ''),
+    ('clusterman.com/tainted', 'Equal', 'false', 'NoExecute'),
+    ('clusterman.com/tainted', '', 'false', 'NoSchedule'),
+    ('clusterman.com/tainted', '', 'true', 'NoSchedule'),
+])
+def test_is_node_tolerable_with_taint_and_non_matching_toleration(pod1, key, value, effect, operator):
+    taint = V1Taint(effect='NoExecute', key='clusterman.com/tainted', value='true')
+    pod1.spec.tolerations = [V1Toleration(key=key, value=value, effect=effect, operator=operator)]
+    assert not is_node_tolerable(pod1, [taint])
+
+
+def test_is_node_tolerable_with_multiple_taints_and_non_matching_toleration(pod1):
+    taint1 = V1Taint(effect='NoExecute', key='clusterman.com/tainted', value='true')
+    taint2 = V1Taint(effect='NoExecute', key='clusterman.com/tainted2', value='true')
+    pod1.spec.tolerations = [V1Toleration(key='clusterman.com/tainted', value='true')]
+    assert not is_node_tolerable(pod1, [taint1, taint2])
+
+
+def test_is_node_tolerable_prefer_no_schedule(pod1):
+    taint = V1Taint(effect='PreferNoSchedule', key='clusterman.com/tainted', value='true')
+    pod1.spec.tolerations = [V1Toleration(key='clusterman.com/tainted', value='false')]
+    assert is_node_tolerable(pod1, [taint])


### PR DESCRIPTION
### Description

This commit checks the following conditions to see if a pod can be
scheduled on a particular node:

0) Is the node "schedulable" from Kubernetes' perspective?
1) Is the node's "max_tasks" (i.e., the maxpods kubelet setting)
   respected?
2) Does the node match the pod's nodeSelector(s)?
3) Does the pod have the appropriate tolerations for the node's taints?

If the answer to these three questions is "yes", the node will be added
as an option for the pod to be scheduled on.

### Testing Done

`make test` passes; new tests added for `_filter_scale_up_options_for_pod` and `is_node_tolerable`
