### PR TITLE
Bump pyyaml, jsonpickle, and urllib3 to patch sec vulns

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ google-auth==1.6.3
 humanfriendly==4.18
 idna==2.8
 jmespath==0.9.4
-jsonpickle==1.2
+jsonpickle==1.4.2
 kiwisolver==1.1.0
 kubernetes==10.0.1
 matplotlib==3.1.1
@@ -30,7 +30,7 @@ pyformance==0.4
 pyparsing==2.4.2
 PyStaticConfiguration==0.10.4
 python-dateutil==2.8.0
-PyYAML==5.1.2
+PyYAML==5.3.1
 requests==2.22.0
 requests-oauthlib==1.2.0
 retry==0.9.2
@@ -43,6 +43,6 @@ six==1.12.0
 sortedcontainers==2.1.0
 sseclient-py==1.7
 typing-extensions==3.7.4
-urllib3==1.25.6
+urllib3==1.25.9
 websocket-client==0.56.0
 ws4py==0.5.1


### PR DESCRIPTION
### Description
Our Jenkins builds are failing security checks because of vulnerabilities in PyYAML, jsonpickle, and urllib3. This PR bumps them all to safe versions.

### Testing Done
`paasta security-check`
`make test`
`make itest`
all pass