### PR TITLE
fix servicedocs building and uploading

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -6,8 +6,9 @@ MarkupSafe==1.1.1
 packaging==19.2
 Pygments==2.4.2
 pytz==2019.3
+servicedocs-tool==2.4.4
 snowballstemmer==2.0.0
-Sphinx==2.2.1
+Sphinx==2.2.0
 sphinx-autodoc-annotation==1.0.post1
 sphinx-rtd-theme==0.4.3
 sphinxcontrib-applehelp==1.0.1

--- a/tox.ini
+++ b/tox.ini
@@ -56,10 +56,17 @@ commands =
 [testenv:docs]
 envdir = .tox/docs
 deps =
-    -rrequirements-doc.txt
+    -rrequirements-docs.txt
 changedir = docs
 commands =
     sphinx-build -b html -d build/doctrees source build/html
+
+[testenv:upload_docs]
+envdir = ./tox/docs
+deps =
+    -rrequirements-docs.txt
+commands =
+    upload-to-servicedocs --yes
 
 [testenv:virtualenv_run-dev]
 commands =


### PR DESCRIPTION
### Description

I had to make these changes in order to upload changes to servicedocs. I've probably missed something that's already configured (after all, past changes must have been uploaded somehow), so feel free to discard this if it's not actually needed.

In no particular order:

- change `Sphinx` to a version that exists in Yelp's internal PyPi
- add an `upload_docs` tox target
- install `servicedocs-tool` which provides the `upload-to-servicedocs` utility

### Testing Done

none, but uploading docs works now
