### PR TITLE
Handling exception while trying describe non-exist instance_id

### DIFF
--- a/clusterman/draining/queue.py
+++ b/clusterman/draining/queue.py
@@ -23,7 +23,7 @@ from typing import Sequence
 from typing import Type
 
 import arrow
-import botocore.exceptions
+from botocore.exceptions import ClientError
 import colorlog
 import staticconf
 
@@ -294,7 +294,7 @@ class DrainingClient:
 def host_from_instance_id(sender: str, receipt_handle: str, instance_id: str,) -> Optional[Host]:
     try:
         instance_data = ec2_describe_instances(instance_ids=[instance_id])
-    except botocore.exceptions.ClientError as e:
+    except ClientError as e:
         logger.warning(f"Couldn't describe instance: {e}")
         return None
     if not instance_data:

--- a/clusterman/draining/queue.py
+++ b/clusterman/draining/queue.py
@@ -23,9 +23,9 @@ from typing import Sequence
 from typing import Type
 
 import arrow
-from botocore.exceptions import ClientError
 import colorlog
 import staticconf
+from botocore.exceptions import ClientError
 
 from clusterman.args import add_cluster_arg
 from clusterman.args import subparser

--- a/clusterman/draining/queue.py
+++ b/clusterman/draining/queue.py
@@ -23,6 +23,7 @@ from typing import Sequence
 from typing import Type
 
 import arrow
+import botocore.exceptions
 import colorlog
 import staticconf
 
@@ -291,7 +292,11 @@ class DrainingClient:
 
 
 def host_from_instance_id(sender: str, receipt_handle: str, instance_id: str,) -> Optional[Host]:
-    instance_data = ec2_describe_instances(instance_ids=[instance_id])
+    try:
+        instance_data = ec2_describe_instances(instance_ids=[instance_id])
+    except botocore.exceptions.ClientError as e:
+        logger.warning(f"Couldn't describe instance: {e}")
+        return None
     if not instance_data:
         logger.warning(f"No instance data found for {instance_id}")
         return None

--- a/clusterman/draining/queue.py
+++ b/clusterman/draining/queue.py
@@ -295,7 +295,7 @@ def host_from_instance_id(sender: str, receipt_handle: str, instance_id: str,) -
     try:
         instance_data = ec2_describe_instances(instance_ids=[instance_id])
     except ClientError as e:
-        logger.warning(f"Couldn't describe instance: {e}")
+        logger.exception(f"Couldn't describe instance: {e}")
         return None
     if not instance_data:
         logger.warning(f"No instance data found for {instance_id}")

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 import copy
 from collections import defaultdict
-from distutils.util import strtobool
 from typing import List
 from typing import Mapping
 from typing import Optional
@@ -35,8 +34,10 @@ from clusterman.kubernetes.util import CachedCoreV1Api
 from clusterman.kubernetes.util import get_node_ip
 from clusterman.kubernetes.util import PodUnschedulableReason
 from clusterman.kubernetes.util import selector_term_matches_requirement
+from clusterman.kubernetes.util import strtobool
 from clusterman.kubernetes.util import total_node_resources
 from clusterman.kubernetes.util import total_pod_resources
+
 
 logger = colorlog.getLogger(__name__)
 KUBERNETES_SCHEDULED_PHASES = {"Pending", "Running"}

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -34,9 +34,9 @@ from clusterman.kubernetes.util import CachedCoreV1Api
 from clusterman.kubernetes.util import get_node_ip
 from clusterman.kubernetes.util import PodUnschedulableReason
 from clusterman.kubernetes.util import selector_term_matches_requirement
-from clusterman.kubernetes.util import strtobool
 from clusterman.kubernetes.util import total_node_resources
 from clusterman.kubernetes.util import total_pod_resources
+from clusterman.util import strtobool
 
 
 logger = colorlog.getLogger(__name__)

--- a/clusterman/kubernetes/util.py
+++ b/clusterman/kubernetes/util.py
@@ -162,18 +162,3 @@ def selector_term_matches_requirement(
                 if match_expression == selector_requirement:
                     return True
     return False
-
-
-def strtobool(val: str) -> int:
-    """Convert a string representation of truth to true (1) or false (0).
-    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
-    are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
-    'val' is anything else.
-    """
-    val = val.lower()
-    if val in ("y", "yes", "t", "true", "on", "1"):
-        return 1
-    elif val in ("n", "no", "f", "false", "off", "0"):
-        return 0
-    else:
-        raise ValueError("invalid truth value %r" % (val,))

--- a/clusterman/kubernetes/util.py
+++ b/clusterman/kubernetes/util.py
@@ -162,3 +162,18 @@ def selector_term_matches_requirement(
                 if match_expression == selector_requirement:
                     return True
     return False
+
+
+def strtobool(val: str) -> int:
+    """Convert a string representation of truth to true (1) or false (0).
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+    are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
+    'val' is anything else.
+    """
+    val = val.lower()
+    if val in ("y", "yes", "t", "true", "on", "1"):
+        return 1
+    elif val in ("n", "no", "f", "false", "off", "0"):
+        return 0
+    else:
+        raise ValueError("invalid truth value %r" % (val,))

--- a/clusterman/util.py
+++ b/clusterman/util.py
@@ -386,3 +386,18 @@ def autoscaling_is_paused(cluster: str, pool: str, scheduler: str, timestamp: ar
         return False
 
     return True
+
+
+def strtobool(val: str) -> int:
+    """Convert a string representation of truth to true (1) or false (0).
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+    are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
+    'val' is anything else.
+    """
+    val = val.lower()
+    if val in ("y", "yes", "t", "true", "on", "1"):
+        return 1
+    elif val in ("n", "no", "f", "false", "off", "0"):
+        return 0
+    else:
+        raise ValueError("invalid truth value %r" % (val,))

--- a/tests/draining/queue_test.py
+++ b/tests/draining/queue_test.py
@@ -14,10 +14,10 @@
 import socket
 
 import arrow
-from botocore.exceptions import ClientError
 import mock
 import pytest
 import staticconf.testing
+from botocore.exceptions import ClientError
 
 from clusterman.aws.spot_fleet_resource_group import SpotFleetResourceGroup
 from clusterman.draining.queue import DrainingClient

--- a/tests/draining/queue_test.py
+++ b/tests/draining/queue_test.py
@@ -14,7 +14,7 @@
 import socket
 
 import arrow
-import botocore.exceptions
+from botocore.exceptions import ClientError
 import mock
 import pytest
 import staticconf.testing
@@ -480,7 +480,7 @@ def test_host_from_instance_id():
         mock_ec2_describe.return_value = [{"InstanceId": "i-123"}]
         assert host_from_instance_id(sender="aws", receipt_handle="rcpt", instance_id="i-123",) is None
 
-        mock_ec2_describe.side_effect = botocore.exceptions.ClientError({}, "")
+        mock_ec2_describe.side_effect = ClientError({}, "")
         assert host_from_instance_id(sender="aws", receipt_handle="rcpt", instance_id="i-123",) is None
 
 

--- a/tests/draining/queue_test.py
+++ b/tests/draining/queue_test.py
@@ -480,6 +480,7 @@ def test_host_from_instance_id():
         mock_ec2_describe.return_value = [{"InstanceId": "i-123"}]
         assert host_from_instance_id(sender="aws", receipt_handle="rcpt", instance_id="i-123",) is None
 
+        # describe method throws exception when instance doesn't exist
         mock_ec2_describe.side_effect = ClientError({}, "")
         assert host_from_instance_id(sender="aws", receipt_handle="rcpt", instance_id="i-123",) is None
 

--- a/tests/draining/queue_test.py
+++ b/tests/draining/queue_test.py
@@ -14,6 +14,7 @@
 import socket
 
 import arrow
+import botocore.exceptions
 import mock
 import pytest
 import staticconf.testing
@@ -477,6 +478,9 @@ def test_host_from_instance_id():
         # instance has no tags, probably because it is new and tags have not
         # yet propagated
         mock_ec2_describe.return_value = [{"InstanceId": "i-123"}]
+        assert host_from_instance_id(sender="aws", receipt_handle="rcpt", instance_id="i-123",) is None
+
+        mock_ec2_describe.side_effect = botocore.exceptions.ClientError({}, "")
         assert host_from_instance_id(sender="aws", receipt_handle="rcpt", instance_id="i-123",) is None
 
 


### PR DESCRIPTION
### Description

Exception occurs when try to describe instance to get host information with non-exist instance_id.
Message returns back to queue and process continuous indefinitely.

### Testing Done

Test case was added to check specific scenario.
Test case failed without my change and it was expected.
