### PR TITLE
Pin cryptography version to 2.8 in acceptance tox env.  Later version…

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,8 @@ envlist = py37
 skipsdist = true
 tox_pip_extensions_ext_pip_custom_platform = true
 tox_pip_extensions_ext_venv_update = true
+# TODO: get rid of this once we're using a bionic base image
+cryptography_version = 2.8
 
 [testenv]
 passenv = HOME SSH_AUTH_SOCK USER LANG PIP_INDEX_URL
@@ -76,6 +78,7 @@ deps =
     boto3
     simplejson
     PyYAML
+    cryptography=={[tox]cryptography_version}
 commands =
     docker-compose -f acceptance/docker-compose.yaml down
     docker-compose -f acceptance/docker-compose.yaml pull


### PR DESCRIPTION
…s are unhappy with the version of openssl we're using, which I I think would mean getting off a xenial base docker image.

### Description

The (internal) build is failing because cryptography 3.2 doesn't like openssl 1.0.2 (with reason -- it's no longer supported).  But we can't easily get newer versions until we're on a bionic base image.

### Testing Done

acceptance tests pass