### PR TITLE
CLUSTERMAN-542: Also allow us to specify default exclude_daemonset_po…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,8 @@ debug:
 		-v $(shell pwd)/.cman_debug_bashrc:/home/nobody/.bashrc:ro \
 		-v $(shell pwd)/etc-kubernetes:/etc/kubernetes:ro \
 		-v /nail/srv/configs:/nail/srv/configs:ro \
+		-v $(shell pwd)/clusterman.yaml:/nail/srv/configs/clusterman.yaml:ro \
+		-v $(shell pwd)/default.kubernetes:/nail/srv/configs/clusterman-clusters/kubestage/default.kubernetes:ro \
 		-v /nail/etc/services:/nail/etc/services:ro \
 		-v /etc/boto_cfg:/etc/boto_cfg:ro \
 		-e "CMAN_CLUSTER=kubestage" \

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -204,7 +204,8 @@ class KubernetesClusterConnector(ClusterConnector):
         pending_pods: List[KubernetesPod] = []
         excluded_pods_by_ip: Mapping[str, List[KubernetesPod]] = defaultdict(list)
 
-        exclude_daemonset_pods = self.pool_config.read_bool('exclude_daemonset_pods', default=False)
+        exclude_daemonset_pods = self.pool_config.read_bool(
+            'exclude_daemonset_pods', default=staticconf.read_bool('exclude_daemonset_pods', default=False))
         all_pods = self._core_api.list_pod_for_all_namespaces().items
         for pod in all_pods:
             if self._pod_belongs_to_pool(pod):


### PR DESCRIPTION
…ds from clusterman config

### Description

In #93 I added the `exclude_daemonset_pods`, but did not read the default value from the primary config.  This fixes that, so we can toggle this at a wider level than just "everything" or "every individual pool".

### Testing Done

`make test` is green and a manual test with `exclude_daemonset_pods` excluded on the per-pool configuration but in `clusterman.yaml` excludes the daemonset resources as expected:
```
$ grep exclude_daemonset_pods /nail/srv/configs/cluster
exclude_daemonset_pods: true
nobody@e6be530dfc24:/code$ grep exclude_daemonset_pods /nail/srv/configs/clusterman-clusters/kubestage/default.kubernetes
nobody@e6be530dfc24:/code$
```

```
INFO:clusterman.kubernetes.kubernetes_cluster_connector:Excluded 0.4 cpus from daemonset pods
INFO:clusterman.kubernetes.kubernetes_cluster_connector:Excluded 600.0 mem from daemonset pods
INFO:clusterman.kubernetes.kubernetes_cluster_connector:Excluded 200.0 disk from daemonset pods
INFO:clusterman.kubernetes.kubernetes_cluster_connector:Excluded 0 gpus from daemonset pods
```