### PR TITLE
Revert "Reduce time needed for clusterman status by using server side filtering"

### DIFF
--- a/clusterman/aws/auto_scaling_resource_group.py
+++ b/clusterman/aws/auto_scaling_resource_group.py
@@ -296,27 +296,9 @@ class AutoScalingResourceGroup(AWSResourceGroup):
 
     @classmethod
     @ttl_cache(ttl=RESOURCE_GROUP_CACHE_SECONDS)
-    def _get_resource_group_tags(cls, filter_tag: str = '') -> Mapping[str, Mapping[str, str]]:
+    def _get_resource_group_tags(cls) -> Mapping[str, Mapping[str, str]]:
         """ Retrieves the tags for each ASG """
         asg_id_to_tags = {}
-
-        if filter_tag:
-            filter = [
-                {
-                    'Name': 'key',
-                    'Values': [
-                        filter_tag,
-                    ]
-                },
-            ]
-            """If the filter tag is present switch to desribe-tag method for server side
-                filtering for performance reasons
-            """
-            for page in autoscaling.get_paginator('describe_tags').paginate(Filters=filter):
-                for instance in page['Tags']:
-                    asg_id_to_tags[instance['ResourceId']] = {filter_tag: instance['Value']}
-            return asg_id_to_tags
-
         for page in autoscaling.get_paginator('describe_auto_scaling_groups').paginate():
             for asg in page['AutoScalingGroups']:
                 tags_dict = {tag['Key']: tag['Value'] for tag in asg['Tags']}

--- a/clusterman/aws/aws_resource_group.py
+++ b/clusterman/aws/aws_resource_group.py
@@ -186,14 +186,13 @@ class AWSResourceGroup(ResourceGroup, metaclass=ABCMeta):
         :param config: a config specific to a resource group type
         :returns: a dictionary of resource groups, indexed by id
         """
+        resource_group_tags = cls._get_resource_group_tags()
+        matching_resource_groups = {}
 
         try:
             identifier_tag_label = config['tag']
         except KeyError:
             return {}
-
-        resource_group_tags = cls._get_resource_group_tags(identifier_tag_label)
-        matching_resource_groups = {}
 
         for rg_id, tags in resource_group_tags.items():
             try:
@@ -211,5 +210,5 @@ class AWSResourceGroup(ResourceGroup, metaclass=ABCMeta):
 
     @classmethod
     @abstractmethod
-    def _get_resource_group_tags(cls, filter_tag: str = '') -> Mapping[str, Mapping[str, str]]:  # pragma: no cover
+    def _get_resource_group_tags(cls) -> Mapping[str, Mapping[str, str]]:  # pragma: no cover
         pass

--- a/clusterman/aws/spot_fleet_resource_group.py
+++ b/clusterman/aws/spot_fleet_resource_group.py
@@ -180,7 +180,7 @@ class SpotFleetResourceGroup(AWSResourceGroup):
 
     @classmethod
     @ttl_cache(ttl=RESOURCE_GROUP_CACHE_SECONDS)
-    def _get_resource_group_tags(cls, filter_tag: str = '') -> Mapping[str, Mapping[str, str]]:
+    def _get_resource_group_tags(cls) -> Mapping[str, Mapping[str, str]]:
         """ Gets a dictionary of SFR id -> a dictionary of tags. The tags are taken
         from the TagSpecifications for the first LaunchSpecification
         """


### PR DESCRIPTION
Reverts Yelp/clusterman#108

Reverting the PR due to `describe-tags` , Which is currently not implemented in `moto` library causing tests to fail