### PR TITLE
Recycling orphan instances by default

### DIFF
--- a/clusterman/autoscaler/config.py
+++ b/clusterman/autoscaler/config.py
@@ -26,7 +26,7 @@ class AutoscalingConfig(NamedTuple):
     target_capacity_margin: float
     prevent_scale_down_after_capacity_loss: bool = False
     instance_loss_threshold: int = 0
-    recycle_orphan_instances: bool = False
+    recycle_orphan_instances: bool = True
     orphan_instance_uptime_threshold_seconds: int = 1800
 
 
@@ -52,7 +52,7 @@ def get_autoscaling_config(config_namespace: str) -> AutoscalingConfig:
             "autoscaling.prevent_scale_down_after_capacity_loss", default=False
         ),
         instance_loss_threshold=reader.read_int("autoscaling.instance_loss_threshold", default=0),
-        recycle_orphan_instances=reader.read_bool("autoscaling.recycle_orphan_instances", default=False),
+        recycle_orphan_instances=reader.read_bool("autoscaling.recycle_orphan_instances", default=True),
         orphan_instance_uptime_threshold_seconds=reader.read_int(
             "autoscaling.orphan_instance_uptime_threshold_seconds", default=1800
         ),


### PR DESCRIPTION
Description
We applied this feature to all pools in all clusters,
We are changing default value of setting to facilitate configuration and apply change to all future pools.

Testing Done
Test case was added already.