### PR TITLE
Re-add autoscaler batch sensu checks for service only (not for signal…

### DIFF
--- a/clusterman/batch/autoscaler.py
+++ b/clusterman/batch/autoscaler.py
@@ -34,17 +34,23 @@ from clusterman.exceptions import AutoscalerError
 from clusterman.exceptions import ClustermanSignalError
 from clusterman.exceptions import PoolConnectionError
 from clusterman.util import get_autoscaler_scribe_stream
+from clusterman.util import sensu_checkin
 from clusterman.util import setup_logging
 from clusterman.util import splay_event_time
+from clusterman.util import Status
 
 logger = colorlog.getLogger(__name__)
 colorlog.getLogger('clusterman_metrics')  # This just adds a handler to the clusterman_metrics logger
+SERVICE_CHECK_NAME = 'check_clusterman_autoscaler_service'
+DEFAULT_TTL = '25m'
+DEFAULT_CHECK_EVERY = '10m'
 
 
 def sensu_alert_triage(fail=False):
     def decorator(fn):
         def wrapper(self):
             msg = ''
+            service_failed = False
             error = None
             try:
                 fn(self)
@@ -56,6 +62,8 @@ def sensu_alert_triage(fail=False):
                 msg = str(e)
                 logger.exception(f'Autoscaler service failed: {msg}')
                 error = e
+                service_failed = True
+            self._do_sensu_checkins(service_failed, msg)
             if fail and error:
                 raise AutoscalerError from error
         return wrapper
@@ -129,6 +137,34 @@ class AutoscalerBatch(BatchDaemon, BatchLoggingMixin, BatchRunningSentinelMixin)
                 self._autoscale()
             except (PoolConnectionError, EndpointConnectionError) as e:
                 logger.exception(f'Encountered a connection error: {e}')
+
+    def _do_sensu_checkins(self, service_failed, msg):
+        check_every = ('{minutes}m'.format(minutes=int(self.autoscaler.run_frequency // 60))
+                       if self.autoscaler else DEFAULT_CHECK_EVERY)
+        # magic-y numbers here; an alert will time out after two autoscaler run periods plus a five minute buffer
+        alert_delay = (
+            '{minutes}m'.format(minutes=int(self.autoscaler.run_frequency // 60) * 2 + 5)
+            if self.autoscaler
+            else DEFAULT_TTL
+        )
+
+        sensu_args = dict(
+            check_name=SERVICE_CHECK_NAME,
+            scheduler=self.options.scheduler,
+            check_every=check_every,
+            source=f'{self.options.cluster}_{self.options.pool}',
+            ttl=alert_delay,
+            alert_after=alert_delay,
+            noop=self.options.dry_run,
+            pool=self.options.pool,
+        )
+
+        if service_failed:
+            sensu_args['output'] = f'FAILED: clusterman autoscaler failed ({msg})'
+            sensu_args['status'] = Status.CRITICAL
+        else:
+            sensu_args['output'] = 'OK: clusterman autoscaler is fine'
+        sensu_checkin(**sensu_args)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
… failures)

See CLUSTERMAN-574

### Description

This more or less selectively reverts https://github.com/Yelp/clusterman/pull/33 -- I brought back the TTL sensu check for the batch only (i.e. not the signal), and I didn't put back all of the testing since it seemed a little overkill.  Open to argument there.

### Testing Done

`make test` passes.  I can do a manual run, too, if you'd like
