### PR TITLE
Do not terminate expired orphaned nodes that have been cordoned

### DIFF
--- a/clusterman/autoscaler/pool_manager.py
+++ b/clusterman/autoscaler/pool_manager.py
@@ -242,6 +242,9 @@ class PoolManager:
         for metadata in node_metadatas:
             group_id = metadata.instance.group_id
             if group_id in known_group_ids and self._is_expired_orphan_instance(metadata, threshold_seconds):
+                if metadata.instance.is_cordoned:
+                    logger.info(f"Not terminating cordoned expired orphan instance {metadata.instance.instance_id}")
+                    continue
                 if group_id not in group_id_to_instance_ids:
                     group_id_to_instance_ids[group_id] = []
                 group_id_to_instance_ids[group_id].append(metadata.instance.instance_id)

--- a/tests/autoscaler/pool_manager_test.py
+++ b/tests/autoscaler/pool_manager_test.py
@@ -600,6 +600,7 @@ def test_get_expired_orphan_instances(mock_pool_manager):
             _make_metadata("sfr-1", "i-3", agent_state=AgentState.ORPHANED, uptime=2500),
             _make_metadata("sfr-2", "i-4", agent_state=AgentState.RUNNING, uptime=2500),
             _make_metadata("sfr-2", "i-5", agent_state=AgentState.RUNNING, uptime=2500),
+            _make_metadata("sfr-2", "i-6", agent_state=AgentState.ORPHANED, uptime=2500, is_cordoned=True),
         ]
     )
 


### PR DESCRIPTION
### Description
The way we identify a node as 'orphaned' will be triggered when we cordon a node currently (we `kubectl delete` the node from the cluster). As a result, when we cordon a node, it will almost immediately be identified as an expired orphan and be terminated.

Because we generally want to keep cordoned nodes around, let's honor the is_cordoned tag for this process, similarly to how we already do so for terminating excess capacity.

### Testing Done
Added a test to ensure an expired orphaned node w/ is_cordoned metadata will not be marked for termination

Also manually tested on our infrastage autoscaler and cordoned a node, confirmed that 
```
2022-06-22 20:09:20,191 clusterman-kubernetes--autoscaler-584f5bbdbf-gh2dm      47      clusterman.autoscaler.pool_manager      INFO    b'Not terminating cordoned expired orphan instance i-09a16b656fd3fced5'
```
appeared in the logs.