### PR TITLE
Handle NoResourceGroupsFoundError

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ package/itest/xenial/*
 package/itest/bionic/*
 /completions/[a-zA-Z]*
 acceptance/.local*
+sftp-config.json

--- a/clusterman/mesos/metrics_generators.py
+++ b/clusterman/mesos/metrics_generators.py
@@ -68,7 +68,7 @@ def generate_simple_metadata(manager: PoolManager) -> Generator[ClusterMetric, N
         try:
             result = value_method(manager)
         except NoResourceGroupsFoundError:
-            logger.warning(f'Resources for metric {metric_name} not found')
+            logger.warning(f'Resources for metric {metric_name} cluster {manager.cluster} not found')
             continue
 
         yield ClusterMetric(metric_name, result, dimensions=dimensions)

--- a/clusterman/mesos/metrics_generators.py
+++ b/clusterman/mesos/metrics_generators.py
@@ -17,10 +17,13 @@ from typing import Mapping
 from typing import NamedTuple
 from typing import Union
 
+import colorlog
+
 from clusterman.autoscaler.pool_manager import PoolManager
 from clusterman.exceptions import NoResourceGroupsFoundError
 from clusterman.util import get_cluster_dimensions
 
+logger = colorlog.getLogger(__name__)
 
 SYSTEM_METRICS = {
     'cpus_allocated': lambda manager: manager.cluster_connector.get_resource_allocation('cpus'),
@@ -65,6 +68,7 @@ def generate_simple_metadata(manager: PoolManager) -> Generator[ClusterMetric, N
         try:
             result = value_method(manager)
         except NoResourceGroupsFoundError:
+            logger.warning(f'Resources for metric {metric_name} not found')
             continue
 
         yield ClusterMetric(metric_name, result, dimensions=dimensions)

--- a/tests/mesos/metrics_generators_test.py
+++ b/tests/mesos/metrics_generators_test.py
@@ -15,6 +15,7 @@ import mock
 import pytest
 
 from clusterman.autoscaler.pool_manager import PoolManager
+from clusterman.exceptions import NoResourceGroupsFoundError
 from clusterman.mesos.metrics_generators import ClusterMetric
 from clusterman.mesos.metrics_generators import generate_simple_metadata
 from clusterman.mesos.metrics_generators import generate_system_metrics
@@ -85,4 +86,35 @@ def test_generate_simple_metadata(mock_pool_manager):
             dimensions={'cluster': 'mesos-test', 'pool': 'bar.mesos'},
         ),
     ]
+    assert sorted(generate_simple_metadata(mock_pool_manager)) == sorted(expected_metrics)
+
+
+def test_generate_simple_metadata_no_terraform_resources(mock_pool_manager):
+    resource_totals = {'cpus': 20, 'mem': 2000, 'disk': 20000, 'gpus': 0}
+    mock_pool_manager.cluster_connector.get_resource_total.side_effect = resource_totals.get
+
+    market_capacities = {'market1': 15, 'market2': 25}
+    mock_pool_manager.get_market_capacities.return_value = market_capacities
+
+    mock_pool_manager.non_orphan_fulfilled_capacity = 12
+
+    expected_metrics = [
+        ClusterMetric(metric_name='cpus_total', value=20, dimensions={'cluster': 'mesos-test', 'pool': 'bar.mesos'}),
+        ClusterMetric(metric_name='mem_total', value=2000, dimensions={'cluster': 'mesos-test', 'pool': 'bar.mesos'}),
+        ClusterMetric(metric_name='disk_total', value=20000, dimensions={'cluster': 'mesos-test', 'pool': 'bar.mesos'}),
+        ClusterMetric(metric_name='gpus_total', value=0, dimensions={'cluster': 'mesos-test', 'pool': 'bar.mesos'}),
+        ClusterMetric(
+            metric_name='fulfilled_capacity',
+            value=market_capacities,
+            dimensions={'cluster': 'mesos-test', 'pool': 'bar.mesos'},
+        ),
+        ClusterMetric(
+            metric_name='non_orphan_fulfilled_capacity',
+            value=12,
+            dimensions={'cluster': 'mesos-test', 'pool': 'bar.mesos'},
+        ),
+    ]
+
+    type(mock_pool_manager).target_capacity = mock.PropertyMock(side_effect=NoResourceGroupsFoundError)
+
     assert sorted(generate_simple_metadata(mock_pool_manager)) == sorted(expected_metrics)

--- a/tests/mesos/metrics_generators_test.py
+++ b/tests/mesos/metrics_generators_test.py
@@ -28,8 +28,41 @@ def mock_pool_manager():
     mock_pool_manager.cluster = 'mesos-test'
     mock_pool_manager.pool = 'bar'
     mock_pool_manager.scheduler = 'mesos'
+
+    resource_totals = {'cpus': 20, 'mem': 2000, 'disk': 20000, 'gpus': 0}
+    mock_pool_manager.cluster_connector.get_resource_total.side_effect = resource_totals.get
+
+    market_capacities = {'market1': 15, 'market2': 25}
+    mock_pool_manager.get_market_capacities.return_value = market_capacities
+
+    mock_pool_manager.non_orphan_fulfilled_capacity = 12
+
     return mock_pool_manager
 
+
+@pytest.fixture
+def simple_metadata_expected_metrics(mock_pool_manager):
+    return [
+        ClusterMetric(metric_name='cpus_total', value=20, dimensions={'cluster': 'mesos-test', 'pool': 'bar.mesos'}),
+        ClusterMetric(metric_name='mem_total', value=2000, dimensions={'cluster': 'mesos-test', 'pool': 'bar.mesos'}),
+        ClusterMetric(metric_name='disk_total', value=20000, dimensions={'cluster': 'mesos-test', 'pool': 'bar.mesos'}),
+        ClusterMetric(metric_name='gpus_total', value=0, dimensions={'cluster': 'mesos-test', 'pool': 'bar.mesos'}),
+        ClusterMetric(
+            metric_name='target_capacity',
+            value=mock_pool_manager.target_capacity,
+            dimensions={'cluster': 'mesos-test', 'pool': 'bar.mesos'},
+        ),
+        ClusterMetric(
+            metric_name='fulfilled_capacity',
+            value={'market1': 15, 'market2': 25},
+            dimensions={'cluster': 'mesos-test', 'pool': 'bar.mesos'},
+        ),
+        ClusterMetric(
+            metric_name='non_orphan_fulfilled_capacity',
+            value=12,
+            dimensions={'cluster': 'mesos-test', 'pool': 'bar.mesos'},
+        ),
+    ]
 
 def test_generate_system_metrics(mock_pool_manager):
     resources_allocated = {'cpus': 10, 'mem': 1000, 'disk': 10000, 'gpus': 0}
@@ -56,65 +89,16 @@ def test_generate_system_metrics(mock_pool_manager):
     assert sorted(generate_system_metrics(mock_pool_manager)) == sorted(expected_metrics)
 
 
-def test_generate_simple_metadata(mock_pool_manager):
-    resource_totals = {'cpus': 20, 'mem': 2000, 'disk': 20000, 'gpus': 0}
-    mock_pool_manager.cluster_connector.get_resource_total.side_effect = resource_totals.get
-
-    market_capacities = {'market1': 15, 'market2': 25}
-    mock_pool_manager.get_market_capacities.return_value = market_capacities
-
-    mock_pool_manager.non_orphan_fulfilled_capacity = 12
-
-    expected_metrics = [
-        ClusterMetric(metric_name='cpus_total', value=20, dimensions={'cluster': 'mesos-test', 'pool': 'bar.mesos'}),
-        ClusterMetric(metric_name='mem_total', value=2000, dimensions={'cluster': 'mesos-test', 'pool': 'bar.mesos'}),
-        ClusterMetric(metric_name='disk_total', value=20000, dimensions={'cluster': 'mesos-test', 'pool': 'bar.mesos'}),
-        ClusterMetric(metric_name='gpus_total', value=0, dimensions={'cluster': 'mesos-test', 'pool': 'bar.mesos'}),
-        ClusterMetric(
-            metric_name='target_capacity',
-            value=mock_pool_manager.target_capacity,
-            dimensions={'cluster': 'mesos-test', 'pool': 'bar.mesos'},
-        ),
-        ClusterMetric(
-            metric_name='fulfilled_capacity',
-            value=market_capacities,
-            dimensions={'cluster': 'mesos-test', 'pool': 'bar.mesos'},
-        ),
-        ClusterMetric(
-            metric_name='non_orphan_fulfilled_capacity',
-            value=12,
-            dimensions={'cluster': 'mesos-test', 'pool': 'bar.mesos'},
-        ),
-    ]
-    assert sorted(generate_simple_metadata(mock_pool_manager)) == sorted(expected_metrics)
+def test_generate_simple_metadata(mock_pool_manager, simple_metadata_expected_metrics):
+    assert sorted(generate_simple_metadata(mock_pool_manager)) == sorted(simple_metadata_expected_metrics)
 
 
-def test_generate_simple_metadata_no_terraform_resources(mock_pool_manager):
-    resource_totals = {'cpus': 20, 'mem': 2000, 'disk': 20000, 'gpus': 0}
-    mock_pool_manager.cluster_connector.get_resource_total.side_effect = resource_totals.get
-
-    market_capacities = {'market1': 15, 'market2': 25}
-    mock_pool_manager.get_market_capacities.return_value = market_capacities
-
-    mock_pool_manager.non_orphan_fulfilled_capacity = 12
-
-    expected_metrics = [
-        ClusterMetric(metric_name='cpus_total', value=20, dimensions={'cluster': 'mesos-test', 'pool': 'bar.mesos'}),
-        ClusterMetric(metric_name='mem_total', value=2000, dimensions={'cluster': 'mesos-test', 'pool': 'bar.mesos'}),
-        ClusterMetric(metric_name='disk_total', value=20000, dimensions={'cluster': 'mesos-test', 'pool': 'bar.mesos'}),
-        ClusterMetric(metric_name='gpus_total', value=0, dimensions={'cluster': 'mesos-test', 'pool': 'bar.mesos'}),
-        ClusterMetric(
-            metric_name='fulfilled_capacity',
-            value=market_capacities,
-            dimensions={'cluster': 'mesos-test', 'pool': 'bar.mesos'},
-        ),
-        ClusterMetric(
-            metric_name='non_orphan_fulfilled_capacity',
-            value=12,
-            dimensions={'cluster': 'mesos-test', 'pool': 'bar.mesos'},
-        ),
-    ]
-
+def test_generate_simple_metadata_no_terraform_resources(mock_pool_manager, simple_metadata_expected_metrics):
+    # Break target_capacity, make sure exception is handled
     type(mock_pool_manager).target_capacity = mock.PropertyMock(side_effect=NoResourceGroupsFoundError)
+
+    # Update expected metrics to exclude target_capacity
+    expected_metrics = list(simple_metadata_expected_metrics)
+    del expected_metrics[4]
 
     assert sorted(generate_simple_metadata(mock_pool_manager)) == sorted(expected_metrics)

--- a/tests/mesos/metrics_generators_test.py
+++ b/tests/mesos/metrics_generators_test.py
@@ -64,6 +64,7 @@ def simple_metadata_expected_metrics(mock_pool_manager):
         ),
     ]
 
+
 def test_generate_system_metrics(mock_pool_manager):
     resources_allocated = {'cpus': 10, 'mem': 1000, 'disk': 10000, 'gpus': 0}
     mock_pool_manager.cluster_connector.get_resource_allocation.side_effect = resources_allocated.get


### PR DESCRIPTION
Handles NoResourceGroupsFoundError and prevents the program from crashing and skipping the rest of the metrics.