### PR TITLE
fix the timeout wrapper for some CLI functions

### DIFF
--- a/clusterman/cli/util.py
+++ b/clusterman/cli/util.py
@@ -22,4 +22,5 @@ def timeout_wrapper(main):
         signal.alarm(TIMEOUT_TIME_SECONDS)
 
         main(args)
+        signal.alarm(0)  # Cancel the alarm if we've gotten here
     return wrapper


### PR DESCRIPTION
### Description

We weren't canceling the alarm if the `main` function returned before the alarm went off, leading to an extra `Alarm clock` output showing up in the stdout; this broke some of our monitoring scripts.  This change ensures that the alarm gets canceled if the main function completes on time.

### Testing Done

manual testing in stageg.