### PR TITLE
Reserve capacity was added to target capacity to avoid stuck

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
             args: [--py3-plus]
             language_version: python3.6
     - repo: http://github.com/psf/black
-      rev: 19.10b0
+      rev: 22.3.0
       hooks:
           - id: black
             language_version: python3.7

--- a/clusterman/autoscaler/autoscaler.py
+++ b/clusterman/autoscaler/autoscaler.py
@@ -308,7 +308,8 @@ class Autoscaler:
                 "Non-orphan fulfilled capacity is 0 and current target capacity > 0, not changing target to let the "
                 "new instances join"
             )
-            return current_target_capacity
+            reserve_capacity = self._get_reserve_capacity()
+            return current_target_capacity + reserve_capacity
 
         # If we get here, everything is non-zero and we can use the "normal" logic to determine scaling
         (most_constrained_resource, usage_pct,) = self._get_most_constrained_resource_for_request(
@@ -447,3 +448,7 @@ class Autoscaler:
             latest_non_zero_values[-1][0],
             sum([float(val) for __, val in latest_non_zero_values]) / len(latest_non_zero_values),
         )
+
+    def _get_reserve_capacity(self) -> float:
+        # logic will be implemented
+        return 0

--- a/clusterman/autoscaler/autoscaler.py
+++ b/clusterman/autoscaler/autoscaler.py
@@ -307,8 +307,7 @@ class Autoscaler:
             # new_target_capacity will be 0, which we do not want (since the resource request is non-zero)
             current_target_capacity += 1
             logger.info(
-                "Non-orphan fulfilled capacity is 0 and current target capacity > 0, not changing target to let the "
-                "new instances join"
+                "Non-orphan fulfilled capacity is 0 and current target capacity > 0, increase target by one"
             )
             return current_target_capacity
 

--- a/clusterman/autoscaler/autoscaler.py
+++ b/clusterman/autoscaler/autoscaler.py
@@ -304,12 +304,12 @@ class Autoscaler:
         elif non_orphan_fulfilled_capacity == 0:
             # Entering the main body of this method with non_orphan_fulfilled_capacity = 0 guarantees that
             # new_target_capacity will be 0, which we do not want (since the resource request is non-zero)
+            current_target_capacity += self._get_reserve_capacity()
             logger.info(
                 "Non-orphan fulfilled capacity is 0 and current target capacity > 0, not changing target to let the "
                 "new instances join"
             )
-            reserve_capacity = self._get_reserve_capacity()
-            return current_target_capacity + reserve_capacity
+            return current_target_capacity
 
         # If we get here, everything is non-zero and we can use the "normal" logic to determine scaling
         (most_constrained_resource, usage_pct,) = self._get_most_constrained_resource_for_request(
@@ -450,5 +450,10 @@ class Autoscaler:
         )
 
     def _get_reserve_capacity(self) -> float:
-        # logic will be implemented
+
+        current_target_capacity = self.pool_manager.target_capacity
+        cluster_total_resources = self.pool_manager.cluster_connector.get_cluster_total_resources()
+        cluster_allocated_resources = self.pool_manager.cluster_connector.get_cluster_allocated_resources()
+        non_orphan_fulfilled_capacity = self.pool_manager.non_orphan_fulfilled_capacity
+
         return 0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -39,7 +39,7 @@ parso==0.5.1
 pexpect==4.7.0
 pickleshare==0.7.5
 pluggy==0.13.0
-pre-commit==1.18.3
+pre-commit==2.17.0
 prompt-toolkit==2.0.10
 ptyprocess==0.6.0
 pycodestyle==2.5.0

--- a/tests/autoscaler/autoscaler_test.py
+++ b/tests/autoscaler/autoscaler_test.py
@@ -250,7 +250,8 @@ class TestComputeTargetCapacity:
         new_target_capacity = mock_autoscaler._compute_target_capacity(
             SignalResourceRequest(cpus=10, mem=500, disk=1000, gpus=0),
         )
-        assert new_target_capacity == mock_autoscaler.pool_manager.target_capacity
+        # autoscaler increase target capacity by one to avoid stucking
+        assert new_target_capacity == mock_autoscaler.pool_manager.target_capacity + 1
 
     def test_scale_most_constrained_resource(self, mock_autoscaler):
         resource_request = SignalResourceRequest(cpus=500, mem=30000, disk=19000, gpus=0)


### PR DESCRIPTION
### Description

Autoscaling component stuck while calculating target capacity in the following case:
If the resource request and the target capacity are non-zero, but the nodes haven't joined
the cluster yet, we just need to wait until they join before doing anything else

### Testing

We dont have test scenario for this case and _compute_target_capacity method.
I will try to add test cases as well in this PR.


