### PR TITLE
fix `sensu_checkin` to read per-pool monitoring configs

### DIFF
--- a/clusterman/batch/autoscaler.py
+++ b/clusterman/batch/autoscaler.py
@@ -151,6 +151,7 @@ class AutoscalerBatch(BatchDaemon, BatchLoggingMixin, BatchRunningSentinelMixin)
         sensu_args = dict(
             check_name=SERVICE_CHECK_NAME,
             scheduler=self.options.scheduler,
+            app=self.apps[0],  # TODO (CLUSTERMAN-126)
             check_every=check_every,
             source=f'{self.options.cluster}_{self.options.pool}',
             ttl=alert_delay,


### PR DESCRIPTION
### Description

We were getting paged for kubestage, even though we had monitoring set
to `page: false` in this cluster.  I eventually traced this to the fact
that `sensu_checkin` requires the `app` argument to be present to read
the pool-based config monitoring values.

The whole concept of "apps" is a bit of cruft left over from the really
early days of clusterman, and I think some of the logic around this is
not really correct and should probably be revisited, but in the
interest of a short-term fix to make our pager quieter I just had the
autoscaler batch provide the app argument to ensure that it reads the
right values from the config.

### Testing Done

manual testing in kubestage
