### PR TITLE
CLUSTERMAN-637: Add basic Rookout support

### DIFF
--- a/clusterman/batch/autoscaler_bootstrap.py
+++ b/clusterman/batch/autoscaler_bootstrap.py
@@ -29,6 +29,7 @@ from clusterman.args import add_env_config_path_arg
 from clusterman.args import add_pool_arg
 from clusterman.args import add_scheduler_arg
 from clusterman.batch.util import BatchLoggingMixin
+from clusterman.clusterman.tools.rookout import enable_rookout
 from clusterman.config import get_pool_config_path
 from clusterman.config import setup_config
 from clusterman.signals.external_signal import setup_signals_environment
@@ -157,4 +158,5 @@ class AutoscalerBootstrapBatch(BatchDaemon, BatchLoggingMixin):
 
 if __name__ == "__main__":
     setup_logging()
+    enable_rookout()
     AutoscalerBootstrapBatch().start()

--- a/clusterman/batch/autoscaler_bootstrap.py
+++ b/clusterman/batch/autoscaler_bootstrap.py
@@ -29,10 +29,10 @@ from clusterman.args import add_env_config_path_arg
 from clusterman.args import add_pool_arg
 from clusterman.args import add_scheduler_arg
 from clusterman.batch.util import BatchLoggingMixin
-from clusterman.clusterman.tools.rookout import enable_rookout
 from clusterman.config import get_pool_config_path
 from clusterman.config import setup_config
 from clusterman.signals.external_signal import setup_signals_environment
+from clusterman.tools.rookout import enable_rookout
 from clusterman.util import get_autoscaler_scribe_stream
 from clusterman.util import setup_logging
 

--- a/clusterman/batch/cluster_metrics_collector.py
+++ b/clusterman/batch/cluster_metrics_collector.py
@@ -43,6 +43,7 @@ from clusterman.autoscaler.pool_manager import PoolManager
 from clusterman.batch.util import BatchLoggingMixin
 from clusterman.batch.util import BatchRunningSentinelMixin
 from clusterman.batch.util import suppress_request_limit_exceeded
+from clusterman.clusterman.tools.rookout import enable_rookout
 from clusterman.config import get_pool_config_path
 from clusterman.config import load_cluster_pool_config
 from clusterman.config import setup_config
@@ -217,4 +218,5 @@ class ClusterMetricsCollector(BatchDaemon, BatchLoggingMixin, BatchRunningSentin
 
 if __name__ == "__main__":
     setup_logging()
+    enable_rookout()
     ClusterMetricsCollector().start()

--- a/clusterman/batch/cluster_metrics_collector.py
+++ b/clusterman/batch/cluster_metrics_collector.py
@@ -43,7 +43,6 @@ from clusterman.autoscaler.pool_manager import PoolManager
 from clusterman.batch.util import BatchLoggingMixin
 from clusterman.batch.util import BatchRunningSentinelMixin
 from clusterman.batch.util import suppress_request_limit_exceeded
-from clusterman.clusterman.tools.rookout import enable_rookout
 from clusterman.config import get_pool_config_path
 from clusterman.config import load_cluster_pool_config
 from clusterman.config import setup_config
@@ -51,6 +50,7 @@ from clusterman.mesos.metrics_generators import ClusterMetric
 from clusterman.mesos.metrics_generators import generate_kubernetes_metrics
 from clusterman.mesos.metrics_generators import generate_simple_metadata
 from clusterman.mesos.metrics_generators import generate_system_metrics
+from clusterman.tools.rookout import enable_rookout
 from clusterman.util import All
 from clusterman.util import get_pool_name_list
 from clusterman.util import sensu_checkin

--- a/clusterman/tools/rookout.py
+++ b/clusterman/tools/rookout.py
@@ -1,0 +1,23 @@
+# Copyright 2022 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from os import getenv
+
+
+def enable_rookout():
+    """Enable rookout if environment variables are set"""
+    if getenv("ROOKOUT_ENABLE", "") != "1":
+        return
+    import rook
+
+    rook.start(token=getenv("ROOKOUT_TOKEN"))

--- a/clusterman/tools/rookout.py
+++ b/clusterman/tools/rookout.py
@@ -14,7 +14,7 @@
 from os import getenv
 
 
-def enable_rookout():
+def enable_rookout() -> None:
     """Enable rookout if environment variables are set"""
     if getenv("ROOKOUT_ENABLE", "") != "1":
         return

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -19,7 +19,4 @@ signalfx
 simplejson
 sortedcontainers
 typing-extensions
-rook==0.1.160
-distro==1.7.0
-funcsigs==1.0.2
-psutil==5.9.1
+rook

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -19,3 +19,7 @@ signalfx
 simplejson
 sortedcontainers
 typing-extensions
+rook==0.1.160
+distro==1.7.0
+funcsigs==1.0.2
+psutil==5.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,3 +49,7 @@ urllib3==1.25.9
 websocket-client==0.56.0
 ws4py==0.5.1
 zipp==0.6.0
+rook==0.1.160
+distro==1.7.0
+funcsigs==1.0.2
+psutil==5.9.1


### PR DESCRIPTION
### Description

COMPINFRA-1009, adding it to clusterman first as there's a bunch of tooling and setup already done that makes it easier to add rookout to paasta services, compared to other projects

Rookout is disabled by default so this should be safe to deploy, can be enabled at any time from soaconfigs