### PR TITLE
handle exception for non-exist instance_id

### DIFF
--- a/clusterman/draining/queue.py
+++ b/clusterman/draining/queue.py
@@ -23,6 +23,7 @@ from typing import Sequence
 from typing import Type
 
 import arrow
+import botocore.exceptions
 import colorlog
 import staticconf
 
@@ -291,7 +292,11 @@ class DrainingClient:
 
 
 def host_from_instance_id(sender: str, receipt_handle: str, instance_id: str,) -> Optional[Host]:
-    instance_data = ec2_describe_instances(instance_ids=[instance_id])
+    try:
+        instance_data = ec2_describe_instances(instance_ids=[instance_id])
+    except botocore.exceptions.ClientError as e:
+        logger.warning(f"Couldn't describe instance: {e}")
+        return None
     if not instance_data:
         logger.warning(f"No instance data found for {instance_id}")
         return None

--- a/tests/draining/queue_test.py
+++ b/tests/draining/queue_test.py
@@ -14,6 +14,7 @@
 import socket
 
 import arrow
+import botocore.exceptions
 import mock
 import pytest
 import staticconf.testing
@@ -477,6 +478,9 @@ def test_host_from_instance_id():
         # instance has no tags, probably because it is new and tags have not
         # yet propagated
         mock_ec2_describe.return_value = [{"InstanceId": "i-123"}]
+        assert host_from_instance_id(sender="aws", receipt_handle="rcpt", instance_id="i-123",) is None
+
+        mock_ec2_describe.side_effect = botocore.exceptions.ClientError({}, "")
         assert host_from_instance_id(sender="aws", receipt_handle="rcpt", instance_id="i-123",) is None
 
 


### PR DESCRIPTION
### Description

Clusterman gets stuck getting messages from queue with non-exist instance_id.
The exception occurs and the message is returned to the queue, and this continues indefinitely.

### Testing Done

Test will be added for non-exist instance_id case
