### PR TITLE
Reduce time needed for clusterman status by using server side filtering

### DIFF
--- a/clusterman/aws/aws_resource_group.py
+++ b/clusterman/aws/aws_resource_group.py
@@ -186,13 +186,14 @@ class AWSResourceGroup(ResourceGroup, metaclass=ABCMeta):
         :param config: a config specific to a resource group type
         :returns: a dictionary of resource groups, indexed by id
         """
-        resource_group_tags = cls._get_resource_group_tags()
-        matching_resource_groups = {}
 
         try:
             identifier_tag_label = config['tag']
         except KeyError:
             return {}
+
+        resource_group_tags = cls._get_resource_group_tags(identifier_tag_label)
+        matching_resource_groups = {}
 
         for rg_id, tags in resource_group_tags.items():
             try:
@@ -210,5 +211,5 @@ class AWSResourceGroup(ResourceGroup, metaclass=ABCMeta):
 
     @classmethod
     @abstractmethod
-    def _get_resource_group_tags(cls) -> Mapping[str, Mapping[str, str]]:  # pragma: no cover
+    def _get_resource_group_tags(cls, filter_tag: str = '') -> Mapping[str, Mapping[str, str]]:  # pragma: no cover
         pass

--- a/clusterman/aws/spot_fleet_resource_group.py
+++ b/clusterman/aws/spot_fleet_resource_group.py
@@ -180,7 +180,7 @@ class SpotFleetResourceGroup(AWSResourceGroup):
 
     @classmethod
     @ttl_cache(ttl=RESOURCE_GROUP_CACHE_SECONDS)
-    def _get_resource_group_tags(cls) -> Mapping[str, Mapping[str, str]]:
+    def _get_resource_group_tags(cls, filter_tag: str = '') -> Mapping[str, Mapping[str, str]]:
         """ Gets a dictionary of SFR id -> a dictionary of tags. The tags are taken
         from the TagSpecifications for the first LaunchSpecification
         """

--- a/tests/cli/toggle_test.py
+++ b/tests/cli/toggle_test.py
@@ -46,7 +46,16 @@ class TestManageMethods:
 
     @mock.patch('clusterman.cli.toggle.autoscaling_is_paused')
     @mock.patch('clusterman.cli.toggle.dynamodb')
-    def test_enable(self, mock_dynamodb, mock_autoscaling_is_paused, mock_logger, mock_staticconf, mock_sts, args, *extra_args):
+    def test_enable(
+        self,
+        mock_dynamodb,
+        mock_autoscaling_is_paused,
+        mock_logger,
+        mock_staticconf,
+        mock_sts,
+        args,
+        *extra_args
+    ):
         # Note the different values
         mock_sts.get_caller_identity.return_value = {'Account': '123'}
         mock_staticconf.read_string.return_value = '456'
@@ -60,7 +69,16 @@ class TestManageMethods:
 
     @mock.patch('clusterman.cli.toggle.autoscaling_is_paused')
     @mock.patch('clusterman.cli.toggle.dynamodb')
-    def test_disable(self, mock_dynamodb, mock_autoscaling_is_paused, mock_logger, mock_staticconf, mock_sts, args, *extra_args):
+    def test_disable(
+        self,
+        mock_dynamodb,
+        mock_autoscaling_is_paused,
+        mock_logger,
+        mock_staticconf,
+        mock_sts,
+        args,
+        *extra_args
+    ):
         # Note the different values
         mock_sts.get_caller_identity.return_value = {'Account': '123'}
         mock_staticconf.read_string.return_value = '456'


### PR DESCRIPTION
### Description

Earlier, During invocation of `clusterman status`, `autoscaling_resource_group` will get the list of all available auto scaling groups in account and then loop through them for tag based filtering. In large accounts where number of ASGs are high, This can take longer time and eventually slow down the status command. 

This PR introduces changes  in `_get_resource_group_tags` method, where instead of getting list of all ASGs in an account, It uses `describe-tags` api to filter out only required  tags. Due to this server side filtering, `poolmanger` class will only need to go through limited number of ASGs even if the total number of ASGs are high in number.
working correctly.
