### PR TITLE
Remove all dependence on DynamoDB metrics from the internal signal

### DIFF
--- a/clusterman/autoscaler/autoscaler.py
+++ b/clusterman/autoscaler/autoscaler.py
@@ -236,8 +236,8 @@ class Autoscaler:
         :returns: the new target capacity we should scale to
         """
         current_target_capacity = self.pool_manager.target_capacity
-        cluster_total_resources = self._get_cluster_total_resources()
-        cluster_allocated_resources = self._get_cluster_allocated_resources()
+        cluster_total_resources = self.pool_manager.cluster_connector.get_cluster_total_resources()
+        cluster_allocated_resources = self.pool_manager.cluster_connector.get_cluster_allocated_resources()
         non_orphan_fulfilled_capacity = self.pool_manager.non_orphan_fulfilled_capacity
         logger.info(f'Currently at target_capacity of {current_target_capacity}')
         logger.info(f'Currently non-orphan fulfilled capacity is {non_orphan_fulfilled_capacity}')
@@ -350,20 +350,6 @@ class Autoscaler:
             new_target_capacity = current_target_capacity
 
         return new_target_capacity
-
-    def _get_cluster_total_resources(self) -> ClustermanResources:
-        total_resources = {
-            resource: self.pool_manager.cluster_connector.get_resource_total(resource)
-            for resource in ClustermanResources._fields
-        }
-        return ClustermanResources(**total_resources)
-
-    def _get_cluster_allocated_resources(self) -> ClustermanResources:
-        allocated_resources = {
-            resource: self.pool_manager.cluster_connector.get_resource_allocation(resource)
-            for resource in ClustermanResources._fields
-        }
-        return ClustermanResources(**allocated_resources)
 
     def _get_most_constrained_resource_for_request(
         self,

--- a/clusterman/interfaces/cluster_connector.py
+++ b/clusterman/interfaces/cluster_connector.py
@@ -19,6 +19,7 @@ import staticconf
 
 from clusterman.config import POOL_NAMESPACE
 from clusterman.interfaces.types import AgentMetadata
+from clusterman.util import ClustermanResources
 
 
 class ClusterConnector(metaclass=ABCMeta):
@@ -72,6 +73,22 @@ class ClusterConnector(metaclass=ABCMeta):
         total = self.get_resource_total(resource_name)
         used = self.get_resource_allocation(resource_name)
         return used / total if total else 0
+
+    def get_cluster_allocated_resources(self) -> ClustermanResources:
+        """Get all allocated resources for the cluster"""
+        allocated_resources = {
+            resource: self.get_resource_allocation(resource)
+            for resource in ClustermanResources._fields
+        }
+        return ClustermanResources(**allocated_resources)
+
+    def get_cluster_total_resources(self) -> ClustermanResources:
+        """Get the total available resources for the cluster"""
+        total_resources = {
+            resource: self.get_resource_total(resource)
+            for resource in ClustermanResources._fields
+        }
+        return ClustermanResources(**total_resources)
 
     @abstractmethod
     def _get_agent_metadata(self, ip_address: str) -> AgentMetadata:  # pragma: no cover

--- a/clusterman/signals/pending_pods_signal.py
+++ b/clusterman/signals/pending_pods_signal.py
@@ -1,4 +1,3 @@
-from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Tuple
@@ -6,68 +5,27 @@ from typing import Union
 
 import arrow
 import colorlog
-from clusterman_metrics import APP_METRICS
 from clusterman_metrics import ClustermanMetricsBotoClient
-from clusterman_metrics import generate_key_with_dimensions
-from clusterman_metrics import SYSTEM_METRICS
 from kubernetes.client.models.v1_pod import V1Pod as KubernetesPod
 
-from clusterman.interfaces.signal import get_metrics_for_signal
-from clusterman.interfaces.signal import MetricsConfigDict
-from clusterman.interfaces.signal import MetricsValuesDict
 from clusterman.interfaces.signal import Signal
 from clusterman.kubernetes.kubernetes_cluster_connector import KubernetesClusterConnector
 from clusterman.kubernetes.util import PodUnschedulableReason
 from clusterman.kubernetes.util import total_pod_resources
+from clusterman.util import ClustermanResources
 from clusterman.util import SignalResourceRequest
 
 logger = colorlog.getLogger(__name__)
 
 
-def _get_required_metrics(cluster: str, pool: str, scheduler: str, minute_range: int = 240) -> List[MetricsConfigDict]:
-    required_metrics = []
-    for resource in SignalResourceRequest._fields:
-        required_metrics.append(MetricsConfigDict(
-            name=f'{resource}_allocated',
-            type=SYSTEM_METRICS,
-            minute_range=minute_range,
-            regex=False,
-        ))
-    required_metrics.append(MetricsConfigDict(
-        name=f'boost_factor|cluster={cluster},pool={pool}.{scheduler}',
-        type=APP_METRICS,
-        minute_range=minute_range,
-        regex=False,
-    ))
-    return required_metrics
-
-
-def _get_max_allocated_resource(resource: str, metrics: MetricsValuesDict) -> Optional[float]:
-    val = max(metrics.get(f'{resource}_allocated', []), default=(None, None))[1]
-    return float(val) if val else None
-
-
-def _get_max_resources(*args: SignalResourceRequest) -> SignalResourceRequest:
-    """ given two (or more) resource request dicts, merge them together by taking
-    the maximum value from each for each resource.  If no dict specifies anything for that
-    resource, set it to None
-    """
-    return SignalResourceRequest(**{
-        r: max([getattr(rdict, r) for rdict in args if getattr(rdict, r) is not None], default=None)
-        for r in SignalResourceRequest._fields
-    })
-
-
 def _get_resource_request(
-    metrics: Optional[MetricsValuesDict],
+    allocated_resources: ClustermanResources,
     pending_pods: Optional[List[Tuple[KubernetesPod, PodUnschedulableReason]]] = None,
 ) -> SignalResourceRequest:
     """ Given a list of metrics, construct a resource request based on the most recent
     data for allocated and pending pods """
-    resource_request = SignalResourceRequest()
-    if not metrics and not pending_pods:
-        return resource_request
 
+    resource_request = SignalResourceRequest()
     pending_pods = pending_pods or []
     if pending_pods:
         for pod, reason in pending_pods:
@@ -77,12 +35,7 @@ def _get_resource_request(
                 # this with a more intelligent solution in the future.
                 resource_request += total_pod_resources(pod) * 2
 
-    if metrics:
-        resource_request += SignalResourceRequest(**{
-            r: _get_max_allocated_resource(r, metrics)
-            for r in SignalResourceRequest._fields
-        })
-    return resource_request
+    return resource_request + allocated_resources
 
 
 class PendingPodsSignal(Signal):
@@ -97,8 +50,6 @@ class PendingPodsSignal(Signal):
         cluster_connector: KubernetesClusterConnector,
     ) -> None:
         super().__init__(self.__class__.__name__, cluster, pool, scheduler, app, config_namespace)
-        self.required_metrics = _get_required_metrics(self.cluster, self.pool, self.scheduler)
-        self.metrics_client = metrics_client
         self.cluster_connector = cluster_connector
 
     def evaluate(
@@ -106,47 +57,11 @@ class PendingPodsSignal(Signal):
             timestamp: arrow.Arrow,
             retry_on_broken_pipe: bool = True,
      ) -> Union[SignalResourceRequest, List[KubernetesPod]]:
-        metrics = get_metrics_for_signal(
-            self.cluster,
-            self.pool,
-            self.scheduler,
-            self.app,
-            self.metrics_client,
-            self.required_metrics,
-            timestamp,
-        )
-
+        allocated_resources = self.cluster_connector.get_cluster_allocated_resources()
         pending_pods = self.cluster_connector.get_unschedulable_pods()
 
         # Get the most recent metrics _now_ and when the boost was set (if any) and merge them
         if self.parameters.get('per_pod_resource_requests'):
             return pending_pods
         else:
-            current_resource_request = _get_resource_request(metrics, pending_pods)
-            boosted_metrics = self._get_boosted_metrics(metrics)
-            boosted_resource_request = _get_resource_request(boosted_metrics)
-
-            return _get_max_resources(current_resource_request, boosted_resource_request)
-
-    def _get_boosted_metrics(self, metrics: Dict) -> Optional[MetricsValuesDict]:
-        """ Given a list of metrics, check to see if a boost_factor has been set,
-        and then apply that boost_factor to the most recent metrics *at the time it was set*
-        """
-        boost_key = generate_key_with_dimensions(
-            'boost_factor',
-            {'cluster': self.cluster, 'pool': f'{self.pool}.{self.scheduler}'}
-        )
-        try:
-            boost_time, boost_factor = metrics[boost_key][-1]
-
-            # Get the metrics at the time of the boost
-            return MetricsValuesDict(list, {
-                key: [
-                    (t, v * boost_factor)
-                    for t, v in values if t < boost_time
-                ]
-                for key, values in metrics.items()
-            })
-        except (IndexError, KeyError):
-            # No boost factor found in the datastore
-            return None
+            return _get_resource_request(allocated_resources, pending_pods)

--- a/itests/autoscaler_scaling.feature
+++ b/itests/autoscaler_scaling.feature
@@ -71,7 +71,7 @@ Feature: make sure the autoscaler scales to the proper amount
        Given a cluster with 2 resource groups
          And 20 target capacity
          And 80 CPUs, 1000 MB mem, 1000 MB disk, and 0 GPUs
-         And 56 CPUs allocated, <pending> CPUs pending, and <boost> boost factor
+         And 56 CPUs allocated and <pending> CPUs pending
          And a kubernetes autoscaler object
         When the autoscaler runs
         Then no exception is raised
@@ -79,9 +79,7 @@ Feature: make sure the autoscaler scales to the proper amount
          And the autoscaler should scale rg2 to <rg2_target> capacity
 
       Examples:
-        | pending   | boost | rg1_target | rg2_target |
-        | 0         |       | 10         | 10         |
-        | 14        |       | 16         | 15         |
-        | 1000      |       | 50         | 50         |
-        | 0         | 2     | 20         | 20         |
-        | 50        | 2     | 28         | 28         |
+        | pending   | rg1_target | rg2_target |
+        | 0         | 10         | 10         |
+        | 14        | 16         | 15         |
+        | 1000      | 50         | 50         |

--- a/tests/signals/pending_pods_signal_test.py
+++ b/tests/signals/pending_pods_signal_test.py
@@ -1,6 +1,3 @@
-from decimal import Decimal
-
-import arrow
 import mock
 import pytest
 from kubernetes.client import V1Container
@@ -12,9 +9,9 @@ from kubernetes.client import V1PodStatus
 from kubernetes.client import V1ResourceRequirements
 
 from clusterman.kubernetes.util import PodUnschedulableReason
-from clusterman.signals.pending_pods_signal import _get_max_resources
 from clusterman.signals.pending_pods_signal import _get_resource_request
 from clusterman.signals.pending_pods_signal import PendingPodsSignal
+from clusterman.util import ClustermanResources
 from clusterman.util import SignalResourceRequest
 
 
@@ -32,13 +29,8 @@ def pending_pods_signal():
 
 
 @pytest.fixture
-def allocated_metrics():
-    return {
-        'cpus_allocated': [(Decimal('900'), Decimal('250')), (Decimal('1000'), Decimal('150'))],
-        'mem_allocated': [(Decimal('900'), Decimal('1250')), (Decimal('1000'), Decimal('1000'))],
-        'disk_allocated': [(Decimal('900'), Decimal('600')), (Decimal('1000'), Decimal('500'))],
-        'gpus_allocated': [(Decimal('900'), Decimal('0')), (Decimal('1000'), None)],
-    }
+def allocated_resources():
+    return ClustermanResources(cpus=150, mem=1000, disk=500, gpus=0)
 
 
 @pytest.fixture
@@ -91,91 +83,28 @@ def pending_pods():
     ]
 
 
-def test_get_resource_request_empty():
-    assert _get_resource_request(None) == SignalResourceRequest()
-
-
-def test_get_resource_request_no_pending_pods(allocated_metrics):
-    assert _get_resource_request(allocated_metrics) == SignalResourceRequest(
+def test_get_resource_request_no_pending_pods(allocated_resources):
+    assert _get_resource_request(allocated_resources) == SignalResourceRequest(
         cpus=150,
         mem=1000,
-        disk=500,
-    )
-
-
-def test_get_resource_request_only_pending_pods(pending_pods):
-    assert _get_resource_request(None, pending_pods) == SignalResourceRequest(cpus=6, mem=1000, disk=0, gpus=0)
-
-
-def test_get_resource_request_pending_pods_and_metrics(allocated_metrics, pending_pods):
-    assert _get_resource_request(allocated_metrics, pending_pods) == SignalResourceRequest(
-        cpus=156,
-        mem=2000,
         disk=500,
         gpus=0,
     )
 
 
-def test_get_max_resources():
-    assert _get_max_resources(
-        SignalResourceRequest(
-            cpus=100,
-            mem=50,
-        ),
-        SignalResourceRequest(
-            cpus=20,
-            mem=100,
-            gpus=1,
-        ),
-    ) == SignalResourceRequest(
-        cpus=100,
-        mem=100,
-        disk=None,
-        gpus=1,
+def test_get_resource_request_only_pending_pods(pending_pods):
+    assert _get_resource_request(ClustermanResources(), pending_pods) == SignalResourceRequest(
+        cpus=6,
+        mem=1000,
+        disk=0,
+        gpus=0,
     )
 
 
-def test_most_recent_values(allocated_metrics, pending_pods_signal):
-    with mock.patch(
-        'clusterman.signals.pending_pods_signal.get_metrics_for_signal',
-        return_value=allocated_metrics,
-    ):
-        assert pending_pods_signal.evaluate(arrow.get(1234)) == SignalResourceRequest(
-            cpus=150,
-            mem=1000,
-            disk=500,
-            gpus=None,
-        )
-
-
-@pytest.mark.parametrize('timestamp', [1234, 2234])
-def test_boost_factor(timestamp, pending_pods_signal):
-    metrics = {
-        'cpus_allocated': [(Decimal('900'), Decimal('250')), (Decimal('1000'), Decimal('150'))],
-        'boost_factor|cluster=foo,pool=bar.kube': [(Decimal('950'), Decimal('3'))] + (
-            [(Decimal('1500'), Decimal('1'))] if timestamp > 1500 else []
-        )
-    }
-    with mock.patch(
-        'clusterman.signals.pending_pods_signal.get_metrics_for_signal', return_value=metrics,
-    ):
-        expected_cpus = 750 if timestamp < 1500 else 150
-        assert pending_pods_signal.evaluate(arrow.get(timestamp)) == SignalResourceRequest(
-            cpus=expected_cpus,
-            mem=None,
-            disk=None,
-            gpus=None,
-        )
-
-
-def test_empty_metric_cache(pending_pods_signal):
-    metrics = {'cpus_allocated': [], 'mem_allocated': [], 'disk_allocated': [], 'gpus_allocated': []}
-    with mock.patch(
-        'clusterman.signals.pending_pods_signal.get_metrics_for_signal', return_value=metrics,
-    ):
-        assert pending_pods_signal.evaluate(arrow.get(1234)) == SignalResourceRequest(
-            cpus=None,
-            mem=None,
-            disk=None,
-            gpus=None,
-        )
+def test_get_resource_request_pending_pods_and_metrics(allocated_resources, pending_pods):
+    assert _get_resource_request(allocated_resources, pending_pods) == SignalResourceRequest(
+        cpus=156,
+        mem=2000,
+        disk=500,
+        gpus=0,
+    )


### PR DESCRIPTION
The metrics collector batch is incredibly slow and has been causing some
scaling woes, so this removes our dependence on the metrics emitted by
that batch, and just queries the Kubernetes apiserver directly for all
metrics.

A consequence of this is that the signal no longer looks for the `boost`
metrics, but this seems fine because boost hasn't worked on Kubernetes
for a long time anyways.  At some point in the future we can either
deprecate boost in favor of `clusterman manage` or re-add the boost into
this code in a better way.

### Testing Done

`make test` passes
