### PR TITLE
Include instance weight in clusterman status json output

### DIFF
--- a/clusterman/cli/status.py
+++ b/clusterman/cli/status.py
@@ -58,6 +58,7 @@ class AgentJsonObject(TypedDict):
     market: InstanceMarket
     task_count: int
     uptime: float
+    weight: float
     resources: Mapping[str, ResourceDictJsonObject]
 
 
@@ -86,6 +87,7 @@ def _get_agent_json(metadata: ClusterNodeMetadata) -> AgentJsonObject:
         "market": metadata.instance.market,
         "task_count": metadata.agent.task_count,
         "uptime": metadata.instance.uptime.total_seconds(),
+        "weight": metadata.instance.weight,
         "resources": {
             resource: {
                 "allocated": getattr(metadata.agent.allocated_resources, resource),


### PR DESCRIPTION
### Description

This adds `weight` of each instance to the JSON response. This is useful if we want to exclude certain nodes from the fulfilled capacity calculation.

### Testing Done

This has been tested by force-installing the package and running it manually on a Kubernetes master in stage. `weight` field is included as expected and no failures have been experienced.