### PR TITLE
Switch to counting the number of lost nodes

### DIFF
--- a/clusterman/autoscaler/autoscaler.py
+++ b/clusterman/autoscaler/autoscaler.py
@@ -158,12 +158,12 @@ class Autoscaler:
         no_scale_down = False
         if self.autoscaling_config.prevent_scale_down_after_capacity_loss:
             logger.warning('prevent_scale_down_after_capacity_loss is enabled, scale down may be slowed')
-            removed_nodes_before_last_reload = self.pool_manager.get_removed_nodes_before_last_reload()
+            num_removed_nodes_before_last_reload = self.pool_manager.get_num_removed_nodes_before_last_reload()
             # TODO (CLUSTERMAN-576): support instance weights here, instead of just instance count
-            if len(removed_nodes_before_last_reload) > self.autoscaling_config.instance_loss_threshold:
+            if num_removed_nodes_before_last_reload > self.autoscaling_config.instance_loss_threshold:
                 logger.warning('Nodes lost since last autoscaler run is {}'
                                ' which is greater than the threshold ({}),'.format(
-                                   len(removed_nodes_before_last_reload),
+                                   num_removed_nodes_before_last_reload,
                                    self.autoscaling_config.instance_loss_threshold
                                    ),
                                ' will not scale down on this run')
@@ -171,7 +171,7 @@ class Autoscaler:
             else:
                 logger.warning('Nodes lost since last autoscaler run ({})'
                                ' is less than the threshold ({}), '.format(
-                                   len(removed_nodes_before_last_reload),
+                                   num_removed_nodes_before_last_reload,
                                    self.autoscaling_config.instance_loss_threshold
                                    ),
                                'scaling down is not restricted')

--- a/clusterman/autoscaler/pool_manager.py
+++ b/clusterman/autoscaler/pool_manager.py
@@ -22,13 +22,11 @@ from typing import Mapping
 from typing import MutableMapping
 from typing import Optional
 from typing import Sequence
-from typing import Set
 from typing import Tuple
 from typing import Type
 
 import colorlog
 import staticconf
-from kubernetes.client.models.v1_node import V1Node as KubernetesNode
 from kubernetes.client.models.v1_pod import V1Pod as KubernetesPod
 
 from clusterman.aws.aws_resource_group import AWSResourceGroup
@@ -92,12 +90,12 @@ class PoolManager:
         logger.info('Recalculating non-orphan fulfilled capacity')
         self.non_orphan_fulfilled_capacity = self._calculate_non_orphan_fulfilled_capacity()
 
-    def get_removed_nodes_before_last_reload(self) -> Set[KubernetesNode]:
+    def get_num_removed_nodes_before_last_reload(self) -> int:
         if not isinstance(self.cluster_connector, KubernetesClusterConnector):
-            logger.warning('get_removed_nodes_since_last_reload is only supported for Kubernetes clusters')
-            return set()
+            logger.warning('get_num_removed_nodes_since_last_reload is only supported for Kubernetes clusters')
+            return 0
 
-        return self.cluster_connector.get_removed_nodes_before_last_reload()
+        return self.cluster_connector.get_num_removed_nodes_before_last_reload()
 
     def mark_stale(self, dry_run: bool) -> None:
         if dry_run:

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -17,7 +17,6 @@ from distutils.util import strtobool
 from typing import List
 from typing import Mapping
 from typing import Optional
-from typing import Set
 from typing import Tuple
 
 import colorlog
@@ -71,16 +70,11 @@ class KubernetesClusterConnector(ClusterConnector):
         self._nodes_by_ip = self._get_nodes_by_ip()
         self._pods_by_ip, self._pending_pods = self._get_pods_by_ip_or_pending()
 
-    def get_removed_nodes_before_last_reload(self) -> Set[KubernetesNode]:
+    def get_num_removed_nodes_before_last_reload(self) -> int:
         previous_nodes = self._prev_nodes_by_ip
         current_nodes = self._nodes_by_ip
 
-        # todo jmalt: make sure this gives the desired results
-        # equality is defined based on to_dict() for V1Node, so this should work
-        if previous_nodes is not None:
-            return set(previous_nodes.values()) - set(current_nodes.values())
-        else:
-            return set()
+        return max(0, len(previous_nodes) - len(current_nodes))
 
     def get_resource_pending(self, resource_name: str) -> float:
         return getattr(allocated_node_resources([p for p, __ in self.get_unschedulable_pods()]), resource_name)

--- a/itests/steps/autoscaler.py
+++ b/itests/steps/autoscaler.py
@@ -27,7 +27,6 @@ from kubernetes.client import V1PodCondition
 from kubernetes.client import V1PodSpec
 from kubernetes.client import V1PodStatus
 from kubernetes.client import V1ResourceRequirements
-from kubernetes.client.models.v1_node import V1Node as KubernetesNode
 from moto import mock_dynamodb2
 
 from clusterman.autoscaler.autoscaler import Autoscaler
@@ -378,9 +377,7 @@ def run_autoscaler(context, once_only=False):
 
 @behave.when('the cluster has recently lost capacity')
 def lost_capacity(context):
-    context.mock_cluster_connector.return_value.get_removed_nodes_before_last_reload.return_value = [
-        KubernetesNode()
-    ]
+    context.mock_cluster_connector.return_value.get_num_removed_nodes_before_last_reload.return_value = 1
 
 
 @behave.then('the autoscaler should scale rg(?P<rg>[12]) to (?P<target>\d+) capacity')


### PR DESCRIPTION


### Description

https://github.com/Yelp/clusterman/pull/73 used a set-difference between the nodes the last time the autoscaler ran and the nodes now. This didn't work as-is because I missed that the `KubernetesNode` class isn't hashable.

Instead, I'm just using the number of nodes now vs the number of nodes then. This has slightly different behaviour in the event that nodes are lost and replaced (assuming the replacements join the k8s cluster before the next autoscaler run), but otherwise it should be the same.

### Testing Done
Unit and integration tests pass

Please fill out!  Generally speaking any new features should include
additional unit or integration tests to ensure the behaviour is
working correctly.
