### PR TITLE
Avoid pods scheduling after marking for termination

### DIFF
--- a/clusterman/autoscaler/pool_manager.py
+++ b/clusterman/autoscaler/pool_manager.py
@@ -444,6 +444,7 @@ class PoolManager:
             self.cluster_connector.freeze_agent(node_metadata.agent)
 
             task_count_realtime = self.cluster_connector.get_task_count_realtime(node_metadata.agent)
+            #node_metadata.agent.task_count = task_count_realtime not sure yet
             if killed_task_count + task_count_realtime > self.max_tasks_to_kill:  # case 4
                 logger.info(
                     f"Killing instance {instance_id} with {task_count_realtime} tasks (realtime) would take us "

--- a/clusterman/autoscaler/pool_manager.py
+++ b/clusterman/autoscaler/pool_manager.py
@@ -439,7 +439,7 @@ class PoolManager:
                     continue
 
             logger.info(f"freezing {instance_id} for termination")
-            self.cluster_connector.freeze_agent(node_metadata.agent)
+            self.cluster_connector.freeze_agent(node_metadata.agent.agent_id)
             logger.info(f"marking {instance_id} for termination")
             marked_nodes[group_id].append(node_metadata)
             rem_group_capacities[group_id] -= instance_weight

--- a/clusterman/autoscaler/pool_manager.py
+++ b/clusterman/autoscaler/pool_manager.py
@@ -545,7 +545,7 @@ class PoolManager:
             node_metadata: ClusterNodeMetadata,
         ) -> Tuple[int, int, int, int, int, int]:
             return (
-                0 if node_metadata.agent.is_freezed else 1,
+                0 if node_metadata.agent.is_frozen else 1,
                 0 if node_metadata.agent.state == AgentState.ORPHANED else 1,
                 0 if node_metadata.agent.state == AgentState.IDLE else 1,
                 0 if node_metadata.instance.is_stale else 1,

--- a/clusterman/autoscaler/pool_manager.py
+++ b/clusterman/autoscaler/pool_manager.py
@@ -423,8 +423,6 @@ class PoolManager:
                 logger.info(f"Resource group {group_id} is at target capacity; skipping {instance_id}")
                 continue
 
-            task_count_realtime = self.cluster_connector.get_task_count_realtime(node_metadata.agent)
-
             if (
                 killed_task_count + node_metadata.agent.task_count > self.max_tasks_to_kill or
                 killed_task_count + self.cluster_connector.get_task_count_realtime(

--- a/clusterman/autoscaler/pool_manager.py
+++ b/clusterman/autoscaler/pool_manager.py
@@ -423,7 +423,8 @@ class PoolManager:
                 logger.info(f"Resource group {group_id} is at target capacity; skipping {instance_id}")
                 continue
 
-            if killed_task_count + node_metadata.agent.task_count > self.max_tasks_to_kill:  # case 2
+            task_count_realtime = self.cluster_connector.get_task_count_realtime(node_metadata.agent)
+            if killed_task_count + task_count_realtime > self.max_tasks_to_kill:  # case 2
                 logger.info(
                     f"Killing instance {instance_id} with {node_metadata.agent.task_count} tasks would take us "
                     f"over our max_tasks_to_kill of {self.max_tasks_to_kill}. Skipping this instance."
@@ -439,6 +440,7 @@ class PoolManager:
                     continue
 
             logger.info(f"marking {instance_id} for termination")
+            #TODO taint node - noschedule ---
             marked_nodes[group_id].append(node_metadata)
             rem_group_capacities[group_id] -= instance_weight
             curr_capacity -= instance_weight

--- a/clusterman/autoscaler/pool_manager.py
+++ b/clusterman/autoscaler/pool_manager.py
@@ -182,7 +182,7 @@ class PoolManager:
         :param dry_run: if True, do not modify the state of the cluster, just log actions
         """
 
-        marked_nodes_by_group = self._choose_nodes_to_prune(new_target_capacity, group_targets)
+        marked_nodes_by_group = self._choose_nodes_to_prune(new_target_capacity, group_targets, dry_run)
 
         if not dry_run:
             if self.draining_enabled:
@@ -352,6 +352,7 @@ class PoolManager:
         self,
         new_target_capacity: float,
         group_targets: Optional[Mapping[str, float]],
+        dry_run: bool = False,
     ) -> Mapping[str, List[ClusterNodeMetadata]]:
         """Choose nodes to kill in order to decrease the capacity on the cluster.
 
@@ -439,7 +440,8 @@ class PoolManager:
                     continue
 
             logger.info(f"freezing {instance_id} for termination")
-            self.cluster_connector.freeze_agent(node_metadata.agent.agent_id)
+            if not dry_run:
+                self.cluster_connector.freeze_agent(node_metadata.agent.agent_id)
             logger.info(f"marking {instance_id} for termination")
             marked_nodes[group_id].append(node_metadata)
             rem_group_capacities[group_id] -= instance_weight

--- a/clusterman/autoscaler/pool_manager.py
+++ b/clusterman/autoscaler/pool_manager.py
@@ -452,6 +452,7 @@ class PoolManager:
                         f"Killing instance {instance_id} with {task_count_realtime} tasks  would take us "
                         f"over our max_tasks_per_node_to_kill of {self.max_tasks_per_node_to_kill}. Skipping this instance."
                     )
+                    # not sure if we need unfreeze or not, maybe it should be terminated in next try.
                     logger.info(f"unfreezing {instance_id} for termination")
                     self.cluster_connector.unfreeze_agent(node_metadata.agent)
                     continue

--- a/clusterman/autoscaler/pool_manager.py
+++ b/clusterman/autoscaler/pool_manager.py
@@ -406,7 +406,8 @@ class PoolManager:
             #  1) The resource group the node belongs to can't be reduced further.
             #  2) Killing the node's tasks would take over the maximum number of tasks we are willing to kill.
             #  3) Killing the node would bring us under our target_capacity of non-orphaned nodes.
-            #  4) agent.task_count may be outdated date (case 3), and pods may be terminated unintentionally.
+            #  4) Killing the node's tasks would take over the maximum number of tasks per node we are willing to kill.
+            #     But agent.task_count may be outdated date, and pods may be terminated unintentionally.
             #     Therefore, double-checking task count from kube-api to avoid that case.
             # In each of the cases, the node has been removed from consideration and we jump to the next iteration.
 

--- a/clusterman/autoscaler/pool_manager.py
+++ b/clusterman/autoscaler/pool_manager.py
@@ -424,7 +424,13 @@ class PoolManager:
                 continue
 
             task_count_realtime = self.cluster_connector.get_task_count_realtime(node_metadata.agent)
-            if killed_task_count + task_count_realtime > self.max_tasks_to_kill:  # case 2
+
+            if (
+                killed_task_count + node_metadata.agent.task_count > self.max_tasks_to_kill or
+                killed_task_count + self.cluster_connector.get_task_count_realtime(
+                    node_metadata.agent) > self.max_tasks_to_kill
+            ):  # case 2
+                # fix log to write correct count
                 logger.info(
                     f"Killing instance {instance_id} with {node_metadata.agent.task_count} tasks would take us "
                     f"over our max_tasks_to_kill of {self.max_tasks_to_kill}. Skipping this instance."
@@ -440,7 +446,9 @@ class PoolManager:
                     continue
 
             logger.info(f"marking {instance_id} for termination")
-            #TODO taint node - noschedule ---
+
+            self.cluster_connector.freeze_agent(node_metadata.agent)
+
             marked_nodes[group_id].append(node_metadata)
             rem_group_capacities[group_id] -= instance_weight
             curr_capacity -= instance_weight

--- a/clusterman/autoscaler/pool_manager.py
+++ b/clusterman/autoscaler/pool_manager.py
@@ -543,7 +543,7 @@ class PoolManager:
 
         def sort_key(
             node_metadata: ClusterNodeMetadata,
-        ) -> Tuple[int, int, int, int, int]:
+        ) -> Tuple[int, int, int, int, int, int]:
             return (
                 0 if node_metadata.agent.is_freezed else 1,
                 0 if node_metadata.agent.state == AgentState.ORPHANED else 1,

--- a/clusterman/autoscaler/pool_manager.py
+++ b/clusterman/autoscaler/pool_manager.py
@@ -531,8 +531,6 @@ class PoolManager:
             return False
         elif node_metadata.instance.is_cordoned:
             return False
-        elif self.max_tasks_per_node_to_kill < node_metadata.agent.task_count:
-            return False
         elif self.max_tasks_to_kill > node_metadata.agent.task_count:
             return True
         else:

--- a/clusterman/autoscaler/pool_manager.py
+++ b/clusterman/autoscaler/pool_manager.py
@@ -545,6 +545,7 @@ class PoolManager:
             node_metadata: ClusterNodeMetadata,
         ) -> Tuple[int, int, int, int, int]:
             return (
+                0 if node_metadata.agent.is_freezed else 1,
                 0 if node_metadata.agent.state == AgentState.ORPHANED else 1,
                 0 if node_metadata.agent.state == AgentState.IDLE else 1,
                 0 if node_metadata.instance.is_stale else 1,

--- a/clusterman/autoscaler/pool_manager.py
+++ b/clusterman/autoscaler/pool_manager.py
@@ -440,18 +440,20 @@ class PoolManager:
                     )
                     continue
 
+            logger.info(f"freezing {instance_id} for termination")
+            self.cluster_connector.freeze_agent(node_metadata.agent)
+
             task_count_realtime = self.cluster_connector.get_task_count_realtime(node_metadata.agent)
             if killed_task_count + task_count_realtime > self.max_tasks_to_kill:  # case 4
                 logger.info(
                     f"Killing instance {instance_id} with {task_count_realtime} tasks (realtime) would take us "
                     f"over our max_tasks_to_kill of {self.max_tasks_to_kill}. Skipping this instance."
                 )
+                logger.info(f"unfreezing {instance_id} for termination")
+                self.cluster_connector.unfreeze_agent(node_metadata.agent)
                 continue
 
             logger.info(f"marking {instance_id} for termination")
-
-            self.cluster_connector.freeze_agent(node_metadata.agent)
-
             marked_nodes[group_id].append(node_metadata)
             rem_group_capacities[group_id] -= instance_weight
             curr_capacity -= instance_weight

--- a/clusterman/autoscaler/pool_manager.py
+++ b/clusterman/autoscaler/pool_manager.py
@@ -444,16 +444,17 @@ class PoolManager:
             logger.info(f"freezing {instance_id} for termination")
             self.cluster_connector.freeze_agent(node_metadata.agent)
 
-            task_count_realtime = self.cluster_connector.get_task_count_realtime(node_metadata.agent)
-            #node_metadata.agent.task_count = task_count_realtime not sure yet
-            if task_count_realtime > self.max_tasks_per_node_to_kill:  # case 4
-                logger.info(
-                    f"Killing instance {instance_id} with {task_count_realtime} tasks  would take us "
-                    f"over our max_tasks_per_node_to_kill of {self.max_tasks_per_node_to_kill}. Skipping this instance."
-                )
-                logger.info(f"unfreezing {instance_id} for termination")
-                self.cluster_connector.unfreeze_agent(node_metadata.agent)
-                continue
+            if self.max_tasks_per_node_to_kill != float("inf"):
+                task_count_realtime = self.cluster_connector.get_task_count_realtime(node_metadata.agent)
+                #node_metadata.agent.task_count = task_count_realtime not sure yet
+                if task_count_realtime > self.max_tasks_per_node_to_kill:  # case 4
+                    logger.info(
+                        f"Killing instance {instance_id} with {task_count_realtime} tasks  would take us "
+                        f"over our max_tasks_per_node_to_kill of {self.max_tasks_per_node_to_kill}. Skipping this instance."
+                    )
+                    logger.info(f"unfreezing {instance_id} for termination")
+                    self.cluster_connector.unfreeze_agent(node_metadata.agent)
+                    continue
 
             logger.info(f"marking {instance_id} for termination")
             marked_nodes[group_id].append(node_metadata)

--- a/clusterman/interfaces/cluster_connector.py
+++ b/clusterman/interfaces/cluster_connector.py
@@ -46,6 +46,12 @@ class ClusterConnector(metaclass=ABCMeta):
             return AgentMetadata()
         return self._get_agent_metadata(ip_address)
 
+    def get_task_count_realtime(self, agent: Optional[AgentMetadata]) -> int:
+        #TODO add description here
+        if not agent:
+            return 0
+        return self._get_task_count_realtime(agent)
+
     @abstractmethod
     def get_resource_allocation(self, resource_name: str) -> float:  # pragma: no cover
         """Get the total amount of the given resource currently allocated for this pool.
@@ -88,6 +94,10 @@ class ClusterConnector(metaclass=ABCMeta):
 
     @abstractmethod
     def _get_agent_metadata(self, ip_address: str) -> AgentMetadata:  # pragma: no cover
+        pass
+
+    @abstractmethod
+    def _get_task_count_realtime(self, agent: AgentMetadata) -> int:
         pass
 
     @staticmethod

--- a/clusterman/interfaces/cluster_connector.py
+++ b/clusterman/interfaces/cluster_connector.py
@@ -46,21 +46,10 @@ class ClusterConnector(metaclass=ABCMeta):
             return AgentMetadata()
         return self._get_agent_metadata(ip_address)
 
-    def get_task_count_realtime(self, agent: Optional[AgentMetadata]) -> int:
+    def freeze_agent(self, agent_id: Optional[str]) -> None:
         #TODO add description here
-        if not agent:
-            return 0
-        return self._get_task_count_realtime(agent)
-
-    def freeze_agent(self, agent: Optional[AgentMetadata]) -> None:
-        #TODO add description here
-        if agent:
-            self._freeze_agent(agent)
-
-    def unfreeze_agent(self, agent: Optional[AgentMetadata]) -> None:
-        #TODO add description here
-        if agent:
-            self._unfreeze_agent(agent)
+        if agent_id:
+            self._freeze_agent(agent_id)
 
     @abstractmethod
     def get_resource_allocation(self, resource_name: str) -> float:  # pragma: no cover
@@ -107,15 +96,7 @@ class ClusterConnector(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def _get_task_count_realtime(self, agent: AgentMetadata) -> int:
-        pass
-
-    @abstractmethod
-    def _freeze_agent(self, agent: AgentMetadata) -> None:
-        pass
-
-    @abstractmethod
-    def _unfreeze_agent(self, agent: AgentMetadata) -> None:
+    def _freeze_agent(self, agent_id: str) -> None:
         pass
 
     @staticmethod

--- a/clusterman/interfaces/cluster_connector.py
+++ b/clusterman/interfaces/cluster_connector.py
@@ -47,7 +47,10 @@ class ClusterConnector(metaclass=ABCMeta):
         return self._get_agent_metadata(ip_address)
 
     def freeze_agent(self, agent_id: Optional[str]) -> None:
-        #TODO add description here
+        """Stop new tasks scheduling to agent
+
+        :param agent_id: agent identifier.
+        """
         if agent_id:
             self._freeze_agent(agent_id)
 

--- a/clusterman/interfaces/cluster_connector.py
+++ b/clusterman/interfaces/cluster_connector.py
@@ -57,6 +57,11 @@ class ClusterConnector(metaclass=ABCMeta):
         if agent:
             self._freeze_agent(agent)
 
+    def unfreeze_agent(self, agent: Optional[AgentMetadata]) -> None:
+        #TODO add description here
+        if agent:
+            self._unfreeze_agent(agent)
+
     @abstractmethod
     def get_resource_allocation(self, resource_name: str) -> float:  # pragma: no cover
         """Get the total amount of the given resource currently allocated for this pool.
@@ -107,6 +112,10 @@ class ClusterConnector(metaclass=ABCMeta):
 
     @abstractmethod
     def _freeze_agent(self, agent: AgentMetadata) -> None:
+        pass
+
+    @abstractmethod
+    def _unfreeze_agent(self, agent: AgentMetadata) -> None:
         pass
 
     @staticmethod

--- a/clusterman/interfaces/cluster_connector.py
+++ b/clusterman/interfaces/cluster_connector.py
@@ -46,13 +46,13 @@ class ClusterConnector(metaclass=ABCMeta):
             return AgentMetadata()
         return self._get_agent_metadata(ip_address)
 
-    def freeze_agent(self, agent_id: Optional[str]) -> None:
+    @abstractmethod
+    def freeze_agent(self, agent_id: str) -> None:
         """Stop new tasks scheduling to agent
 
         :param agent_id: agent identifier.
         """
-        if agent_id:
-            self._freeze_agent(agent_id)
+        pass
 
     @abstractmethod
     def get_resource_allocation(self, resource_name: str) -> float:  # pragma: no cover
@@ -96,10 +96,6 @@ class ClusterConnector(metaclass=ABCMeta):
 
     @abstractmethod
     def _get_agent_metadata(self, ip_address: str) -> AgentMetadata:  # pragma: no cover
-        pass
-
-    @abstractmethod
-    def _freeze_agent(self, agent_id: str) -> None:
         pass
 
     @staticmethod

--- a/clusterman/interfaces/cluster_connector.py
+++ b/clusterman/interfaces/cluster_connector.py
@@ -52,6 +52,11 @@ class ClusterConnector(metaclass=ABCMeta):
             return 0
         return self._get_task_count_realtime(agent)
 
+    def freeze_agent(self, agent: Optional[AgentMetadata]) -> None:
+        #TODO add description here
+        if agent:
+            self._freeze_agent(agent)
+
     @abstractmethod
     def get_resource_allocation(self, resource_name: str) -> float:  # pragma: no cover
         """Get the total amount of the given resource currently allocated for this pool.
@@ -98,6 +103,10 @@ class ClusterConnector(metaclass=ABCMeta):
 
     @abstractmethod
     def _get_task_count_realtime(self, agent: AgentMetadata) -> int:
+        pass
+
+    @abstractmethod
+    def _freeze_agent(self, agent: AgentMetadata) -> None:
         pass
 
     @staticmethod

--- a/clusterman/interfaces/types.py
+++ b/clusterman/interfaces/types.py
@@ -20,6 +20,7 @@ class AgentMetadata(NamedTuple):
     allocated_resources: ClustermanResources = ClustermanResources()
     batch_task_count: int = 0
     is_safe_to_kill: bool = True
+    is_freezed: bool = False
     state: AgentState = AgentState.UNKNOWN
     task_count: int = 0
     total_resources: ClustermanResources = ClustermanResources()

--- a/clusterman/interfaces/types.py
+++ b/clusterman/interfaces/types.py
@@ -20,7 +20,7 @@ class AgentMetadata(NamedTuple):
     allocated_resources: ClustermanResources = ClustermanResources()
     batch_task_count: int = 0
     is_safe_to_kill: bool = True
-    is_freezed: bool = False
+    is_frozen: bool = False
     state: AgentState = AgentState.UNKNOWN
     task_count: int = 0
     total_resources: ClustermanResources = ClustermanResources()

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -205,9 +205,6 @@ class KubernetesClusterConnector(ClusterConnector):
         )
 
     def _is_node_frozen(self, node: KubernetesNode) -> bool:
-        if not node.spec:
-            return False
-
         if node.spec.taints:
             for taint in node.spec.taints:
                 if taint.key == CLUSTERMAN_TERMINATION_TAINT_KEY:

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -254,6 +254,14 @@ class KubernetesClusterConnector(ClusterConnector):
     def _freeze_agent(self, agent: AgentMetadata) -> None:
         body = {
             "spec": {
+                "unschedulable": True
+            }
+        }
+        self._core_api.patch_node(agent.agent_id, body)
+
+    def _unfreeze_agent(self, agent: AgentMetadata) -> None:
+        body = {
+            "spec": {
                 "unschedulable": False
             }
         }

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -131,11 +131,14 @@ class KubernetesClusterConnector(ClusterConnector):
 
     def freeze_agent(self, agent_id: str) -> None:
         try:
-            body = {"spec": {"taints": [{"effect": "NoSchedule", "key": "clusterman.yelp.com/terminating", "value": "True"}]}}
+            body = {
+                "spec": {
+                    "taints": [{"effect": "NoSchedule", "key": "clusterman.yelp.com/terminating", "value": "True"}]
+                }
+            }
             self._core_api.patch_node(agent_id, body)
         except ApiException as e:
             logger.warning(f"Failed to patch {agent_id}: {e}")
-
 
     def _pod_belongs_to_daemonset(self, pod: KubernetesPod) -> bool:
         return pod.metadata.owner_references and any(

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -128,6 +128,10 @@ class KubernetesClusterConnector(ClusterConnector):
                 unschedulable_pods.append((pod, self._get_pod_unschedulable_reason(pod)))
         return unschedulable_pods
 
+    def freeze_agent(self, agent_id: str) -> None:
+        body = {"spec": {"unschedulable": True}}
+        self._core_api.patch_node(agent_id, body)
+
     def _pod_belongs_to_daemonset(self, pod: KubernetesPod) -> bool:
         return pod.metadata.owner_references and any(
             [owner_reference.kind == "DaemonSet" for owner_reference in pod.metadata.owner_references]
@@ -240,10 +244,6 @@ class KubernetesClusterConnector(ClusterConnector):
                     count += not strtobool(value)  # if it's safe to evict, it's NOT a batch task
                     break
         return count
-
-    def _freeze_agent(self, agent_id: str) -> None:
-        body = {"spec": {"unschedulable": True}}
-        self._core_api.patch_node(agent_id, body)
 
     @property
     def pool_label_key(self):

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -241,31 +241,13 @@ class KubernetesClusterConnector(ClusterConnector):
                     break
         return count
 
-    def _get_task_count_realtime(self, agent: AgentMetadata) -> int:
-        kwargs = dict(
-            field_selector=f"spec.nodeName={agent.agent_id}"
-        )
-        exclude_daemonset_pods = True
-        node_pods = self._core_api.list_pod_for_all_namespaces(**kwargs).items
-
-        filtered_pods = [pod for pod in node_pods if ((not exclude_daemonset_pods or not self._pod_belongs_to_daemonset(pod)) and pod.status.phase == "Running")]
-        return len(filtered_pods)
-
-    def _freeze_agent(self, agent: AgentMetadata) -> None:
+    def _freeze_agent(self, agent_id: str) -> None:
         body = {
             "spec": {
                 "unschedulable": True
             }
         }
-        self._core_api.patch_node(agent.agent_id, body)
-
-    def _unfreeze_agent(self, agent: AgentMetadata) -> None:
-        body = {
-            "spec": {
-                "unschedulable": False
-            }
-        }
-        self._core_api.patch_node(agent.agent_id, body)
+        self._core_api.patch_node(agent_id, body)
 
     @property
     def pool_label_key(self):

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -135,9 +135,7 @@ class KubernetesClusterConnector(ClusterConnector):
         now = str(int(arrow.now().timestamp()))
         try:
             body = {
-                "spec": {
-                    "taints": [{"effect": "NoSchedule", "key": CLUSTERMAN_TERMINATION_TAINT_KEY, "value": now}]
-                }
+                "spec": {"taints": [{"effect": "NoSchedule", "key": CLUSTERMAN_TERMINATION_TAINT_KEY, "value": now}]}
             }
             self._core_api.patch_node(agent_id, body)
         except ApiException as e:

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -241,6 +241,10 @@ class KubernetesClusterConnector(ClusterConnector):
                     break
         return count
 
+    def _get_task_count_realtime(self, agent: AgentMetadata) -> int:
+        # TODO should be implemented: describe node and get information here if possible
+        return 0
+
     @property
     def pool_label_key(self):
         return self.pool_config.read_string("pool_label_key", default="clusterman.com/pool")

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -242,11 +242,7 @@ class KubernetesClusterConnector(ClusterConnector):
         return count
 
     def _freeze_agent(self, agent_id: str) -> None:
-        body = {
-            "spec": {
-                "unschedulable": True
-            }
-        }
+        body = {"spec": {"unschedulable": True}}
         self._core_api.patch_node(agent_id, body)
 
     @property

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -197,14 +197,14 @@ class KubernetesClusterConnector(ClusterConnector):
             agent_id=node.metadata.name,
             allocated_resources=allocated_node_resources(self._pods_by_ip[node_ip]),
             is_safe_to_kill=self._is_node_safe_to_kill(node_ip),
-            is_freezed=self._is_node_freezed(node),
+            is_frozen=self._is_node_frozen(node),
             batch_task_count=self._count_batch_tasks(node_ip),
             state=(AgentState.RUNNING if self._pods_by_ip[node_ip] else AgentState.IDLE),
             task_count=len(self._pods_by_ip[node_ip]),
             total_resources=total_node_resources(node, self._excluded_pods_by_ip.get(node_ip, [])),
         )
 
-    def _is_node_freezed(self, node: KubernetesNode) -> bool:
+    def _is_node_frozen(self, node: KubernetesNode) -> bool:
         if not node.spec:
             return False
 

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -205,6 +205,9 @@ class KubernetesClusterConnector(ClusterConnector):
         )
 
     def _is_node_frozen(self, node: KubernetesNode) -> bool:
+        if not node.spec:
+            return False
+
         if node.spec.taints:
             for taint in node.spec.taints:
                 if taint.key == CLUSTERMAN_TERMINATION_TAINT_KEY:

--- a/clusterman/mesos/mesos_cluster_connector.py
+++ b/clusterman/mesos/mesos_cluster_connector.py
@@ -129,3 +129,6 @@ class MesosClusterConnector(ClusterConnector):
 
     def _get_task_count_realtime(self, agent: AgentMetadata) -> int:
         return agent.task_count
+
+    def _freeze_agent(self, agent: AgentMetadata) -> None:
+        return

--- a/clusterman/mesos/mesos_cluster_connector.py
+++ b/clusterman/mesos/mesos_cluster_connector.py
@@ -126,3 +126,6 @@ class MesosClusterConnector(ClusterConnector):
         """If the framework matches any of the prefixes in self.non_batch_framework_prefixes
         this will return False, otherwise we assume the task to be a batch task"""
         return not any([framework_name.startswith(prefix) for prefix in self.non_batch_framework_prefixes])
+
+    def _get_task_count_realtime(self, agent: AgentMetadata) -> int:
+        return agent.task_count

--- a/clusterman/mesos/mesos_cluster_connector.py
+++ b/clusterman/mesos/mesos_cluster_connector.py
@@ -74,6 +74,7 @@ class MesosClusterConnector(ClusterConnector):
         return sum(getattr(total_agent_resources(agent), resource_name) for agent in self._agents_by_ip.values())
 
     def freeze_agent(self, agent_id: str) -> None:
+        logger.info("Skipping freeze process because scheduler is mesos")
         return
 
     def _get_agent_metadata(self, instance_ip: str) -> AgentMetadata:

--- a/clusterman/mesos/mesos_cluster_connector.py
+++ b/clusterman/mesos/mesos_cluster_connector.py
@@ -73,6 +73,9 @@ class MesosClusterConnector(ClusterConnector):
     def get_resource_total(self, resource_name: str) -> float:
         return sum(getattr(total_agent_resources(agent), resource_name) for agent in self._agents_by_ip.values())
 
+    def freeze_agent(self, agent_id: str) -> None:
+        return
+
     def _get_agent_metadata(self, instance_ip: str) -> AgentMetadata:
         agent_dict = self._agents_by_ip.get(instance_ip)
         if not agent_dict:
@@ -126,6 +129,3 @@ class MesosClusterConnector(ClusterConnector):
         """If the framework matches any of the prefixes in self.non_batch_framework_prefixes
         this will return False, otherwise we assume the task to be a batch task"""
         return not any([framework_name.startswith(prefix) for prefix in self.non_batch_framework_prefixes])
-
-    def _freeze_agent(self, agent_id: str) -> None:
-        return

--- a/clusterman/mesos/mesos_cluster_connector.py
+++ b/clusterman/mesos/mesos_cluster_connector.py
@@ -127,11 +127,5 @@ class MesosClusterConnector(ClusterConnector):
         this will return False, otherwise we assume the task to be a batch task"""
         return not any([framework_name.startswith(prefix) for prefix in self.non_batch_framework_prefixes])
 
-    def _get_task_count_realtime(self, agent: AgentMetadata) -> int:
-        return agent.task_count
-
-    def _freeze_agent(self, agent: AgentMetadata) -> None:
-        return
-
-    def _unfreeze_agent(self, agent: AgentMetadata) -> None:
+    def _freeze_agent(self, agent_id: str) -> None:
         return

--- a/clusterman/mesos/mesos_cluster_connector.py
+++ b/clusterman/mesos/mesos_cluster_connector.py
@@ -132,3 +132,6 @@ class MesosClusterConnector(ClusterConnector):
 
     def _freeze_agent(self, agent: AgentMetadata) -> None:
         return
+
+    def _unfreeze_agent(self, agent: AgentMetadata) -> None:
+        return

--- a/clusterman/simulator/simulated_cluster_connector.py
+++ b/clusterman/simulator/simulated_cluster_connector.py
@@ -64,3 +64,6 @@ class SimulatedClusterConnector(ClusterConnector):
 
     def _get_task_count_realtime(self, agent: AgentMetadata) -> int:
         return agent.task_count
+
+    def _freeze_agent(self, agent: AgentMetadata) -> None:
+        return

--- a/clusterman/simulator/simulated_cluster_connector.py
+++ b/clusterman/simulator/simulated_cluster_connector.py
@@ -44,6 +44,9 @@ class SimulatedClusterConnector(ClusterConnector):
                 total += getattr(i.resources, resource_name)
         return total
 
+    def freeze_agent(self, agent_id: str) -> None:
+        return
+
     def _get_agent_metadata(self, instance_ip: str) -> AgentMetadata:
         for c in self.simulator.aws_clusters:
             for i in c.instances.values():
@@ -61,6 +64,3 @@ class SimulatedClusterConnector(ClusterConnector):
 
         # if we don't know the given IP then it's orphaned
         return AgentMetadata(state=AgentState.ORPHANED)
-
-    def _freeze_agent(self, agent_id: str) -> None:
-        return

--- a/clusterman/simulator/simulated_cluster_connector.py
+++ b/clusterman/simulator/simulated_cluster_connector.py
@@ -67,3 +67,6 @@ class SimulatedClusterConnector(ClusterConnector):
 
     def _freeze_agent(self, agent: AgentMetadata) -> None:
         return
+
+    def _unfreeze_agent(self, agent: AgentMetadata) -> None:
+        return

--- a/clusterman/simulator/simulated_cluster_connector.py
+++ b/clusterman/simulator/simulated_cluster_connector.py
@@ -62,11 +62,5 @@ class SimulatedClusterConnector(ClusterConnector):
         # if we don't know the given IP then it's orphaned
         return AgentMetadata(state=AgentState.ORPHANED)
 
-    def _get_task_count_realtime(self, agent: AgentMetadata) -> int:
-        return agent.task_count
-
-    def _freeze_agent(self, agent: AgentMetadata) -> None:
-        return
-
-    def _unfreeze_agent(self, agent: AgentMetadata) -> None:
+    def _freeze_agent(self, agent_id: str) -> None:
         return

--- a/clusterman/simulator/simulated_cluster_connector.py
+++ b/clusterman/simulator/simulated_cluster_connector.py
@@ -61,3 +61,6 @@ class SimulatedClusterConnector(ClusterConnector):
 
         # if we don't know the given IP then it's orphaned
         return AgentMetadata(state=AgentState.ORPHANED)
+
+    def _get_task_count_realtime(self, agent: AgentMetadata) -> int:
+        return agent.task_count


### PR DESCRIPTION
### Description

1) Clusterman get pods count in node and then start termination process.
2) Kube scheduler schedule new pods before Clusterman terminating node
https://jira.yelpcorp.com/browse/CLUSTERMAN-642
