### PR TITLE
Consider Pending pods when calculating resource utilization

### DIFF
--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -217,10 +217,11 @@ class KubernetesClusterConnector(ClusterConnector):
         }
 
     def _get_pods_by_ip(self) -> Mapping[str, List[KubernetesPod]]:
+        KUBERNETES_SCHEDULED_PHASES = {'Pending', 'Running'}
         all_pods = self._core_api.list_pod_for_all_namespaces().items
         pods_by_ip: Mapping[str, List[KubernetesPod]] = defaultdict(list)
         for pod in all_pods:
-            if (pod.status.phase == 'Running' or pod.status.phase == 'Pending') \
+            if pod.status.phase in KUBERNETES_SCHEDULED_PHASES \
                     and pod.status.host_ip in self._nodes_by_ip:
                 pods_by_ip[pod.status.host_ip].append(pod)
         return pods_by_ip

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -220,7 +220,8 @@ class KubernetesClusterConnector(ClusterConnector):
         all_pods = self._core_api.list_pod_for_all_namespaces().items
         pods_by_ip: Mapping[str, List[KubernetesPod]] = defaultdict(list)
         for pod in all_pods:
-            if pod.status.phase == 'Running' and pod.status.host_ip in self._nodes_by_ip:
+            if (pod.status.phase == 'Running' or pod.status.phase == 'Pending') \
+                    and pod.status.host_ip in self._nodes_by_ip:
                 pods_by_ip[pod.status.host_ip].append(pod)
         return pods_by_ip
 

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -37,6 +37,7 @@ from clusterman.kubernetes.util import total_node_resources
 from clusterman.kubernetes.util import total_pod_resources
 
 logger = colorlog.getLogger(__name__)
+KUBERNETES_SCHEDULED_PHASES = {'Pending', 'Running'}
 
 
 class KubernetesClusterConnector(ClusterConnector):
@@ -217,7 +218,6 @@ class KubernetesClusterConnector(ClusterConnector):
         }
 
     def _get_pods_by_ip(self) -> Mapping[str, List[KubernetesPod]]:
-        KUBERNETES_SCHEDULED_PHASES = {'Pending', 'Running'}
         all_pods = self._core_api.list_pod_for_all_namespaces().items
         pods_by_ip: Mapping[str, List[KubernetesPod]] = defaultdict(list)
         for pod in all_pods:


### PR DESCRIPTION
### Description

Details in [CLUSTERMAN-561](https://jira.yelpcorp.com/browse/CLUSTERMAN-561)

In short, we don't consider Pending pods when looking at what's on a node, but k8s does for scheduling purposes. This means if lots of pods are stuck Pending (e.g. `ImagePullBackOff`), k8s might be out of capacity but Clusterman doesn't know it.

### Testing Done

`make test` passes, but this method doesn't have any test coverage and I don't think such a small change merits writing a bunch of new tests.
