### PR TITLE
Use python3.7 for reorder-python-imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
             --remove-import, 'from __future__ import print_function',
             --remove-import, 'from __future__ import unicode_literals',
         ]
-        language_version: python3.6
+        language_version: python3.7
 -   repo: https://github.com/asottile/pyupgrade
     rev: v1.2.0
     hooks:


### PR DESCRIPTION
### Description

`pre-commit` was failing because `aspy-refactor-imports` v2.1.1 requires python >=3.6.1:

```
Output:
    Looking in indexes: https://pypi.yelpcorp.com/simple/
    Processing /nail/home/jmalt/.cache/pre-commit/repo446md50d
    Collecting aspy.refactor_imports>=0.5.3 (from reorder-python-imports==0.3.5)
      Using cached https://pypi.yelpcorp.com/p/aspy.refactor_imports-2.1.1-py2.py3-none-any.whl

Errors:
    ERROR: Package 'aspy.refactor-imports' requires a different Python: 3.6.0 not in '>=3.6.1'
```

We can either use Python >= 3.6.1 for the hook, or pin an earlier version of `aspy-refactor-imports`.  I went with Option 1, but both of these have been done by different teams, see [this Slack thread (yelp internal)](https://yelp.slack.com/archives/CDBRTGJF8/p1602105114463200). 

### Testing Done

`pre-commit` works now

Please fill out!  Generally speaking any new features should include
additional unit or integration tests to ensure the behaviour is
working correctly.
