### PR TITLE
add some logging for the pending pods signal

### DIFF
--- a/clusterman/signals/pending_pods_signal.py
+++ b/clusterman/signals/pending_pods_signal.py
@@ -35,6 +35,9 @@ def _get_resource_request(
                 # this with a more intelligent solution in the future.
                 resource_request += total_pod_resources(pod) * 2
 
+    logger.info(f'List of pending pods: {pending_pods}')
+    logger.info(f'Signal requesting {resource_request} for all the pending pods')
+
     return resource_request + allocated_resources
 
 


### PR DESCRIPTION
### Description

It's a little hard to see sometimes what Clusterman thinks is pending and why, and what it's doing with those resources, so this adds a couple log lines to make this more clear.

### Testing Done

none
