### PR TITLE
Stop writing framework metadata metrics because they are unused and a…

### DIFF
--- a/clusterman/batch/cluster_metrics_collector.py
+++ b/clusterman/batch/cluster_metrics_collector.py
@@ -47,7 +47,6 @@ from clusterman.config import get_pool_config_path
 from clusterman.config import load_cluster_pool_config
 from clusterman.config import setup_config
 from clusterman.mesos.metrics_generators import ClusterMetric
-from clusterman.mesos.metrics_generators import generate_framework_metadata
 from clusterman.mesos.metrics_generators import generate_kubernetes_metrics
 from clusterman.mesos.metrics_generators import generate_simple_metadata
 from clusterman.mesos.metrics_generators import generate_system_metrics
@@ -75,8 +74,6 @@ METRICS_TO_WRITE = [
                   pools=All, schedulers=['kubernetes', 'mesos']),
     MetricToWrite(generate_simple_metadata, METADATA, aggregate_meteorite_dims=False,
                   pools=All, schedulers=['kubernetes', 'mesos']),
-    MetricToWrite(generate_framework_metadata, METADATA, aggregate_meteorite_dims=True,
-                  pools=['default.mesos'], schedulers=['mesos']),
 ]
 
 

--- a/examples/batch/cluster_metrics_collector.py
+++ b/examples/batch/cluster_metrics_collector.py
@@ -39,7 +39,6 @@ from clusterman.autoscaler.pool_manager import PoolManager
 from clusterman.config import load_cluster_pool_config
 from clusterman.config import setup_config
 from clusterman.mesos.metrics_generators import ClusterMetric
-from clusterman.mesos.metrics_generators import generate_framework_metadata
 from clusterman.mesos.metrics_generators import generate_simple_metadata
 from clusterman.mesos.metrics_generators import generate_system_metrics
 from clusterman.util import All
@@ -62,12 +61,6 @@ class MetricToWrite(NamedTuple):
 METRICS_TO_WRITE = [
     MetricToWrite(generate_system_metrics, SYSTEM_METRICS, aggregate_meteorite_dims=False, pools=All),
     MetricToWrite(generate_simple_metadata, METADATA, aggregate_meteorite_dims=False, pools=All),
-    MetricToWrite(
-        generate_framework_metadata,
-        METADATA,
-        aggregate_meteorite_dims=True,
-        pools=['default'],
-    ),
 ]
 
 

--- a/itests/steps/pool_manager.py
+++ b/itests/steps/pool_manager.py
@@ -67,7 +67,7 @@ def mock_agents_by_ip_and_tasks(context):
         side_effect=get_agents_by_ip,
     ), mock.patch(
         'clusterman.mesos.mesos_cluster_connector.MesosClusterConnector._get_tasks_and_frameworks',
-        return_value=([], [], []),
+        return_value=([], []),
     ), staticconf.testing.PatchConfiguration(
         {'scaling_limits': {'max_weight_to_remove': 1000}},
         namespace='bar.mesos_config',

--- a/itests/steps/prune_excess_fulfilled_capacity.py
+++ b/itests/steps/prune_excess_fulfilled_capacity.py
@@ -81,7 +81,6 @@ def killable_instance_with_tasks(context, tasks):
                 {'slave_id': instances[0]['InstanceId'], 'state': 'TASK_RUNNING', 'framework_id': 'framework_a'}
             ] * int(tasks),
             {'framework_a': {'name': 'framework_a_name'}},
-            {},
         )
 
     context.pool_manager.cluster_connector._get_tasks_and_frameworks.side_effect = get_tasks_and_frameworks

--- a/tests/batch/cluster_metrics_collector_test.py
+++ b/tests/batch/cluster_metrics_collector_test.py
@@ -153,6 +153,6 @@ def test_run(mock_sensu, mock_running, mock_time, mock_sleep, batch):
 
         assert writer_context.__exit__.call_count == len(METRICS_TO_WRITE) * 4
         assert mock_sensu.call_count == 3
-        assert mock_logger.warn.call_count == 4
+        assert mock_logger.warn.call_count == len(METRICS_TO_WRITE)
 
     assert mock_sleep.call_args_list == [mock.call(9), mock.call(7), mock.call(2), mock.call(2)]


### PR DESCRIPTION
…re slowing down the cluster_metrics_collector

These were originally added for use by the SparkSignal, but it never got around to using them.

See CLUSTERMAN-560

### Description
I maybe went overboard deleting things?

### Testing Done
`make test`
`make itest`