### PR TITLE
Expired orphan node timeout threshold was made configurable

### DIFF
--- a/clusterman/autoscaler/autoscaler.py
+++ b/clusterman/autoscaler/autoscaler.py
@@ -177,7 +177,7 @@ class Autoscaler:
         if self.autoscaling_config.recycle_orphan_instances:
             try:
                 self.pool_manager.terminate_expired_orphan_instances(
-                    self.autoscaling_config.orphan_instance_timeout_threshold_seconds, dry_run=dry_run
+                    self.autoscaling_config.orphan_instance_uptime_threshold_seconds, dry_run=dry_run
                 )
             except Exception as e:
                 logger.error(f"Orphan instances termination failed: {e}")

--- a/clusterman/autoscaler/autoscaler.py
+++ b/clusterman/autoscaler/autoscaler.py
@@ -176,7 +176,9 @@ class Autoscaler:
 
         if self.autoscaling_config.recycle_orphan_instances:
             try:
-                self.pool_manager.terminate_expired_orphan_instances(dry_run=dry_run)
+                self.pool_manager.terminate_expired_orphan_instances(
+                    self.autoscaling_config.orphan_instance_timeout_threshold_seconds, dry_run=dry_run
+                )
             except Exception as e:
                 logger.error(f"Orphan instances termination failed: {e}")
 

--- a/clusterman/autoscaler/config.py
+++ b/clusterman/autoscaler/config.py
@@ -27,7 +27,7 @@ class AutoscalingConfig(NamedTuple):
     prevent_scale_down_after_capacity_loss: bool = False
     instance_loss_threshold: int = 0
     recycle_orphan_instances: bool = False
-    orphan_instance_timeout_threshold_seconds: int = 1800
+    orphan_instance_uptime_threshold_seconds: int = 1800
 
 
 def get_autoscaling_config(config_namespace: str) -> AutoscalingConfig:
@@ -53,7 +53,7 @@ def get_autoscaling_config(config_namespace: str) -> AutoscalingConfig:
         ),
         instance_loss_threshold=reader.read_int("autoscaling.instance_loss_threshold", default=0),
         recycle_orphan_instances=reader.read_bool("autoscaling.recycle_orphan_instances", default=False),
-        orphan_instance_timeout_threshold_seconds=reader.read_int(
-            "autoscaling.orphan_instance_timeout_threshold_seconds", default=1800
+        orphan_instance_uptime_threshold_seconds=reader.read_int(
+            "autoscaling.orphan_instance_uptime_threshold_seconds", default=1800
         ),
     )

--- a/clusterman/autoscaler/config.py
+++ b/clusterman/autoscaler/config.py
@@ -27,6 +27,7 @@ class AutoscalingConfig(NamedTuple):
     prevent_scale_down_after_capacity_loss: bool = False
     instance_loss_threshold: int = 0
     recycle_orphan_instances: bool = False
+    orphan_instance_timeout_threshold_seconds: int = 1800
 
 
 def get_autoscaling_config(config_namespace: str) -> AutoscalingConfig:
@@ -52,4 +53,7 @@ def get_autoscaling_config(config_namespace: str) -> AutoscalingConfig:
         ),
         instance_loss_threshold=reader.read_int("autoscaling.instance_loss_threshold", default=0),
         recycle_orphan_instances=reader.read_bool("autoscaling.recycle_orphan_instances", default=False),
+        orphan_instance_timeout_threshold_seconds=reader.read_int(
+            "autoscaling.orphan_instance_timeout_threshold_seconds", default=1800
+        ),
     )

--- a/clusterman/autoscaler/pool_manager.py
+++ b/clusterman/autoscaler/pool_manager.py
@@ -203,11 +203,11 @@ class PoolManager:
             for instance_metadata in group.get_instance_metadatas(state_filter)
         ]
 
-    def terminate_expired_orphan_instances(self, timeout_seconds: int, dry_run: bool = False) -> None:
+    def terminate_expired_orphan_instances(self, threshold_seconds: int, dry_run: bool = False) -> None:
         if dry_run:
             logger.warning('Running in "dry-run" mode; cluster state will not be modified')
 
-        group_id_to_instance_ids = self.get_expired_orphan_instances(timeout_seconds)
+        group_id_to_instance_ids = self.get_expired_orphan_instances(threshold_seconds)
 
         if len(group_id_to_instance_ids) > 0:
             logger.info(f"Terminating expired orphan instances: \n{group_id_to_instance_ids}")
@@ -218,7 +218,7 @@ class PoolManager:
         for group_id, instance_ids in group_id_to_instance_ids.items():
             self.resource_groups[group_id].terminate_instances_by_id(instance_ids)
 
-    def get_expired_orphan_instances(self, timeout_seconds: int) -> Dict[str, List[str]]:
+    def get_expired_orphan_instances(self, threshold_seconds: int) -> Dict[str, List[str]]:
         known_group_ids = {group.id for group in self.resource_groups.values()}
         node_metadatas = self.get_node_metadatas(AWS_RUNNING_STATES)
 
@@ -226,15 +226,16 @@ class PoolManager:
 
         for metadata in node_metadatas:
             group_id = metadata.instance.group_id
-            if group_id in known_group_ids and self._is_expired_orphan_instance(metadata, timeout_seconds):
+            if group_id in known_group_ids and self._is_expired_orphan_instance(metadata, threshold_seconds):
                 if group_id not in group_id_to_instance_ids:
                     group_id_to_instance_ids[group_id] = []
                 group_id_to_instance_ids[group_id].append(metadata.instance.instance_id)
 
         return group_id_to_instance_ids
 
-    def _is_expired_orphan_instance(self, metadata: ClusterNodeMetadata, timeout: int) -> bool:
-        return metadata.agent.state == AgentState.ORPHANED and metadata.instance.uptime.total_seconds() > timeout
+    def _is_expired_orphan_instance(self, metadata: ClusterNodeMetadata, threshold: int) -> bool:
+        return metadata.agent.state == AgentState.ORPHANED and metadata.instance.uptime.total_seconds() > threshold
+        return metadata.agent.state == AgentState.ORPHANED and metadata.instance.uptime.total_seconds() > threshold
 
     # currently dead code, so don't count towards coverage metrics
     def _filter_scale_up_options_for_pod(

--- a/clusterman/autoscaler/pool_manager.py
+++ b/clusterman/autoscaler/pool_manager.py
@@ -235,7 +235,6 @@ class PoolManager:
 
     def _is_expired_orphan_instance(self, metadata: ClusterNodeMetadata, threshold: int) -> bool:
         return metadata.agent.state == AgentState.ORPHANED and metadata.instance.uptime.total_seconds() > threshold
-        return metadata.agent.state == AgentState.ORPHANED and metadata.instance.uptime.total_seconds() > threshold
 
     # currently dead code, so don't count towards coverage metrics
     def _filter_scale_up_options_for_pod(

--- a/clusterman/autoscaler/pool_manager.py
+++ b/clusterman/autoscaler/pool_manager.py
@@ -208,7 +208,9 @@ class PoolManager:
             logger.warning('Running in "dry-run" mode; cluster state will not be modified')
 
         group_id_to_instance_ids = self.get_expired_orphan_instances(timeout_seconds)
-        logger.info(f"Terminating expired orphan instances: \n{group_id_to_instance_ids}")
+
+        if len(group_id_to_instance_ids) > 0:
+            logger.info(f"Terminating expired orphan instances: \n{group_id_to_instance_ids}")
 
         if dry_run:
             return

--- a/clusterman/autoscaler/pool_manager.py
+++ b/clusterman/autoscaler/pool_manager.py
@@ -233,8 +233,10 @@ class PoolManager:
 
         return group_id_to_instance_ids
 
-    def _is_expired_orphan_instance(self, metadata: ClusterNodeMetadata, threshold: int) -> bool:
-        return metadata.agent.state == AgentState.ORPHANED and metadata.instance.uptime.total_seconds() > threshold
+    def _is_expired_orphan_instance(self, metadata: ClusterNodeMetadata, threshold_seconds: int) -> bool:
+        return (
+                metadata.agent.state == AgentState.ORPHANED and metadata.instance.uptime.total_seconds() > threshold_seconds
+        )
 
     # currently dead code, so don't count towards coverage metrics
     def _filter_scale_up_options_for_pod(

--- a/clusterman/autoscaler/pool_manager.py
+++ b/clusterman/autoscaler/pool_manager.py
@@ -235,7 +235,7 @@ class PoolManager:
 
     def _is_expired_orphan_instance(self, metadata: ClusterNodeMetadata, threshold_seconds: int) -> bool:
         return (
-                metadata.agent.state == AgentState.ORPHANED and metadata.instance.uptime.total_seconds() > threshold_seconds
+            metadata.agent.state == AgentState.ORPHANED and metadata.instance.uptime.total_seconds() > threshold_seconds
         )
 
     # currently dead code, so don't count towards coverage metrics

--- a/tests/autoscaler/pool_manager_test.py
+++ b/tests/autoscaler/pool_manager_test.py
@@ -570,6 +570,6 @@ def test_get_expired_orphan_instances(mock_pool_manager):
         ]
     )
 
-    result = mock_pool_manager.get_expired_orphan_instances()
+    result = mock_pool_manager.get_expired_orphan_instances(1800)
 
     assert result == {"sfr-0": ["i-0"], "sfr-1": ["i-3"]}


### PR DESCRIPTION
### Description

We needed timeout threshold to define "expired orphan node" and we set 30 minutes (hard coded).
We are going to make this threshold configurable.


### Testing Done

Test case was changed as well.
