### PR TITLE
Pins virtualenv in requirements-bootstrap.txt so that your build does…

### DIFF
--- a/requirements-bootstrap.txt
+++ b/requirements-bootstrap.txt
@@ -3,4 +3,5 @@ pip-custom-platform==0.3.1
 pymonkey==0.2.2
 setuptools==41.4.0
 venv-update==2.1.3
+virtualenv==16.7.5
 wheel==0.32.3


### PR DESCRIPTION
…n't break when virtualenv 20+ is uploaded to internal pypi

---

This is a clone of an automated PR created by spatel in the internal mirror of the repo
