### PR TITLE
Don't kill EC2 instances with is_cordoned: True tag

### DIFF
--- a/clusterman/autoscaler/pool_manager.py
+++ b/clusterman/autoscaler/pool_manager.py
@@ -464,6 +464,8 @@ class PoolManager:
             return False
         elif not node_metadata.agent.is_safe_to_kill:
             return False
+        elif node_metadata.instance.is_cordoned:
+            return False
         elif self.max_tasks_to_kill > node_metadata.agent.task_count:
             return True
         else:


### PR DESCRIPTION
`make test`

This hasn't been actually tested with a node having this tag yet. I'm aiming to merge this first before doing that.