### PR TITLE
CLUSTERMAN-613: add default until for disable

### DIFF
--- a/clusterman/cli/toggle.py
+++ b/clusterman/cli/toggle.py
@@ -55,6 +55,10 @@ def disable(args: argparse.Namespace) -> None:
         "timestamp": {"N": str(int(time.time()))},
     }
 
+    if not args.until:
+        print("Default has changed; autoscaler will be re-enabled in 30m since no --until flag was used.")
+        args.until = "30m"
+
     if args.until:
         state["expiration_timestamp"] = {"N": str(parse_time_string(args.until).timestamp)}
 
@@ -102,7 +106,7 @@ def add_cluster_disable_parser(subparser, required_named_args, optional_named_ar
     optional_named_args.add_argument(
         "--until",
         metavar="timestamp",
-        help='time at which to re-enable autoscaling (try "tomorrow", "+5m"; use quotes)',
+        help='time at which to re-enable autoscaling (try "tomorrow", "+5m"; use quotes) (Default: 30m)',
     )
     add_cluster_config_directory_arg(optional_named_args)
 

--- a/tests/cli/toggle_test.py
+++ b/tests/cli/toggle_test.py
@@ -70,3 +70,30 @@ class TestManageMethods:
 
         with pytest.raises(AccountNumberMistmatchError):
             disable(args)
+
+    @mock.patch("clusterman.cli.toggle.autoscaling_is_paused")
+    @mock.patch("clusterman.cli.toggle.dynamodb")
+    def test_disable_until(
+        self,
+        mock_dynamodb,
+        mock_autoscaling_is_paused,
+        mock_logger,
+        mock_staticconf,
+        mock_sts,
+        args,
+        capsys,
+        *extra_args,
+    ):
+        """Test default until value, and test it shoes a message correctly"""
+        # Note the different values
+        mock_sts.get_caller_identity.return_value = {"Account": "123"}
+        mock_staticconf.read_string.return_value = "123"
+
+        mock_dynamodb.delete_item = mock.Mock()
+
+        mock_autoscaling_is_paused.return_value = True
+
+        disable(args)
+        # https://docs.pytest.org/en/6.2.x/capture.html#accessing-captured-output-from-a-test-function
+        captured = capsys.readouterr()
+        assert "Default has changed; autoscaler" in captured.out


### PR DESCRIPTION
### Description

closes CLUSTERMAN-613

### Testing Done

Please fill out!  Generally speaking any new features should include
additional unit or integration tests to ensure the behaviour is
working correctly.
