### PR TITLE
Drmorr/get test coverage back up

### DIFF
--- a/clusterman/autoscaler/pool_manager.py
+++ b/clusterman/autoscaler/pool_manager.py
@@ -206,11 +206,12 @@ class PoolManager:
             for instance_metadata in group.get_instance_metadatas(state_filter)
         ]
 
+    # currently dead code, so don't count towards coverage metrics
     def _filter_scale_up_options_for_pod(
         self,
         pod: KubernetesPod,
         scale_up_options: Mapping[str, List[ClusterNodeMetadata]],
-    ) -> Mapping[str, List[ClusterNodeMetadata]]:
+    ) -> Mapping[str, List[ClusterNodeMetadata]]:  # pragma: no cover
         filtered_options: Mapping[str, List[ClusterNodeMetadata]] = defaultdict(list)
         for group_id, options in scale_up_options.items():
             for option in options:

--- a/clusterman/interfaces/resource_group.py
+++ b/clusterman/interfaces/resource_group.py
@@ -164,7 +164,7 @@ class ResourceGroup(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def scale_up_options(self) -> Iterable[ClusterNodeMetadata]:
+    def scale_up_options(self) -> Iterable[ClusterNodeMetadata]:  # pragma: no cover
         """ Generate each of the options for scaling up this resource group. For a spot fleet, this would be one
         ClustermanResources for each instance type. For a non-spot ASG, this would be a single ClustermanResources that
         represents the instance type the ASG is configured to run.
@@ -172,7 +172,7 @@ class ResourceGroup(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def scale_down_options(self) -> Iterable[ClusterNodeMetadata]:
+    def scale_down_options(self) -> Iterable[ClusterNodeMetadata]:  # pragma: no cover
         """ Generate each of the options for scaling down this resource group, i.e. the list of instance types currently
         running in this resource group.
         """

--- a/clusterman/interfaces/signal.py
+++ b/clusterman/interfaces/signal.py
@@ -86,10 +86,10 @@ class Signal(metaclass=ABCMeta):
 
     @abstractmethod
     def evaluate(
-            self,
-            timestamp: arrow.Arrow,
-            retry_on_broken_pipe: bool = True,
-     ) -> Union[SignalResourceRequest, List[KubernetesPod]]:
+        self,
+        timestamp: arrow.Arrow,
+        retry_on_broken_pipe: bool = True,
+    ) -> Union[SignalResourceRequest, List[KubernetesPod]]:  # pragma: no cover
         """ Compute a signal and return either a single response (representing an aggregate resource request), or a
         list of responses (representing per-pod resource requests)
 

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -134,36 +134,6 @@ class KubernetesClusterConnector(ClusterConnector):
 
         return PodUnschedulableReason.InsufficientResources
 
-    def set_node_unschedulable(self, node_ip: str):
-        try:
-            agent_metadata = self._get_agent_metadata(node_ip)
-            self._core_api.patch_node(
-                name=agent_metadata.agent_id,
-                body={'spec': {'unschedulable': True}}
-            )
-        except Exception as e:
-            logger.warning(f'error when unscheduling pod: {e}')
-
-    def evict_pods_on_node(self, node_ip: str):
-        pods = self._pods_by_ip[node_ip]
-        for pod in pods:
-            try:
-                self._core_api.create_namespaced_pod_eviction(
-                    name=pod.metadata.name,
-                    namespace=pod.metadata.namespace,
-                    body=kubernetes.client.V1beta1Eviction()
-                )
-            except Exception as e:
-                logger.warning(f'error when evict pod: {e}')
-
-    def delete_node(self, node_ip: str):
-        agent_metadata = self._get_agent_metadata(node_ip)
-        self._core_api.delete_node(
-            name=agent_metadata.agent_id,
-            grace_period_seconds=0,
-            body=kubernetes.client.V1DeleteOptions()
-        )
-
     def _get_agent_metadata(self, node_ip: str) -> AgentMetadata:
         node = self._nodes_by_ip.get(node_ip)
         if not node:

--- a/clusterman/kubernetes/util.py
+++ b/clusterman/kubernetes/util.py
@@ -104,11 +104,7 @@ class ResourceParser:
     @staticmethod
     def gpus(resources):
         resources = resources or {}
-        try:
-            return int(resources.get('nvidia.com/gpu', 0))
-        except ValueError:
-            # on the off chance kubernetes tries to set this to a non-integer
-            return 0
+        return int(resources.get('nvidia.com/gpu', 0))
 
 
 class PodUnschedulableReason(Enum):

--- a/tests/autoscaler/autoscaler_test.py
+++ b/tests/autoscaler/autoscaler_test.py
@@ -134,6 +134,11 @@ def test_get_signal_for_app(mock_autoscaler, signal_response):
     assert signal == (mock_autoscaler.default_signal if isinstance(signal_response, Exception) else signal)
 
 
+def test_run_interval_seconds(mock_autoscaler):
+    mock_autoscaler.signal.period_minutes = 7
+    assert mock_autoscaler.run_frequency == 7 * 60
+
+
 @pytest.mark.parametrize('dry_run', [True, False])
 def test_autoscaler_run(dry_run, mock_autoscaler, run_timestamp):
     mock_autoscaler._compute_target_capacity = mock.Mock(return_value=100)

--- a/tests/autoscaler/pool_manager_test.py
+++ b/tests/autoscaler/pool_manager_test.py
@@ -35,11 +35,13 @@ def _make_metadata(
     weight=1,
     tasks=5,
     batch_tasks=0,
+    is_safe_to_kill=True,
 ):
     return ClusterNodeMetadata(
         AgentMetadata(
             agent_id='foo',
             batch_task_count=batch_tasks,
+            is_safe_to_kill=is_safe_to_kill,
             state=agent_state,
             task_count=tasks,
         ),
@@ -532,6 +534,7 @@ def test_instance_kill_order(mock_pool_manager):
         _make_metadata('sfr-0', 'i-6', batch_tasks=1),
         _make_metadata('sfr-0', 'i-8', agent_state=AgentState.UNKNOWN),
         _make_metadata('sfr-0', 'i-9', tasks=100000),
+        _make_metadata('sfr-0', 'i-10', is_safe_to_kill=False),
     ])
     mock_pool_manager.max_tasks_to_kill = 1000
     killable_nodes = mock_pool_manager._get_prioritized_killable_nodes()

--- a/tests/kubernetes/kubernetes_cluster_connector_test.py
+++ b/tests/kubernetes/kubernetes_cluster_connector_test.py
@@ -312,39 +312,6 @@ def test_pending_cpus(mock_cluster_connector):
     assert mock_cluster_connector.get_resource_pending('cpus') == 1.5
 
 
-def test_evict_pods_on_node(mock_cluster_connector):
-    with mock.patch(
-            'clusterman.kubernetes.kubernetes_cluster_connector.KubernetesClusterConnector.evict_pods_on_node',
-            autospec=True,
-    ) as mock_evict_pods_on_node:
-        mock_node = mock.Mock()
-        mock_evict_pods_on_node.return_value = None
-        mock_cluster_connector.evict_pods_on_node(mock_node)
-        assert mock_evict_pods_on_node.called
-
-
-def test_set_node_unscheduable(mock_cluster_connector):
-    with mock.patch(
-            'clusterman.kubernetes.kubernetes_cluster_connector.KubernetesClusterConnector.set_node_unschedulable',
-            autospec=True,
-    ) as mock_set_node_unschedulable:
-        mock_node = mock.Mock()
-        mock_set_node_unschedulable.return_value = None
-        mock_cluster_connector.set_node_unschedulable(mock_node)
-        assert mock_set_node_unschedulable.called
-
-
-def test_delete_node(mock_cluster_connector):
-    with mock.patch(
-            'clusterman.kubernetes.kubernetes_cluster_connector.KubernetesClusterConnector.delete_node',
-            autospec=True,
-    ) as mock_delete_node:
-        mock_node = mock.Mock()
-        mock_delete_node.return_value = None
-        mock_cluster_connector.delete_node(mock_node)
-        assert mock_delete_node.called
-
-
 def test_pod_belongs_to_pool(
     mock_cluster_connector,
     running_pod_1,

--- a/tests/kubernetes/util_test.py
+++ b/tests/kubernetes/util_test.py
@@ -1,7 +1,65 @@
+import os
+
+import mock
+import pytest
 from kubernetes.client.models.v1_node_selector_requirement import V1NodeSelectorRequirement
 from kubernetes.client.models.v1_node_selector_term import V1NodeSelectorTerm
 
+from clusterman.kubernetes.util import CachedCoreV1Api
+from clusterman.kubernetes.util import ResourceParser
 from clusterman.kubernetes.util import selector_term_matches_requirement
+
+
+@pytest.fixture
+def mock_cached_core_v1_api():
+    with mock.patch('clusterman.kubernetes.util.kubernetes'):
+        yield CachedCoreV1Api('/foo/bar/admin.conf')
+
+
+def test_cached_corev1_api_no_kubeconfig(caplog):
+    with pytest.raises(TypeError):
+        CachedCoreV1Api('/foo/bar/admin.conf')
+        assert 'Could not load KUBECONFIG' in caplog.text
+
+
+def test_cached_corev1_api_caches_non_cached_function(mock_cached_core_v1_api):
+    mock_cached_core_v1_api.list_namespace()
+    assert mock_cached_core_v1_api._client.list_namespace.call_count == 1
+
+
+def test_cached_corev1_api_caches_cached_function_no_env_var(mock_cached_core_v1_api):
+    mock_cached_core_v1_api.list_node()
+    mock_cached_core_v1_api.list_node()
+    assert mock_cached_core_v1_api._client.list_node.call_count == 2
+
+
+def test_cached_corev1_api_caches_cached_function(mock_cached_core_v1_api):
+    with mock.patch.dict(os.environ, {'KUBE_CACHE_ENABLED': 'true'}):
+        mock_cached_core_v1_api.list_node()
+        mock_cached_core_v1_api.list_node()
+    assert mock_cached_core_v1_api._client.list_node.call_count == 1
+
+
+def test_resource_parser_cpu():
+    assert ResourceParser.cpus({'cpu': '2'}) == 2.0
+    assert ResourceParser.cpus({'cpu': '500m'}) == 0.5
+
+
+def test_resource_parser_mem():
+    assert ResourceParser.mem({'memory': '1Gi'}) == 1000.0
+
+
+def test_resource_parser_disk():
+    assert ResourceParser.disk({'ephemeral-storage': '1Gi'}) == 1000.0
+
+
+def test_resource_parser_gpus():
+    assert ResourceParser.gpus({'nvidia.com/gpu': '3'}) == 3
+
+
+def test_resource_parser_gpus_non_integer():
+    with pytest.raises(ValueError):
+        ResourceParser.gpus({'nvidia.com/gpu': '3.5'})
 
 
 def test_selector_term_matches_requirement():


### PR DESCRIPTION
### Description

This is basically a no-op change, I just added some more tests to get our coverage back up (and I think they're more-or-less useful tests, as well).

The two substantive changes I made were to 
* delete a bunch of dead code around evicting pods and cordoning nodes from the `KubernetesClusterConnector`; we don't do this from inside Clusterman anymore, instead it should be handled from `graceful_k8s_shutdown`.
* I don't think we should just return `0` if kubernetes returns a bad value for gpu count, I think it's better to just crash in this case.

### Testing Done

`make test` passes
