### PR TITLE
make some changes to try to reduce memory usage

### DIFF
--- a/clusterman/kubernetes/util.py
+++ b/clusterman/kubernetes/util.py
@@ -11,12 +11,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
+import socket
 from enum import auto
 from enum import Enum
 from typing import List
 
+import colorlog
+import kubernetes
+from cachetools import TTLCache
+from cachetools.keys import hashkey
 from humanfriendly import parse_size
 from kubernetes.client.models.v1_node import V1Node as KubernetesNode
+from kubernetes.client.models.v1_node_selector_requirement import V1NodeSelectorRequirement
+from kubernetes.client.models.v1_node_selector_term import V1NodeSelectorTerm
 from kubernetes.client.models.v1_pod import V1Pod as KubernetesPod
 
 from clusterman.util import ClustermanResources
@@ -30,6 +38,47 @@ from clusterman.util import ClustermanResources
 DEFAULT_KUBERNETES_CPU_REQUEST = '100m'
 DEFAULT_KUBERNETES_MEMORY_REQUEST = '200MB'
 DEFAULT_KUBERNETES_DISK_REQUEST = '0'  # Kubernetes doesn't schedule based on disk allocation right now
+KUBERNETES_API_CACHE_SIZE = 16
+KUBERNETES_API_CACHE_TTL = 60
+KUBERNETES_API_CACHE = TTLCache(maxsize=KUBERNETES_API_CACHE_SIZE, ttl=KUBERNETES_API_CACHE_TTL)
+logger = colorlog.getLogger(__name__)
+
+
+class CachedCoreV1Api:
+    CACHED_FUNCTION_CALLS = {'list_node', 'list_pod_for_all_namespaces'}
+
+    def __init__(self, kubeconfig_path: str):
+        try:
+            kubernetes.config.load_kube_config(kubeconfig_path)
+        except TypeError:
+            error_msg = 'Could not load KUBECONFIG; is this running on Kubernetes master?'
+            if 'yelpcorp' in socket.getfqdn():
+                error_msg += '\nHint: try using the clusterman-k8s-<clustername> wrapper script!'
+            logger.error(error_msg)
+            raise
+
+        self._client = kubernetes.client.CoreV1Api()
+
+    def __getattr__(self, attr):
+        global KUBERNETES_API_CACHE
+        func = getattr(self._client, attr)
+
+        if os.environ.get('KUBE_CACHE_ENABLED', '') and attr in self.CACHED_FUNCTION_CALLS:
+            def decorator(f):
+                def wrapper(*args, **kwargs):
+                    k = hashkey(attr, *args, **kwargs)
+                    try:
+                        return KUBERNETES_API_CACHE[k]
+                    except KeyError:
+                        logger.debug(f'Cache miss for the {attr} Kubernetes function call')
+                        pass  # the function call hasn't been cached recently
+                    v = f(*args, **kwargs)
+                    KUBERNETES_API_CACHE[k] = v
+                    return v
+                return wrapper
+            func = decorator(func)
+
+        return func
 
 
 class ResourceParser:
@@ -106,3 +155,15 @@ def total_pod_resources(pod: KubernetesPod) -> ClustermanResources:
         disk=sum(ResourceParser.disk(c.resources.requests) for c in pod.spec.containers),
         gpus=sum(ResourceParser.gpus(c.resources.requests) for c in pod.spec.containers),
     )
+
+
+def selector_term_matches_requirement(
+    selector_terms: List[V1NodeSelectorTerm],
+    selector_requirement: V1NodeSelectorRequirement,
+) -> bool:
+    for selector_term in selector_terms:
+        if selector_term.match_expressions:
+            for match_expression in selector_term.match_expressions:
+                if match_expression == selector_requirement:
+                    return True
+    return False

--- a/tests/kubernetes/util_test.py
+++ b/tests/kubernetes/util_test.py
@@ -1,0 +1,26 @@
+from kubernetes.client.models.v1_node_selector_requirement import V1NodeSelectorRequirement
+from kubernetes.client.models.v1_node_selector_term import V1NodeSelectorTerm
+
+from clusterman.kubernetes.util import selector_term_matches_requirement
+
+
+def test_selector_term_matches_requirement():
+    selector_term = [V1NodeSelectorTerm(
+        match_expressions=[
+            V1NodeSelectorRequirement(
+                key='clusterman.com/scheduler',
+                operator='Exists'
+            ),
+            V1NodeSelectorRequirement(
+                key='clusterman.com/pool',
+                operator='In',
+                values=['bar']
+            )
+        ]
+    )]
+    selector_requirement = V1NodeSelectorRequirement(
+        key='clusterman.com/pool',
+        operator='In',
+        values=['bar']
+    )
+    assert selector_term_matches_requirement(selector_term, selector_requirement)


### PR DESCRIPTION
### Description

The main change here is that we don't require the autoscalers to track
all the pods, just the ones that belong to the current pool.  This
should hopefully reduce the amount of memory used by _most_ of the
autoscaler instances.

To accomplish this, we just filter all the pods that are a) running on a
node in our pool, b) has a node selector for nodes in our pool, or c)
has an affinity for nodes in our pool.

We also only store the pods _once_, instead of having a list of all the
pods, and then have a separate dict of pods by IP.  (Actually I'm not sure, 
maybe we were just storing references in one of those, but anyways, 
*shrug*).

We still cache everything for the metrics collector, so these will still
need large memory utilization.

I *think* this maybe also solves [CLUSTERMAN-562](https://jira.yelpcorp.com/browse/CLUSTERMAN-562); @EvanKrall can you
take a look and see if you agree?

### Testing Done

Made sure all the tests still pass