### PR TITLE
Restrict scaling down if we recently lost capacity for any reason

### DIFF
--- a/acceptance/srv-configs/clusterman-clusters/local-dev/default.kubernetes
+++ b/acceptance/srv-configs/clusterman-clusters/local-dev/default.kubernetes
@@ -16,7 +16,6 @@ autoscale_signal:
   internal: true
   period_minutes: 1
 
-# TODO (jmalt): this config option is a first draft, both naming and location are open to change
 autoscaling:
   prevent_scale_down_after_capacity_loss: true
   capacity_loss_threshold: 3

--- a/acceptance/srv-configs/clusterman-clusters/local-dev/default.kubernetes
+++ b/acceptance/srv-configs/clusterman-clusters/local-dev/default.kubernetes
@@ -15,3 +15,8 @@ scaling_limits:
 autoscale_signal:
   internal: true
   period_minutes: 1
+
+# TODO (jmalt): this config option is a first draft, both naming and location are open to change
+autoscaling:
+  prevent_scale_down_after_capacity_loss: true
+  capacity_loss_threshold: 3

--- a/acceptance/srv-configs/clusterman-clusters/local-dev/default.kubernetes
+++ b/acceptance/srv-configs/clusterman-clusters/local-dev/default.kubernetes
@@ -18,4 +18,4 @@ autoscale_signal:
 
 autoscaling:
   prevent_scale_down_after_capacity_loss: true
-  capacity_loss_threshold: 3
+  instance_loss_threshold: 3

--- a/clusterman/autoscaler/autoscaler.py
+++ b/clusterman/autoscaler/autoscaler.py
@@ -156,7 +156,7 @@ class Autoscaler:
         no_scale_down = False
         if self.autoscaling_config.prevent_scale_down_after_capacity_loss:
             removed_nodes_since_last_reload = self.pool_manager.get_removed_nodes_since_last_reload()
-            # TODO (jmalt): we may want something more sophisticated than len(nodes),
+            # TODO (jmalt, CLUSTERMAN-553): we may want something more sophisticated than len(nodes),
             # especially for heterogeneous SFRs
             if len(removed_nodes_since_last_reload) > self.autoscaling_config.capacity_loss_threshold:
                 logger.warning('Nodes lost since last autoscaler run is greater than limit,'

--- a/clusterman/autoscaler/autoscaler.py
+++ b/clusterman/autoscaler/autoscaler.py
@@ -153,17 +153,17 @@ class Autoscaler:
 
         logger.info(f'Signal {signal_name} requested {resource_request}')
 
+        self.pool_manager.reload_state()
+
         no_scale_down = False
         if self.autoscaling_config.prevent_scale_down_after_capacity_loss:
-            removed_nodes_since_last_reload = self.pool_manager.get_removed_nodes_since_last_reload()
-            # TODO (jmalt, CLUSTERMAN-553): we may want something more sophisticated than len(nodes),
-            # especially for heterogeneous SFRs
-            if len(removed_nodes_since_last_reload) > self.autoscaling_config.capacity_loss_threshold:
+            removed_nodes_before_last_reload = self.pool_manager.get_removed_nodes_before_last_reload()
+            # TODO (CLUSTERMAN-576): support instance weights here, instead of just instance count
+            if len(removed_nodes_before_last_reload) > self.autoscaling_config.instance_loss_threshold:
                 logger.warning('Nodes lost since last autoscaler run is greater than limit,'
                                ' will not scale down on this run')
                 no_scale_down = True
 
-        self.pool_manager.reload_state()
         if isinstance(resource_request, list):
             pass
         else:

--- a/clusterman/autoscaler/config.py
+++ b/clusterman/autoscaler/config.py
@@ -25,7 +25,7 @@ class AutoscalingConfig(NamedTuple):
     setpoint: float
     target_capacity_margin: float
     prevent_scale_down_after_capacity_loss: bool = False
-    capacity_loss_threshold: int = 0
+    instance_loss_threshold: int = 0
 
 
 def get_autoscaling_config(config_namespace: str) -> AutoscalingConfig:
@@ -49,5 +49,5 @@ def get_autoscaling_config(config_namespace: str) -> AutoscalingConfig:
         ),
         prevent_scale_down_after_capacity_loss=reader.read_bool(
             'autoscaling.prevent_scale_down_after_capacity_loss', default=False),
-        capacity_loss_threshold=reader.read_int('autoscaling.capacity_loss_threshold', default=0)
+        instance_loss_threshold=reader.read_int('autoscaling.instance_loss_threshold', default=0)
     )

--- a/clusterman/autoscaler/config.py
+++ b/clusterman/autoscaler/config.py
@@ -24,6 +24,8 @@ class AutoscalingConfig(NamedTuple):
     excluded_resources: List[str]
     setpoint: float
     target_capacity_margin: float
+    prevent_scale_down_after_capacity_loss: bool = False
+    capacity_loss_threshold: int = 0
 
 
 def get_autoscaling_config(config_namespace: str) -> AutoscalingConfig:
@@ -45,4 +47,7 @@ def get_autoscaling_config(config_namespace: str) -> AutoscalingConfig:
             'autoscaling.target_capacity_margin',
             default=default_target_capacity_margin,
         ),
+        prevent_scale_down_after_capacity_loss=reader.read_bool(
+            'autoscaling.prevent_scale_down_after_capacity_loss', default=False),
+        capacity_loss_threshold=reader.read_int('autoscaling.capacity_loss_threshold', default=0)
     )

--- a/clusterman/autoscaler/pool_manager.py
+++ b/clusterman/autoscaler/pool_manager.py
@@ -92,12 +92,12 @@ class PoolManager:
         logger.info('Recalculating non-orphan fulfilled capacity')
         self.non_orphan_fulfilled_capacity = self._calculate_non_orphan_fulfilled_capacity()
 
-    def get_removed_nodes_since_last_reload(self) -> Set[KubernetesNode]:
+    def get_removed_nodes_before_last_reload(self) -> Set[KubernetesNode]:
         if not isinstance(self.cluster_connector, KubernetesClusterConnector):
             logger.warning('get_removed_nodes_since_last_reload is only supported for Kubernetes clusters')
             return set()
 
-        return self.cluster_connector.get_removed_nodes_since_last_reload()
+        return self.cluster_connector.get_removed_nodes_before_last_reload()
 
     def mark_stale(self, dry_run: bool) -> None:
         if dry_run:

--- a/clusterman/interfaces/cluster_connector.py
+++ b/clusterman/interfaces/cluster_connector.py
@@ -37,9 +37,9 @@ class ClusterConnector(metaclass=ABCMeta):
         """ Refresh any state that needs to be stored at the start of an autoscaling run """
         pass
 
-    def get_removed_nodes_since_last_reload(self) -> Set[KubernetesNode]:
-        # this is only available in the KubernetesClusterConnector and shouldn't be called otherwise
-        raise NotImplementedError
+    # def get_removed_nodes_since_last_reload(self) -> Set[KubernetesNode]:
+    #     # this is only available in the KubernetesClusterConnector and shouldn't be called otherwise
+    #     raise NotImplementedError
 
     def get_agent_metadata(self, ip_address: Optional[str]) -> AgentMetadata:
         """ Get metadata about a cluster agent given an IP address

--- a/clusterman/interfaces/cluster_connector.py
+++ b/clusterman/interfaces/cluster_connector.py
@@ -14,10 +14,8 @@
 from abc import ABCMeta
 from abc import abstractmethod
 from typing import Optional
-from typing import Set
 
 import staticconf
-from kubernetes.client.models.v1_node import V1Node as KubernetesNode
 
 from clusterman.config import POOL_NAMESPACE
 from clusterman.interfaces.types import AgentMetadata
@@ -36,10 +34,6 @@ class ClusterConnector(metaclass=ABCMeta):
     def reload_state(self) -> None:  # pragma: no cover
         """ Refresh any state that needs to be stored at the start of an autoscaling run """
         pass
-
-    # def get_removed_nodes_since_last_reload(self) -> Set[KubernetesNode]:
-    #     # this is only available in the KubernetesClusterConnector and shouldn't be called otherwise
-    #     raise NotImplementedError
 
     def get_agent_metadata(self, ip_address: Optional[str]) -> AgentMetadata:
         """ Get metadata about a cluster agent given an IP address

--- a/clusterman/interfaces/cluster_connector.py
+++ b/clusterman/interfaces/cluster_connector.py
@@ -14,8 +14,10 @@
 from abc import ABCMeta
 from abc import abstractmethod
 from typing import Optional
+from typing import Set
 
 import staticconf
+from kubernetes.client.models.v1_node import V1Node as KubernetesNode
 
 from clusterman.config import POOL_NAMESPACE
 from clusterman.interfaces.types import AgentMetadata
@@ -34,6 +36,10 @@ class ClusterConnector(metaclass=ABCMeta):
     def reload_state(self) -> None:  # pragma: no cover
         """ Refresh any state that needs to be stored at the start of an autoscaling run """
         pass
+
+    def get_removed_nodes_since_last_reload(self) -> Set[KubernetesNode]:
+        # this is only available in the KubernetesClusterConnector and shouldn't be called otherwise
+        raise NotImplementedError
 
     def get_agent_metadata(self, ip_address: Optional[str]) -> AgentMetadata:
         """ Get metadata about a cluster agent given an IP address

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -59,12 +59,12 @@ class KubernetesClusterConnector(ClusterConnector):
             f'clusters.{cluster}.pod_safe_to_evict_annotation',
             default='cluster-autoscaler.kubernetes.io/safe-to-evict',
         )
+        self._nodes_by_ip = {}
 
     def reload_state(self) -> None:
         logger.info('Reloading nodes')
 
         self._core_api = CachedCoreV1Api(self.kubeconfig_path)
-        self._pods = self._get_all_pods()
 
         # store the previous _nodes_by_ip for use in get_removed_nodes_before_last_reload()
         self._prev_nodes_by_ip = copy.deepcopy(self._nodes_by_ip)

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -17,6 +17,7 @@ from distutils.util import strtobool
 from typing import List
 from typing import Mapping
 from typing import Optional
+from typing import Set
 from typing import Tuple
 
 import colorlog
@@ -70,6 +71,23 @@ class KubernetesClusterConnector(ClusterConnector):
         self._pods = self._get_all_pods()
         self._nodes_by_ip = self._get_nodes_by_ip()
         self._pods_by_ip = self._get_pods_by_ip()
+
+    def get_removed_nodes_since_last_reload(self) -> Set[KubernetesNode]:
+        try:
+            kubernetes.config.load_kube_config(staticconf.read_string(f'{self.kubeconfig_path}'))
+        except TypeError:
+            error_msg = 'Could not load KUBECONFIG; is this running on Kubernetes master?'
+            if 'yelpcorp' in socket.getfqdn():
+                error_msg += '\nHint: try using the clusterman-k8s-<clustername> wrapper script!'
+            logger.error(error_msg)
+            raise
+
+        previous_nodes = self._nodes_by_ip
+        current_nodes = self._get_nodes_by_ip()
+
+        # todo jmalt: make sure this gives the desired results
+        # equality is defined based on to_dict() for V1Node, so this should work
+        return set(previous_nodes.values()) - set(current_nodes.values())
 
     def get_resource_pending(self, resource_name: str) -> float:
         return getattr(allocated_node_resources([p for p, __ in self.get_unschedulable_pods()]), resource_name)

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -107,15 +107,6 @@ class KubernetesClusterConnector(ClusterConnector):
         self._pods_by_ip = self._get_pods_by_ip()
 
     def get_removed_nodes_since_last_reload(self) -> Set[KubernetesNode]:
-        try:
-            kubernetes.config.load_kube_config(staticconf.read_string(f'{self.kubeconfig_path}'))
-        except TypeError:
-            error_msg = 'Could not load KUBECONFIG; is this running on Kubernetes master?'
-            if 'yelpcorp' in socket.getfqdn():
-                error_msg += '\nHint: try using the clusterman-k8s-<clustername> wrapper script!'
-            logger.error(error_msg)
-            raise
-
         previous_nodes = self._nodes_by_ip
         current_nodes = self._get_nodes_by_ip()
 

--- a/itests/autoscaler_scaling.feature
+++ b/itests/autoscaler_scaling.feature
@@ -85,17 +85,12 @@ Feature: make sure the autoscaler scales to the proper amount
         | 1000      | 50         | 50         |
 
     Scenario: instances are not killed if we've lost capacity recently
-         Given a cluster with 1 resource groups
+       Given a cluster with 1 resource groups
          And 10 target capacity
          And 40 CPUs, 500 MB mem, 500 MB disk, and 0 GPUs
-        And  10 CPUs allocated and 0 CPUs pending
+         And 1 CPUs allocated and 0 CPUs pending
          And a kubernetes autoscaler object with prevent_scale_down_after_capacity_loss enabled
-         When the autoscaler runs only once
-        Then no exception is raised
-         And the autoscaler should scale rg1 to 4 capacity
-        Given 1 CPUs allocated and 0 CPUs pending
-        And a kubernetes autoscaler object with prevent_scale_down_after_capacity_loss enabled
         When the cluster has recently lost capacity
-        When the autoscaler runs only once
+         And the autoscaler runs only once
         Then no exception is raised
-        Then the autoscaler should do nothing
+         And the autoscaler should do nothing

--- a/itests/autoscaler_scaling.feature
+++ b/itests/autoscaler_scaling.feature
@@ -84,16 +84,18 @@ Feature: make sure the autoscaler scales to the proper amount
         | 14        | 16         | 15         |
         | 1000      | 50         | 50         |
 
-
-      @wip
     Scenario: instances are not killed if we've lost capacity recently
-        # start with a scale-down operation to cause "lost capacity recently"
-        # this doesn't yet test that we don't scale down again afterwards
          Given a cluster with 1 resource groups
          And 10 target capacity
          And 40 CPUs, 500 MB mem, 500 MB disk, and 0 GPUs
-        And  1 CPUs allocated and 0 CPUs pending
-         And a kubernetes autoscaler object
-         When the autoscaler runs
+        And  10 CPUs allocated and 0 CPUs pending
+         And a kubernetes autoscaler object with prevent_scale_down_after_capacity_loss enabled
+         When the autoscaler runs only once
         Then no exception is raised
-         And the autoscaler should scale rg1 to 12 capacity
+         And the autoscaler should scale rg1 to 4 capacity
+        Given 1 CPUs allocated and 0 CPUs pending
+        And a kubernetes autoscaler object with prevent_scale_down_after_capacity_loss enabled
+        When the cluster has recently lost capacity
+        When the autoscaler runs only once
+        Then no exception is raised
+        Then the autoscaler should do nothing

--- a/itests/autoscaler_scaling.feature
+++ b/itests/autoscaler_scaling.feature
@@ -83,3 +83,17 @@ Feature: make sure the autoscaler scales to the proper amount
         | 0         | 10         | 10         |
         | 14        | 16         | 15         |
         | 1000      | 50         | 50         |
+
+
+      @wip
+    Scenario: instances are not killed if we've lost capacity recently
+        # start with a scale-down operation to cause "lost capacity recently"
+        # this doesn't yet test that we don't scale down again afterwards
+         Given a cluster with 1 resource groups
+         And 10 target capacity
+         And 40 CPUs, 500 MB mem, 500 MB disk, and 0 GPUs
+        And  1 CPUs allocated and 0 CPUs pending
+         And a kubernetes autoscaler object
+         When the autoscaler runs
+        Then no exception is raised
+         And the autoscaler should scale rg1 to 12 capacity

--- a/itests/steps/autoscaler.py
+++ b/itests/steps/autoscaler.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# import pdb
 import time
 from decimal import Decimal
 


### PR DESCRIPTION
### Description
[CLUSTERMAN-553](https://jira.yelpcorp.com/browse/CLUSTERMAN-553) (Yelp-internal) has more context.

This adds an option to prevent scaling down if we've recently lost instances in the pool. Unlike existing limits on scaling down, this accoutns for instances going away for any reason, including k8s problems, Spot terminations, etc. 

It is an **extremely rough draft** and hasn't been tested yet, putting this PR out to make sure I'm going in the right direction.

### Testing Done
`make test` passes but I haven't actually tested this feature.
