### PR TITLE
Fix error while printing message for prevent_scale_down option

### DIFF
--- a/clusterman/autoscaler/autoscaler.py
+++ b/clusterman/autoscaler/autoscaler.py
@@ -163,8 +163,8 @@ class Autoscaler:
                                ' which is greater than the threshold ({}),'.format(
                                    str(num_removed_nodes_before_last_reload),
                                    str(self.autoscaling_config.instance_loss_threshold)
-                                   ),
-                               ' will not scale down on this run')
+                                   ))
+                logger.warning('Autoscaler will not kill any nodes on this run.')
                 no_scale_down = True
 
         if isinstance(resource_request, list):


### PR DESCRIPTION
### Description

While watching Clusterman scale a pool down today, I noticed an error while printing the log line indicating that scaling down was restricted

```
TypeError: not all arguments converted during string formatting
Call stack:
  File "/usr/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/code/clusterman/batch/autoscaler.py", line 173, in <module>
    AutoscalerBatch().start()
  File "/code/virtualenv_run/lib/python3.7/site-packages/yelp_batch/batch.py", line 580, in start
    self.run()
  File "/code/clusterman/batch/autoscaler.py", line 137, in run
    self._autoscale()
  File "/code/clusterman/batch/autoscaler.py", line 56, in wrapper
    fn(self)
  File "/code/clusterman/batch/autoscaler.py", line 130, in _autoscale
    self.autoscaler.run(dry_run=self.options.dry_run)
  File "/code/clusterman/autoscaler/autoscaler.py", line 167, in run
    ' will not scale down on this run')
Message: 'Nodes lost since last autoscaler run is 29 which is greater than the threshold (2),'
Arguments: (' will not scale down on this run',)
ERROR:__main__:Autoscaler service failed: not all arguments converted during string formatting
```

This exception is logged but doesn't actually break autoscaling, but it's still worth fixing.

To fix it I moved the second part of the log line to a separate call to `logger.warning`.

### Testing Done

`make test && make itest`
