### PR TITLE
remove pending pods feature toggle

### DIFF
--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -140,10 +140,6 @@ class KubernetesClusterConnector(ClusterConnector):
         return False
 
     def _get_pod_unschedulable_reason(self, pod: KubernetesPod) -> PodUnschedulableReason:
-        # TODO (CLUSTERMAN-587) delete this feature toggle once we're sure everything's working as planned
-        if not self.pool_config.read_bool('autoscale_signal.prioritize_pending_pods', default=False):
-            return PodUnschedulableReason.Unknown
-
         pod_resource_request = total_pod_resources(pod)
         for node_ip, pods_on_node in self._pods_by_ip.items():
             node = self._nodes_by_ip.get(node_ip)


### PR DESCRIPTION
just removing the feature toggle for the pending-pods fix, now that we're reasonably confident it's working properly.

I'll clean up srv-configs once this is deployed.