### PR TITLE
Drmorr/fix some clusterman bugs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,11 +150,13 @@ debug:
 		-v $(shell pwd)/clusterman:/code/clusterman:rw \
 		-v $(shell pwd)/.cman_debug_bashrc:/home/nobody/.bashrc:ro \
 		-v /nail/srv/configs:/nail/srv/configs:ro \
+		-v $(shell pwd)/clusterman.yaml:/nail/srv/configs/clusterman.yaml:ro \
 		-v $(shell pwd)/etc-kubernetes:/etc/kubernetes:ro \
 		-v /nail/etc/services:/nail/etc/services:ro \
 		-v /etc/boto_cfg:/etc/boto_cfg:ro \
-		-e "CMAN_CLUSTER=mesosstage" \
+		-e "CMAN_CLUSTER=kubestage" \
 		-e "CMAN_POOL=default" \
+		-e "CMAN_SCHEDULER=kubernetes" \
 		clusterman_debug_container /bin/bash
 
 .PHONY:

--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,6 @@ debug:
 		-v $(shell pwd)/clusterman:/code/clusterman:rw \
 		-v $(shell pwd)/.cman_debug_bashrc:/home/nobody/.bashrc:ro \
 		-v /nail/srv/configs:/nail/srv/configs:ro \
-		-v $(shell pwd)/clusterman.yaml:/nail/srv/configs/clusterman.yaml:ro \
 		-v $(shell pwd)/etc-kubernetes:/etc/kubernetes:ro \
 		-v /nail/etc/services:/nail/etc/services:ro \
 		-v /etc/boto_cfg:/etc/boto_cfg:ro \

--- a/clusterman/autoscaler/autoscaler.py
+++ b/clusterman/autoscaler/autoscaler.py
@@ -141,6 +141,7 @@ class Autoscaler:
             logger.info('Autoscaling is currently paused; doing nothing')
             return
 
+        self.pool_manager.reload_state()
         try:
             signal_name = self.signal.name
             resource_request = self.signal.evaluate(timestamp)
@@ -152,8 +153,6 @@ class Autoscaler:
             exception, tb = e, traceback.format_exc()
 
         logger.info(f'Signal {signal_name} requested {resource_request}')
-
-        self.pool_manager.reload_state()
 
         no_scale_down = False
         if self.autoscaling_config.prevent_scale_down_after_capacity_loss:

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -140,6 +140,10 @@ class KubernetesClusterConnector(ClusterConnector):
         return False
 
     def _get_pod_unschedulable_reason(self, pod: KubernetesPod) -> PodUnschedulableReason:
+        # TODO (CLUSTERMAN-587) delete this feature toggle once we're sure everything's working as planned
+        if not self.pool_config.read_bool('autoscale_signal.prioritize_pending_pods', default=False):
+            return PodUnschedulableReason.Unknown
+
         pod_resource_request = total_pod_resources(pod)
         for node_ip, pods_on_node in self._pods_by_ip.items():
             node = self._nodes_by_ip.get(node_ip)

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -141,8 +141,9 @@ class KubernetesClusterConnector(ClusterConnector):
 
     def _get_pod_unschedulable_reason(self, pod: KubernetesPod) -> PodUnschedulableReason:
         pod_resource_request = total_pod_resources(pod)
-        for node in self._nodes_by_ip.values():
-            if pod_resource_request < total_node_resources(node):
+        for node_ip, pods_on_node in self._pods_by_ip.items():
+            node = self._nodes_by_ip.get(node_ip)
+            if node and pod_resource_request < total_node_resources(node) - allocated_node_resources(pods_on_node):
                 return PodUnschedulableReason.Unknown
 
         return PodUnschedulableReason.InsufficientResources

--- a/clusterman/util.py
+++ b/clusterman/util.py
@@ -75,6 +75,14 @@ class ClustermanResources(NamedTuple):
             gpus=resources.gpus,
         )
 
+    def __sub__(self, other: 'ClustermanResources') -> 'ClustermanResources':
+        return ClustermanResources(
+            cpus=self.cpus - other.cpus,
+            mem=self.mem - other.mem,
+            disk=self.disk - other.disk,
+            gpus=self.gpus - other.gpus,
+        )
+
     def __mul__(self, scalar: float) -> 'ClustermanResources':
         return ClustermanResources(
             cpus=self.cpus * scalar,
@@ -82,6 +90,9 @@ class ClustermanResources(NamedTuple):
             disk=self.disk * scalar,
             gpus=self.gpus * scalar,
         )
+
+    def __lt__(self, other) -> bool:
+        return (self.cpus < other.cpus and self.mem < other.mem and self.disk < other.disk and self.gpus < other.gpus)
 
 
 class SignalResourceRequest(NamedTuple):

--- a/itests/autoscaler_scaling.feature
+++ b/itests/autoscaler_scaling.feature
@@ -84,8 +84,22 @@ Feature: make sure the autoscaler scales to the proper amount
         | 14        | 16         | 15         |
         | 1000      | 50         | 50         |
 
+    @wip
+    Scenario: the PendingPodsSignal is using up-to-date data
+       Given a cluster with 1 resource group
+         And 10 target capacity
+         And 40 CPUs, 500 MB mem, 500 MB disk, and 0 GPUs
+         And 28 CPUs allocated and 0 CPUs pending
+         And a kubernetes autoscaler object
+        When the autoscaler runs only once
+         And allocated CPUs changes to 40
+         And the autoscaler runs only once
+        Then no exception is raised
+         And the autoscaler should scale rg1 to 15 capacity
+
+
     Scenario: instances are not killed if we've lost capacity recently
-       Given a cluster with 1 resource groups
+       Given a cluster with 1 resource group
          And 10 target capacity
          And 40 CPUs, 500 MB mem, 500 MB disk, and 0 GPUs
          And 1 CPUs allocated and 0 CPUs pending


### PR DESCRIPTION
### Description

This change fixes two bugs found in the autoscaling behaviour

1) The first, and less serious, is that we weren't reloading the pool
state until _after_ we'd already evaluated our signals, which means that
for the internal version of the signal (which doesn't rely on the
metrics store), we were using the data from the _last_ autoscaling run
instead of the current one.

2) The second is a bit larger: it turns out we were never actually
scaling based on pending pods, because pending pods were always getting
marked as "Unknown".  The reason for this is that we were comparing the
pending pods request to the total allocatable capacity on the node,
instead of what's remaining, so Clusterman never realized that pods
potentially couldn't fit on a given node.

This change fixes both of these behaviours.  Since these both change how
the scaling behaviour actually happens, we'll want to roll it out
slowly.

### Testing Done

I fixed the itests that check scaling behaviour to actually make sure the 
pods are getting classified correctly.
