### PR TITLE
add helpful messages if you're running commands in the wrong place

### DIFF
--- a/clusterman/cli/manage.py
+++ b/clusterman/cli/manage.py
@@ -24,6 +24,7 @@ from clusterman.args import add_pool_arg
 from clusterman.args import add_scheduler_arg
 from clusterman.args import subparser
 from clusterman.autoscaler.pool_manager import PoolManager
+from clusterman.cli.util import timeout_wrapper
 from clusterman.config import POOL_NAMESPACE
 from clusterman.util import ask_for_confirmation
 from clusterman.util import get_autoscaler_scribe_stream
@@ -74,6 +75,7 @@ def mark_stale(manager: PoolManager, dry_run: bool) -> str:
     )
 
 
+@timeout_wrapper
 def main(args: argparse.Namespace) -> None:
     if args.target_capacity and args.mark_stale:
         raise ValueError('Cannot specify --target-capacity and --mark-stale simultaneously')

--- a/clusterman/cli/status.py
+++ b/clusterman/cli/status.py
@@ -26,6 +26,7 @@ from clusterman.args import add_pool_arg
 from clusterman.args import add_scheduler_arg
 from clusterman.args import subparser
 from clusterman.autoscaler.pool_manager import PoolManager
+from clusterman.cli.util import timeout_wrapper
 from clusterman.interfaces.types import AgentState
 from clusterman.interfaces.types import ClusterNodeMetadata
 from clusterman.util import any_of
@@ -136,6 +137,7 @@ def print_status(manager: PoolManager, args) -> None:
     sys.stdout.write('\n')
 
 
+@timeout_wrapper
 def main(args: argparse.Namespace) -> None:  # pragma: no cover
     manager = PoolManager(args.cluster, args.pool, args.scheduler)
     print_status(manager, args)

--- a/clusterman/cli/toggle.py
+++ b/clusterman/cli/toggle.py
@@ -22,12 +22,14 @@ from clusterman.args import add_pool_arg
 from clusterman.args import add_scheduler_arg
 from clusterman.args import subparser
 from clusterman.aws.client import dynamodb
+from clusterman.cli.util import timeout_wrapper
 from clusterman.util import AUTOSCALER_PAUSED
 from clusterman.util import autoscaling_is_paused
 from clusterman.util import CLUSTERMAN_STATE_TABLE
 from clusterman.util import parse_time_string
 
 
+@timeout_wrapper
 def disable(args: argparse.Namespace) -> None:
     state = {
         'state': {'S': AUTOSCALER_PAUSED},
@@ -54,6 +56,7 @@ def disable(args: argparse.Namespace) -> None:
         print(s)
 
 
+@timeout_wrapper
 def enable(args: argparse.Namespace) -> None:
     dynamodb.delete_item(
         TableName=staticconf.read('aws.state_table', default=CLUSTERMAN_STATE_TABLE),

--- a/clusterman/cli/util.py
+++ b/clusterman/cli/util.py
@@ -1,0 +1,25 @@
+import argparse
+import signal
+import socket
+
+import colorlog
+
+logger = colorlog.getLogger(__name__)
+TIMEOUT_TIME_SECONDS = 10
+
+
+def timeout_wrapper(main):
+    def wrapper(args: argparse.Namespace):
+
+        # After 10s, prints a warning message if the command is running from the wrong place
+        def timeout_handler(signum, frame):
+            warning_string = 'This command is taking a long time to run; are you running from the right account?'
+            if 'yelpcorp' in socket.getfqdn():
+                warning_string += '\nHINT: try ssh\'ing to adhoc-prod or another box in the right account.'
+            logger.warning(warning_string)
+
+        signal.signal(signal.SIGALRM, timeout_handler)
+        signal.alarm(TIMEOUT_TIME_SECONDS)
+
+        main(args)
+    return wrapper

--- a/clusterman/run.py
+++ b/clusterman/run.py
@@ -21,7 +21,7 @@ from clusterman.util import setup_logging
 def main(argv=None):
     if argv is None:
         argv = sys.argv[1:]
-    args = parse_args(argv, 'Mesos cluster scaling and management')
+    args = parse_args(argv, 'Cluster scaling and management for Mesos and Kubernetes')
     setup_logging(args.log_level)
     setup_config(args)
     args.entrypoint(args)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -33,7 +33,7 @@ mccabe==0.6.1
 mock==3.0.5
 more-itertools==7.2.0
 #moto==1.3.13
--e git+git://github.com/kevinfrommelt/moto@asg-from-launch-template#egg=moto
+-e git+git://github.com/spulec/moto@55b02c6ee92ff6b0bd8dd381b7fc8b1520230603#egg=moto
 mypy==0.730
 nodeenv==1.3.3
 packaging==19.2


### PR DESCRIPTION
### Description

This change lets you know if you're running from dev and trying to access a prod cluster, or running a Kubernetes command not on a Kubernetes master, instead of just spitting out tracebacks.  Modified slightly from #27 .

### Testing Done

`make test`
manual testing