### PR TITLE
Added new error exception when no resource groups are found

### DIFF
--- a/clusterman/autoscaler/pool_manager.py
+++ b/clusterman/autoscaler/pool_manager.py
@@ -35,6 +35,7 @@ from clusterman.aws.util import RESOURCE_GROUPS
 from clusterman.config import POOL_NAMESPACE
 from clusterman.draining.queue import DrainingClient
 from clusterman.exceptions import AllResourceGroupsAreStaleError
+from clusterman.exceptions import NoResourceGroupsFoundError
 from clusterman.exceptions import PoolManagerError
 from clusterman.exceptions import ResourceGroupError
 from clusterman.interfaces.cluster_connector import ClusterConnector
@@ -516,7 +517,11 @@ class PoolManager:
         """ The target capacity is the *desired* weighted capacity for the given Mesos cluster pool.  There is no
         guarantee that the actual capacity will equal the target capacity.
         """
+        if not self.resource_groups:
+            raise NoResourceGroupsFoundError()
+
         non_stale_groups = [group for group in self.resource_groups.values() if not group.is_stale]
+
         if not non_stale_groups:
             raise AllResourceGroupsAreStaleError()
         return sum(group.target_capacity for group in non_stale_groups)

--- a/clusterman/exceptions.py
+++ b/clusterman/exceptions.py
@@ -37,6 +37,10 @@ class NoLaunchTemplateConfiguredError(ClustermanException):
     pass
 
 
+class NoResourceGroupsFoundError(Exception):
+    pass
+
+
 class NoSignalConfiguredException(ClustermanException):
     pass
 

--- a/tests/autoscaler/pool_manager_test.py
+++ b/tests/autoscaler/pool_manager_test.py
@@ -505,7 +505,7 @@ def test_compute_new_resource_group_targets_scale_up_stale_pools_0(non_stale_cap
 
 
 def test_compute_target_capacity_no_resource_groups_found(mock_pool_manager):
-    mock_pool_manager.resource_groups = []
+    mock_pool_manager.resource_groups = {}
     with pytest.raises(NoResourceGroupsFoundError):
         mock_pool_manager.target_capacity == 0
 

--- a/tests/autoscaler/pool_manager_test.py
+++ b/tests/autoscaler/pool_manager_test.py
@@ -20,6 +20,7 @@ from clusterman.autoscaler.pool_manager import ClusterNodeMetadata
 from clusterman.autoscaler.pool_manager import PoolManager
 from clusterman.aws.aws_resource_group import AWSResourceGroup
 from clusterman.exceptions import AllResourceGroupsAreStaleError
+from clusterman.exceptions import NoResourceGroupsFoundError
 from clusterman.exceptions import PoolManagerError
 from clusterman.exceptions import ResourceGroupError
 from clusterman.interfaces.types import AgentMetadata
@@ -501,6 +502,12 @@ def test_compute_new_resource_group_targets_scale_up_stale_pools_0(non_stale_cap
 
     new_targets = mock_pool_manager._compute_new_resource_group_targets(6)
     assert new_targets == {'sfr-0': 2, 'sfr-1': 2, 'sfr-2': 2, 'sfr-3': 0, 'sfr-4': 0, 'sfr-5': 0, 'sfr-6': 0}
+
+
+def test_compute_target_capacity_no_resource_groups_found(mock_pool_manager):
+    mock_pool_manager.resource_groups = []
+    with pytest.raises(NoResourceGroupsFoundError):
+        mock_pool_manager.target_capacity == 0
 
 
 def test_get_market_capacities(mock_pool_manager):


### PR DESCRIPTION
### Description

Created a new Error Exception called `NoResourceGroupsFoundError`. This is created as per one of the action items of DAR-1046 to make Error Exception `AllResourceGroupsAreStaleError` more specific.

Clusterman will now first check if there are any resource groups at all. 

- If there are none, it will raise `NoResourceGroupsFoundError`. 
- If there are resource groups (but are considered stale), it will raise `AllResourceGroupsAreStaleError`.

### Testing Done

`make test - COMPLETE`