### PR TITLE
Make splay_event_time return a maximum wait time of the input frequen…

### DIFF
--- a/clusterman/util.py
+++ b/clusterman/util.py
@@ -326,14 +326,21 @@ def splay_event_time(frequency: int, key: str, timestamp: float = None) -> float
     randomly splay out the 'initial' start time based on some key, to prevent events with the same
     frequency from all triggering at once
 
+    Chooses a random offset within a time window of `frequency` seconds that events should be triggered
+    and finds the number of seconds to the next offset.
+
     :param frequency: how often the event should occur (in seconds)
     :param key: a string to hash to get the splay time
     :param timestamp: what time it is "now" (uses time.time() if None)
     :returns: the number of seconds until the next event should happen
     """
     timestamp = timestamp or time.time()
-    random_wait_time = hash(key) % frequency
-    return frequency - (timestamp % frequency) + random_wait_time
+    desired_offset_in_window = hash(key) % frequency
+    current_offset_in_window = timestamp % frequency
+    if current_offset_in_window <= desired_offset_in_window:
+        return desired_offset_in_window - current_offset_in_window
+    else:
+        return frequency - current_offset_in_window + desired_offset_in_window
 
 
 def read_int_or_inf(reader, param):

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -30,6 +30,7 @@ from clusterman.util import get_pool_name_list
 from clusterman.util import parse_time_interval_seconds
 from clusterman.util import parse_time_string
 from clusterman.util import sensu_checkin
+from clusterman.util import splay_event_time
 from clusterman.util import Status
 
 
@@ -223,3 +224,11 @@ def test_is_paused_with_expiration_timestamp(exp_timestamp):
             not exp_timestamp or
             int(exp_timestamp) > 300
         )
+
+
+@mock.patch('builtins.hash')
+def test_splay_event_time(mock_hash):
+    frequency = 10
+    mock_hash.return_value = frequency - 1  # make `hash(key) % frequency` returns its max value
+    for timestamp in range(20):
+        assert 0 <= splay_event_time(frequency, 'key', timestamp) < frequency


### PR DESCRIPTION
…cy.  Currently it can return up to 2x the run_frequency.

See CLUSTERMAN-577

### Description

See the ticket for more details

### Testing Done

I wrote a new test, and all existing tests pass.
