### PR TITLE
CLUSTERMAN-542: Allow excluding daemonset pods from resource calculations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,9 +148,10 @@ debug:
 	docker build . -t clusterman_debug_container
 	paasta_docker_wrapper run -it \
 		-v $(shell pwd)/clusterman:/code/clusterman:rw \
+		-v $(shell pwd)/clusterman.conf:/var/lib/clusterman/clusterman.conf:rw \
 		-v $(shell pwd)/.cman_debug_bashrc:/home/nobody/.bashrc:ro \
-		-v /nail/srv/configs:/nail/srv/configs:ro \
 		-v $(shell pwd)/etc-kubernetes:/etc/kubernetes:ro \
+		-v /nail/srv/configs:/nail/srv/configs:ro \
 		-v /nail/etc/services:/nail/etc/services:ro \
 		-v /etc/boto_cfg:/etc/boto_cfg:ro \
 		-e "CMAN_CLUSTER=kubestage" \

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -97,7 +97,7 @@ class KubernetesClusterConnector(ClusterConnector):
             for node in self._nodes_by_ip.values()
         )
         if excluded_total > 0:
-            logger.debug(f'Excluded {excluded_total} {resource_name} from total resources by config')
+            logger.info(f'Excluded {excluded_total} {resource_name} from total resources')
         return base_total - excluded_total
 
     def get_unschedulable_pods(self) -> List[Tuple[KubernetesPod, PodUnschedulableReason]]:

--- a/clusterman/kubernetes/util.py
+++ b/clusterman/kubernetes/util.py
@@ -135,13 +135,15 @@ def get_node_ip(node: KubernetesNode) -> str:
     raise ValueError('Kubernetes node {node.metadata.name} has no "InternalIP" address')
 
 
-def total_node_resources(node: KubernetesNode) -> ClustermanResources:
-    return ClustermanResources(
+def total_node_resources(node: KubernetesNode, excluded_pods: List[KubernetesPod]) -> ClustermanResources:
+    base_total = ClustermanResources(
         cpus=ResourceParser.cpus(node.status.allocatable),
         mem=ResourceParser.mem(node.status.allocatable),
         disk=ResourceParser.disk(node.status.allocatable),
         gpus=ResourceParser.gpus(node.status.allocatable),
     )
+    excluded_resources = allocated_node_resources(excluded_pods)
+    return base_total - excluded_resources
 
 
 def total_pod_resources(pod: KubernetesPod) -> ClustermanResources:


### PR DESCRIPTION
### Description

We saw in CLUSTERMAN-542 that clusterman refused to remove hosts running nothing but pods common to every node running from daemonsets because these pods were counted towards *allocated* resources requested.

This change adds an optional pool-level toggle `exclude_daemonset_pods` that will exclude any pods created via daemonsets from being added to *allocated* or *requested* resources, and any resources they are taking will be removed from *total* available resources.  This will take both `Pending` and `Running` daemonset pods into account on the appropriate pool nodes.  

This will also exclude daemonset pods from being counted towards running tasks taken into consideration for killing nodes (i.e. daemonset pods aren't counted towards `max_tasks_to_kill`), as task count is taken directly from `_pods_by_ip`, which would now exclude all daemonset pods with this config toggle.

### Testing Done
Added a test into `kubernetes_cluster_connector_test` to verify this config and calculations do what we expect, and ran manually against `kubestage`'s `default` pool:

**Without `exclude_daemonset_pods`**:
```
INFO:clusterman.autoscaler.autoscaler:Current cluster total resources: ClustermanResources(cpus=156.0, mem=297769.544704, disk=2242208.257206, gpus=0)
INFO:clusterman.autoscaler.autoscaler:Current cluster allocated resources: ClustermanResources(cpus=8.699999999999998, mem=46628.0, disk=19750.0, gpus=0)
```

**With `exclude_daemonset_pods`**:
```
INFO:clusterman.kubernetes.kubernetes_cluster_connector:Excluded 0.7000000000000001 cpus from daemonset pods
INFO:clusterman.kubernetes.kubernetes_cluster_connector:Excluded 1300.0 mem from daemonset pods
INFO:clusterman.kubernetes.kubernetes_cluster_connector:Excluded 100.0 disk from daemonset pods
INFO:clusterman.kubernetes.kubernetes_cluster_connector:Excluded 0 gpus from daemonset pods
INFO:clusterman.autoscaler.autoscaler:Current cluster total resources: ClustermanResources(cpus=155.3, mem=296469.544704, disk=2242108.257206, gpus=0)
INFO:clusterman.autoscaler.autoscaler:Current cluster allocated resources: ClustermanResources(cpus=7.999999999999998, mem=45328.0, disk=19650.0, gpus=0)
```

After increasing target capacity in kubestage, then manually modifying local `default.kubernetes` to set `max_tasks_to_kill: 1`, a dry-run with `exclude_daemonset_pods: true` would have scaled down appropriately:
```
INFO:clusterman.kubernetes.kubernetes_cluster_connector:Excluded 0.6000000000000001 cpus from total resources
INFO:clusterman.kubernetes.kubernetes_cluster_connector:Excluded 1000.0 mem from total resources
INFO:clusterman.kubernetes.kubernetes_cluster_connector:Excluded 200.0 disk from total resources
...
INFO:clusterman.autoscaler.autoscaler:Current cluster total resources: ClustermanResources(cpus=87.4, mem=176373.6448, disk=1824558.235394, gpus=0)
INFO:clusterman.autoscaler.autoscaler:Current cluster allocated resources: ClustermanResources(cpus=12.2, mem=70328.0, disk=24404.0, gpus=0)
...
INFO:clusterman.autoscaler.pool_manager:Killable instance IDs in kill order:
['i-09cec463628b2136b', 'i-03b9e0f50e8956c7f']
```

without `exclude_daemonset_pods`, the autoscaler found 0 killable instances:
```
INFO:clusterman.autoscaler.autoscaler:Current cluster total resources: ClustermanResources(cpus=88.0, mem=177373.6448, disk=1824758.235394, gpus=0)
INFO:clusterman.autoscaler.autoscaler:Current cluster allocated resources: ClustermanResources(cpus=12.799999999999997, mem=71328.0, disk=24604.0, gpus=0)
...
INFO:clusterman.autoscaler.pool_manager:Killable instance IDs in kill order:
[]
```


