### PR TITLE
Update OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,3 +1,3 @@
 ---
 teams:
-- Compute Infra <compute-infra@yelp.com>
+  - Compute Infrastructure Core


### PR DESCRIPTION
Emails are no longer required by the Ownership service, so I've opted to leave CIC's email out in this update.