### PR TITLE
CLUSTERMAN-542 bugfix: some pods may not have owner_references

### DIFF
--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -116,7 +116,10 @@ class KubernetesClusterConnector(ClusterConnector):
         return unschedulable_pods
 
     def _pod_belongs_to_daemonset(self, pod: KubernetesPod) -> bool:
-        return any([owner_reference.kind == 'DaemonSet' for owner_reference in pod.metadata.owner_references])
+        return (
+            pod.metadata.owner_references and
+            any([owner_reference.kind == 'DaemonSet' for owner_reference in pod.metadata.owner_references])
+        )
 
     def _pod_belongs_to_pool(self, pod: KubernetesPod) -> bool:
         # Check if the pod is on a node in the pool -- this should cover most cases

--- a/tests/kubernetes/kubernetes_cluster_connector_test.py
+++ b/tests/kubernetes/kubernetes_cluster_connector_test.py
@@ -42,7 +42,7 @@ from clusterman.kubernetes.kubernetes_cluster_connector import KubernetesCluster
 @pytest.fixture
 def running_pod_1():
     return V1Pod(
-        metadata=V1ObjectMeta(name='running_pod_1', owner_references=[]),
+        metadata=V1ObjectMeta(name='running_pod_1'),
         status=V1PodStatus(phase='Running', host_ip='10.10.10.2'),
         spec=V1PodSpec(containers=[
                V1Container(


### PR DESCRIPTION
### Description

Clusterman failed on a cluster that had some pods with a null `metadata.ownerReferences` with the following error:
```
return any([owner_reference.kind == 'DaemonSet' for owner_reference in pod.metadata.owner_references])
          TypeError: 'NoneType' object is not iterable
```

This fixes that issue by ensuring ownerReferences is not empy before attempting to iterate over it. 

### Testing Done

To capture this potential issue I removed `owner_references` in one of the test pods to ensure everything still functioned as expected.  `make test` now returns green with these changes.

by contrast, with `owner_references` removed on the test pod but `kubernetes_cluster_connector.py` unchanged, I get the error as expectec: 
```
>       return any([owner_reference.kind == 'DaemonSet' for owner_reference in pod.metadata.owner_references])
E       TypeError: 'NoneType' object is not iterable
```