### PR TITLE
Fix the Clusterman Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN     apt-get update \
             lsb-release \
             make \
             openssh-client \
+            python3.6 \
             python3.7 \
             python-pip \
             python-setuptools \

--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,6 @@ debug:
 		-v $(shell pwd)/clusterman:/code/clusterman:rw \
 		-v $(shell pwd)/.cman_debug_bashrc:/home/nobody/.bashrc:ro \
 		-v /nail/srv/configs:/nail/srv/configs:ro \
-		-v $(shell pwd)/cluster-configs:/nail/srv/configs/clusterman-clusters:ro \
 		-v $(shell pwd)/etc-kubernetes:/etc/kubernetes:ro \
 		-v /nail/etc/services:/nail/etc/services:ro \
 		-v /etc/boto_cfg:/etc/boto_cfg:ro \


### PR DESCRIPTION
### Description

For reasons I don't understand, the Clusterman docker image suddenly
started breaking; specifically, the signals started crashing with errors
like

```
Fatal Python error: Py_Initialize: Unable to get the locale encoding
```

My best guess is that something changed in the base Xenial image that
stopped shipping some Python3.6 "stuff", because this change appears to
resolve the issue.  I'm not really sure _what_ happened but I'm not
super-inclined to figure it out at this point, because that sounds like
a rabbit hole.

P.S. I think the `cluster-configs` volume mount is a mistake that's left over
from some testing I was doing or something, I deleted it.

### Testing Done

Manual testing with `make debug`
