### PR TITLE
Add label based filtering for pods 

### DIFF
--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -220,7 +220,7 @@ class KubernetesClusterConnector(ClusterConnector):
             default=staticconf.read_bool("exclude_daemonset_pods", default=False),
         )
 
-        label_selector = "{0}={1}".format(self.pool_label_key, self.pool)
+        label_selector = "{}={}".format(self.pool_label_key, self.pool)
 
         for pod in self._core_api.list_pod_for_all_namespaces(label_selector=label_selector).items:
             if pod.status.phase not in KUBERNETES_SCHEDULED_PHASES:

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -244,7 +244,7 @@ class KubernetesClusterConnector(ClusterConnector):
 
             if exclude_daemonset_pods and self._pod_belongs_to_daemonset(pod):
                 excluded_pods_by_ip[pod.status.host_ip].append(pod)
-            elif pod.status.phase == "Running" or self._is_recently_scheduled(pod)
+            elif pod.status.phase == "Running" or self._is_recently_scheduled(pod):
                 pods_by_ip[pod.status.host_ip].append(pod)
             elif self._is_unschedulable(pod):
                 unschedulable_pods.append(pod)

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -220,7 +220,7 @@ class KubernetesClusterConnector(ClusterConnector):
             default=staticconf.read_bool("exclude_daemonset_pods", default=False),
         )
 
-        label_selector="{0}={1}".format(self.pool_label_key, self.pool)
+        label_selector = "{0}={1}".format(self.pool_label_key, self.pool)
 
         for pod in self._core_api.list_pod_for_all_namespaces(label_selector=label_selector).items:
             if pod.status.phase not in KUBERNETES_SCHEDULED_PHASES:

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -244,11 +244,13 @@ class KubernetesClusterConnector(ClusterConnector):
 
             if exclude_daemonset_pods and self._pod_belongs_to_daemonset(pod):
                 excluded_pods_by_ip[pod.status.host_ip].append(pod)
-            elif pod.status.phase == "Running":
+            elif pod.status.phase == "Running" or self._is_recently_scheduled(pod)
                 pods_by_ip[pod.status.host_ip].append(pod)
+            elif self._is_unschedulable(pod):
+                unschedulable_pods.append(pod)
             else:
-                pending_pods.append(pod)
-        return pods_by_ip, pending_pods, excluded_pods_by_ip
+                logger.info(f"Skipping {pod.metadata.name} pod ({pod.status.phase})")
+        return pods_by_ip, unschedulable_pods, excluded_pods_by_ip
 
     def _count_batch_tasks(self, node_ip: str) -> int:
         count = 0

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -219,8 +219,7 @@ class KubernetesClusterConnector(ClusterConnector):
             "exclude_daemonset_pods",
             default=staticconf.read_bool("exclude_daemonset_pods", default=False),
         )
-        all_pods = self.get_all_pods_for_the_pool()
-        for pod in all_pods:
+        for pod in self.get_all_pods_for_the_pool():
             if exclude_daemonset_pods and self._pod_belongs_to_daemonset(pod):
                 excluded_pods_by_ip[pod.status.host_ip].append(pod)
             elif pod.status.phase == "Running":
@@ -241,14 +240,16 @@ class KubernetesClusterConnector(ClusterConnector):
         return count
 
     def get_all_namespaces(self) -> List[str]:
-        total_namespaces = []
+        total_namespaces: List[str] = []
+        
         namespaces_in_cluster = self._core_api.list_namespace().items
         for data in namespaces_in_cluster:
             total_namespaces.append(data.metadata.name)
         return total_namespaces
 
     def get_all_pods_for_the_pool(self) -> List[KubernetesPod]:
-        all_pods = []
+        all_pods: List[KubernetesPod] = []
+
         pool_label_selector = self.pool_config.read_string("pool_label_key", default="clusterman.com/pool")
         label_selector="{0}={1}".format(pool_label_selector, self.pool)
         for namespace in self.get_all_namespaces():

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -240,7 +240,7 @@ class KubernetesClusterConnector(ClusterConnector):
                     break
         return count
 
-    def get_all_namespaces(self) -> [str]:
+    def get_all_namespaces(self) -> List[str]:
         total_namespaces = []
         namespaces_in_cluster = self._core_api.list_namespace().items
         for data in namespaces_in_cluster:

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -220,6 +220,9 @@ class KubernetesClusterConnector(ClusterConnector):
             default=staticconf.read_bool("exclude_daemonset_pods", default=False),
         )
         for pod in self.get_all_pods_for_the_pool().items:
+            if pod.status.phase not in KUBERNETES_SCHEDULED_PHASES:
+                continue
+
             if exclude_daemonset_pods and self._pod_belongs_to_daemonset(pod):
                 excluded_pods_by_ip[pod.status.host_ip].append(pod)
             elif pod.status.phase == "Running":

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -235,7 +235,6 @@ class KubernetesClusterConnector(ClusterConnector):
             "exclude_daemonset_pods",
             default=staticconf.read_bool("exclude_daemonset_pods", default=False),
         )
-        
         label_selector = "{}={}".format(self.pool_label_key, self.pool)
 
         for pod in self._core_api.list_pod_for_all_namespaces(label_selector=label_selector).items:


### PR DESCRIPTION
### Description
Currently Clusterman gets the all the pods while running `clusterman status`, which is very inefficient, this change is part of a big change where labels are added to different pod operators and clusterman can then filter the pods by labels for a pool rather than getting all pods at the same time. 

Use label based filter to find out pods in a pool - https://github.com/Yelp/paasta/pull/3383

### Verification
```sh
(virtualenv_run) akshaysha@dev55-uswest1adevc:~/akshay/playground/clusterman$ make test
find -name '*.pyc' -delete
find -name '__pycache__' -delete
rm -rf .mypy_cache
rm -rf .pytest_cache
tox -e yelp
yelp installed: arrow==0.14.6,asn1crypto==1.1.0,atomicwrites==1.3.0,attrs==19.2.0,aws-sam-translator==1.15.1,aws-xray-sdk==2.4.2,backcall==0.1.0,backports.entry-points-selectable==1.1.0,behave==1.2.6,boto==2.49.0,boto3==1.11.11,botocore==1.14.11,cached-property==1.5.2,cachetools==3.1.1,certifi==2019.9.11,cffi==1.12.3,cfgv==2.0.1,cfn-lint==0.24.4,chardet==3.0.4,clusterman-metrics==2.2.1,colorama==0.4.1,colorlog==4.0.2,contextdecorator==0.10.0,contextlib2==0.6.0,coverage==4.5.4,cryptography==2.7,cycler==0.10.0,data-streams-audit==3.0.8,decorator==4.4.0,distlib==0.3.4,distro==1.7.0,docker==4.1.0,docutils==0.15.2,ecdsa==0.13.3,entrypoints==0.3,filelock==3.0.12,flake8==3.7.8,funcsigs==1.0.2,future==0.18.0,google-auth==1.6.3,humanfriendly==4.18,identify==2.5.1,idna==2.8,importlib-metadata==0.23,ipdb==0.13.9,ipython==7.17.0,ipython-genutils==0.2.0,iso8601==1.0.2,jedi==0.15.1,Jinja2==2.10.3,jmespath==0.9.4,jsondiff==1.1.2,jsonpatch==1.24,jsonpickle==1.4.2,jsonpointer==2.0,jsonschema==3.1.1,kiwisolver==1.1.0,kubernetes==10.0.1,MarkupSafe==1.1.1,matplotlib==3.1.1,mccabe==0.6.1,mock==3.0.5,monk==1.1.0,more-itertools==7.2.0,moto==1.3.16,mypy==0.730,mypy-extensions==0.4.2,nodeenv==1.3.3,numpy==1.17.2,oauthlib==3.1.0,packaging==19.2,parse==1.12.1,parse-type==0.5.2,parsedatetime==2.4,parso==0.5.1,pexpect==4.7.0,pickleshare==0.7.5,platformdirs==2.5.2,pluggy==0.13.0,ply==3.11,pre-commit==2.9.2,prompt-toolkit==2.0.10,protobuf==3.10.0,psutil==5.9.1,ptyprocess==0.6.0,py==1.8.0,pyasn1==0.4.7,pyasn1-modules==0.2.7,pycodestyle==2.5.0,pycparser==2.19,pyflakes==2.1.1,pyformance==0.4,Pygments==2.4.2,PyHamcrest==1.9.0,pyparsing==2.4.2,pyrsistent==0.15.4,pysensu-yelp==0.4.1,PyStaticConfiguration==0.10.4,pysubnettree==0.35,pytest==5.2.1,python-dateutil==2.8.0,python-jose==3.1.0,pytz==2019.3,PyYAML==5.4.1,requests==2.22.0,requests-oauthlib==1.2.0,requirements-tools==2.0.0,responses==0.10.6,retry==0.9.2,retrying==1.3.3,rook==0.1.160,rsa==4.6,s3transfer==0.3.2,setproctitle==1.2.3,signalfx==1.1.1,simplejson==3.16.0,six==1.12.0,sortedcontainers==2.1.0,srv-configs==1.1.0,sseclient-py==1.7,sshpubkeys==3.1.0,static-completion==0.1.7,thriftpy2==0.4.14,toml==0.10.2,traitlets==4.3.3,typed-ast==1.4.0,typing-extensions==3.7.4,urllib3==1.25.9,venv-update==3.2.4,virtualenv==20.6.0,wcwidth==0.1.7,websocket-client==0.56.0,Werkzeug==0.16.0,wrapt==1.11.2,ws4py==0.5.1,xmltodict==0.12.0,yelp-batch==10.1.3,yelp-clog==4.1.0,yelp-lib==13.1.5,yelp-meteorite==1.5.1,zipp==0.6.0
yelp bootstrap: -r/nail/home/akshaysha/akshay/playground/clusterman/requirements-bootstrap.txt
yelp installdeps: -rrequirements.txt,-rrequirements-dev.txt,-rextra-requirements-yelp.txt,-rextra-requirements-yelp-dev.txt
yelp installed: arrow==0.14.6,asn1crypto==1.1.0,atomicwrites==1.3.0,attrs==19.2.0,aws-sam-translator==1.15.1,aws-xray-sdk==2.4.2,backcall==0.1.0,backports.entry-points-selectable==1.1.0,behave==1.2.6,boto==2.49.0,boto3==1.11.11,botocore==1.14.11,cached-property==1.5.2,cachetools==3.1.1,certifi==2019.9.11,cffi==1.12.3,cfgv==2.0.1,cfn-lint==0.24.4,chardet==3.0.4,clusterman-metrics==2.2.1,colorama==0.4.1,colorlog==4.0.2,contextdecorator==0.10.0,contextlib2==0.6.0,coverage==4.5.4,cryptography==2.7,cycler==0.10.0,data-streams-audit==3.0.8,decorator==4.4.0,distlib==0.3.4,distro==1.7.0,docker==4.1.0,docutils==0.15.2,ecdsa==0.13.3,entrypoints==0.3,filelock==3.0.12,flake8==3.7.8,funcsigs==1.0.2,future==0.18.0,google-auth==1.6.3,humanfriendly==4.18,identify==2.5.1,idna==2.8,importlib-metadata==0.23,ipdb==0.13.9,ipython==7.17.0,ipython-genutils==0.2.0,iso8601==1.0.2,jedi==0.15.1,Jinja2==2.10.3,jmespath==0.9.4,jsondiff==1.1.2,jsonpatch==1.24,jsonpickle==1.4.2,jsonpointer==2.0,jsonschema==3.1.1,kiwisolver==1.1.0,kubernetes==10.0.1,MarkupSafe==1.1.1,matplotlib==3.1.1,mccabe==0.6.1,mock==3.0.5,monk==1.1.0,more-itertools==7.2.0,moto==1.3.16,mypy==0.730,mypy-extensions==0.4.2,nodeenv==1.3.3,numpy==1.17.2,oauthlib==3.1.0,packaging==19.2,parse==1.12.1,parse-type==0.5.2,parsedatetime==2.4,parso==0.5.1,pexpect==4.7.0,pickleshare==0.7.5,platformdirs==2.5.2,pluggy==0.13.0,ply==3.11,pre-commit==2.9.2,prompt-toolkit==2.0.10,protobuf==3.10.0,psutil==5.9.1,ptyprocess==0.6.0,py==1.8.0,pyasn1==0.4.7,pyasn1-modules==0.2.7,pycodestyle==2.5.0,pycparser==2.19,pyflakes==2.1.1,pyformance==0.4,Pygments==2.4.2,PyHamcrest==1.9.0,pyparsing==2.4.2,pyrsistent==0.15.4,pysensu-yelp==0.4.1,PyStaticConfiguration==0.10.4,pysubnettree==0.35,pytest==5.2.1,python-dateutil==2.8.0,python-jose==3.1.0,pytz==2019.3,PyYAML==5.4.1,requests==2.22.0,requests-oauthlib==1.2.0,requirements-tools==2.0.0,responses==0.10.6,retry==0.9.2,retrying==1.3.3,rook==0.1.160,rsa==4.6,s3transfer==0.3.2,setproctitle==1.2.3,signalfx==1.1.1,simplejson==3.16.0,six==1.12.0,sortedcontainers==2.1.0,srv-configs==1.1.0,sseclient-py==1.7,sshpubkeys==3.1.0,static-completion==0.1.7,thriftpy2==0.4.14,toml==0.10.2,traitlets==4.3.3,typed-ast==1.4.0,typing-extensions==3.7.4,urllib3==1.25.9,venv-update==3.2.4,virtualenv==20.6.0,wcwidth==0.1.7,websocket-client==0.56.0,Werkzeug==0.16.0,wrapt==1.11.2,ws4py==0.5.1,xmltodict==0.12.0,yelp-batch==10.1.3,yelp-clog==4.1.0,yelp-lib==13.1.5,yelp-meteorite==1.5.1,zipp==0.6.0
yelp run-test-pre: PYTHONHASHSEED='3101363281'
yelp run-test: commands[0] | check-requirements -v
Checking requirements...
================================================================================== test session starts ==================================================================================
platform linux -- Python 3.7.5, pytest-5.2.1, py-1.8.0, pluggy-0.13.0
cachedir: virtualenv_run/.pytest_cache
rootdir: /nail/home/akshaysha/akshay/playground/clusterman, inifile: tox.ini
collected 4 items                                                                                                                                                                       

virtualenv_run/lib/python3.7/site-packages/requirements_tools/check_requirements.py ....

=================================================================================== 4 passed in 0.82s ===================================================================================
yelp run-test: commands[1] | mypy clusterman tests
Success: no issues found in 113 source files
yelp run-test: commands[2] | coverage erase
yelp run-test: commands[3] | coverage run -m pytest tests
================================================================================== test session starts ==================================================================================
platform linux -- Python 3.7.5, pytest-5.2.1, py-1.8.0, pluggy-0.13.0
cachedir: virtualenv_run/.pytest_cache
rootdir: /nail/home/akshaysha/akshay/playground/clusterman, inifile: tox.ini
collected 449 items                                                                                                                                                                     

tests/args_test.py ...                                                                                                                                                            [  0%]
tests/config_test.py .......                                                                                                                                                      [  2%]
tests/monitoring_lib_test.py ..                                                                                                                                                   [  2%]
tests/util_test.py ...........................                                                                                                                                    [  8%]
tests/autoscaler/autoscaler_test.py ................................................                                                                                              [ 19%]
tests/autoscaler/config_test.py .                                                                                                                                                 [ 19%]
tests/autoscaler/pool_manager_test.py ............................................................                                                                                [ 32%]
tests/aws/auto_scaling_resource_group_test.py .....................                                                                                                               [ 37%]
tests/aws/aws_resource_group_test.py ...........                                                                                                                                  [ 40%]
tests/aws/client_test.py ....                                                                                                                                                     [ 40%]
tests/aws/spot_fleet_resource_group_test.py .............                                                                                                                         [ 43%]
tests/aws/spot_prices_test.py .....                                                                                                                                               [ 44%]
tests/batch/autoscaler_test.py ....                                                                                                                                               [ 45%]
tests/batch/cluster_metrics_collector_test.py ...                                                                                                                                 [ 46%]
tests/batch/spot_price_collector_test.py ......                                                                                                                                   [ 47%]
tests/batch/util_test.py ..                                                                                                                                                       [ 48%]
tests/cli/manage_test.py .............                                                                                                                                            [ 51%]
tests/cli/simulate_test.py ....                                                                                                                                                   [ 52%]
tests/cli/toggle_test.py ....                                                                                                                                                     [ 53%]
tests/common/sfx_test.py .                                                                                                                                                        [ 53%]
tests/draining/mesos_test.py ..................                                                                                                                                   [ 57%]
tests/draining/queue_test.py ...................                                                                                                                                  [ 61%]
tests/interfaces/signal_test.py ....                                                                                                                                              [ 62%]
tests/kubernetes/kubernetes_cluster_connector_test.py ...........                                                                                                                 [ 64%]
tests/kubernetes/util_test.py ..........                                                                                                                                          [ 67%]
tests/math/piecewise_test.py ..................................                                                                                                                   [ 74%]
tests/mesos/mesos_cluster_connector_test.py .............                                                                                                                         [ 77%]
tests/mesos/metrics_generators_test.py ...                                                                                                                                        [ 78%]
tests/mesos/util_test.py ....                                                                                                                                                     [ 79%]
tests/signals/external_signal_test.py ...........                                                                                                                                 [ 81%]
tests/signals/pending_pods_signal_test.py ...                                                                                                                                     [ 82%]
tests/simulator/io_test.py ...                                                                                                                                                    [ 82%]
tests/simulator/simulated_aws_cluster_test.py ......                                                                                                                              [ 84%]
tests/simulator/simulated_cluster_connector_test.py ...                                                                                                                           [ 84%]
tests/simulator/simulated_spot_fleet_resource_group_test.py ..................                                                                                                    [ 88%]
tests/simulator/simulator_test.py .................................................                                                                                               [ 99%]
tests/tools/signalfx_scraper_test.py .                                                                                                                                            [100%]

=================================================================================== warnings summary ====================================================================================
virtualenv_run/lib/python3.7/site-packages/kubernetes/client/models/admissionregistration_v1beta1_webhook_client_config.py:82
  /nail/home/akshaysha/akshay/playground/clusterman/virtualenv_run/lib/python3.7/site-packages/kubernetes/client/models/admissionregistration_v1beta1_webhook_client_config.py:82: DeprecationWarning: invalid escape sequence \/
    if ca_bundle is not None and not re.search('^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$', ca_bundle):

virtualenv_run/lib/python3.7/site-packages/kubernetes/client/models/admissionregistration_v1beta1_webhook_client_config.py:83
  /nail/home/akshaysha/akshay/playground/clusterman/virtualenv_run/lib/python3.7/site-packages/kubernetes/client/models/admissionregistration_v1beta1_webhook_client_config.py:83: DeprecationWarning: invalid escape sequence \/
    raise ValueError("Invalid value for `ca_bundle`, must be a follow pattern or equal to `/^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/`")

virtualenv_run/lib/python3.7/site-packages/kubernetes/client/models/apiextensions_v1beta1_webhook_client_config.py:82
  /nail/home/akshaysha/akshay/playground/clusterman/virtualenv_run/lib/python3.7/site-packages/kubernetes/client/models/apiextensions_v1beta1_webhook_client_config.py:82: DeprecationWarning: invalid escape sequence \/
    if ca_bundle is not None and not re.search('^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$', ca_bundle):

virtualenv_run/lib/python3.7/site-packages/kubernetes/client/models/apiextensions_v1beta1_webhook_client_config.py:83
  /nail/home/akshaysha/akshay/playground/clusterman/virtualenv_run/lib/python3.7/site-packages/kubernetes/client/models/apiextensions_v1beta1_webhook_client_config.py:83: DeprecationWarning: invalid escape sequence \/
    raise ValueError("Invalid value for `ca_bundle`, must be a follow pattern or equal to `/^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/`")

virtualenv_run/lib/python3.7/site-packages/kubernetes/client/models/runtime_raw_extension.py:73
  /nail/home/akshaysha/akshay/playground/clusterman/virtualenv_run/lib/python3.7/site-packages/kubernetes/client/models/runtime_raw_extension.py:73: DeprecationWarning: invalid escape sequence \/
    if raw is not None and not re.search('^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$', raw):

virtualenv_run/lib/python3.7/site-packages/kubernetes/client/models/runtime_raw_extension.py:74
  /nail/home/akshaysha/akshay/playground/clusterman/virtualenv_run/lib/python3.7/site-packages/kubernetes/client/models/runtime_raw_extension.py:74: DeprecationWarning: invalid escape sequence \/
    raise ValueError("Invalid value for `raw`, must be a follow pattern or equal to `/^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/`")

virtualenv_run/lib/python3.7/site-packages/kubernetes/client/models/v1_api_service_spec.py:99
  /nail/home/akshaysha/akshay/playground/clusterman/virtualenv_run/lib/python3.7/site-packages/kubernetes/client/models/v1_api_service_spec.py:99: DeprecationWarning: invalid escape sequence \/
    if ca_bundle is not None and not re.search('^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$', ca_bundle):

virtualenv_run/lib/python3.7/site-packages/kubernetes/client/models/v1_api_service_spec.py:100
  /nail/home/akshaysha/akshay/playground/clusterman/virtualenv_run/lib/python3.7/site-packages/kubernetes/client/models/v1_api_service_spec.py:100: DeprecationWarning: invalid escape sequence \/
    raise ValueError("Invalid value for `ca_bundle`, must be a follow pattern or equal to `/^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/`")

virtualenv_run/lib/python3.7/site-packages/kubernetes/client/models/v1alpha1_webhook_client_config.py:82
  /nail/home/akshaysha/akshay/playground/clusterman/virtualenv_run/lib/python3.7/site-packages/kubernetes/client/models/v1alpha1_webhook_client_config.py:82: DeprecationWarning: invalid escape sequence \/
    if ca_bundle is not None and not re.search('^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$', ca_bundle):

virtualenv_run/lib/python3.7/site-packages/kubernetes/client/models/v1alpha1_webhook_client_config.py:83
  /nail/home/akshaysha/akshay/playground/clusterman/virtualenv_run/lib/python3.7/site-packages/kubernetes/client/models/v1alpha1_webhook_client_config.py:83: DeprecationWarning: invalid escape sequence \/
    raise ValueError("Invalid value for `ca_bundle`, must be a follow pattern or equal to `/^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/`")

virtualenv_run/lib/python3.7/site-packages/kubernetes/client/models/v1beta1_api_service_spec.py:99
  /nail/home/akshaysha/akshay/playground/clusterman/virtualenv_run/lib/python3.7/site-packages/kubernetes/client/models/v1beta1_api_service_spec.py:99: DeprecationWarning: invalid escape sequence \/
    if ca_bundle is not None and not re.search('^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$', ca_bundle):

virtualenv_run/lib/python3.7/site-packages/kubernetes/client/models/v1beta1_api_service_spec.py:100
  /nail/home/akshaysha/akshay/playground/clusterman/virtualenv_run/lib/python3.7/site-packages/kubernetes/client/models/v1beta1_api_service_spec.py:100: DeprecationWarning: invalid escape sequence \/
    raise ValueError("Invalid value for `ca_bundle`, must be a follow pattern or equal to `/^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/`")

virtualenv_run/lib/python3.7/site-packages/kubernetes/client/models/v1beta1_certificate_signing_request_spec.py:144
  /nail/home/akshaysha/akshay/playground/clusterman/virtualenv_run/lib/python3.7/site-packages/kubernetes/client/models/v1beta1_certificate_signing_request_spec.py:144: DeprecationWarning: invalid escape sequence \/
    if request is not None and not re.search('^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$', request):

virtualenv_run/lib/python3.7/site-packages/kubernetes/client/models/v1beta1_certificate_signing_request_spec.py:145
  /nail/home/akshaysha/akshay/playground/clusterman/virtualenv_run/lib/python3.7/site-packages/kubernetes/client/models/v1beta1_certificate_signing_request_spec.py:145: DeprecationWarning: invalid escape sequence \/
    raise ValueError("Invalid value for `request`, must be a follow pattern or equal to `/^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/`")

virtualenv_run/lib/python3.7/site-packages/kubernetes/client/models/v1beta1_certificate_signing_request_status.py:77
  /nail/home/akshaysha/akshay/playground/clusterman/virtualenv_run/lib/python3.7/site-packages/kubernetes/client/models/v1beta1_certificate_signing_request_status.py:77: DeprecationWarning: invalid escape sequence \/
    if certificate is not None and not re.search('^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$', certificate):

virtualenv_run/lib/python3.7/site-packages/kubernetes/client/models/v1beta1_certificate_signing_request_status.py:78
  /nail/home/akshaysha/akshay/playground/clusterman/virtualenv_run/lib/python3.7/site-packages/kubernetes/client/models/v1beta1_certificate_signing_request_status.py:78: DeprecationWarning: invalid escape sequence \/
    raise ValueError("Invalid value for `certificate`, must be a follow pattern or equal to `/^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/`")

virtualenv_run/lib/python3.7/site-packages/kubernetes/client/api_client.py:265
  /nail/home/akshaysha/akshay/playground/clusterman/virtualenv_run/lib/python3.7/site-packages/kubernetes/client/api_client.py:265: DeprecationWarning: invalid escape sequence \[
    sub_kls = re.match('list\[(.*)\]', klass).group(1)

virtualenv_run/lib/python3.7/site-packages/kubernetes/client/api_client.py:270
  /nail/home/akshaysha/akshay/playground/clusterman/virtualenv_run/lib/python3.7/site-packages/kubernetes/client/api_client.py:270: DeprecationWarning: invalid escape sequence \(
    sub_kls = re.match('dict\(([^,]*), (.*)\)', klass).group(2)

virtualenv_run/lib/python3.7/site-packages/boto/plugin.py:40
  /nail/home/akshaysha/akshay/playground/clusterman/virtualenv_run/lib/python3.7/site-packages/boto/plugin.py:40: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    import imp

tests/util_test.py::test_parse_time_string_without_tz
tests/util_test.py::test_parse_time_string_with_tz
tests/util_test.py::test_parse_time_string_non_arrow
tests/batch/spot_price_collector_test.py::test_start_time_parsing
tests/cli/simulate_test.py::test_main_too_many_compares
tests/cli/simulate_test.py::test_main_too_many_compares
tests/cli/simulate_test.py::test_main_compare_param[compare0]
tests/cli/simulate_test.py::test_main_compare_param[compare0]
tests/cli/simulate_test.py::test_main_compare_param[compare1]
tests/cli/simulate_test.py::test_main_compare_param[compare1]
tests/cli/simulate_test.py::test_main_compare_param[compare2]
tests/cli/simulate_test.py::test_main_compare_param[compare2]
tests/cli/toggle_test.py::TestManageMethods::test_disable_until
tests/cli/toggle_test.py::TestManageMethods::test_disable_until
tests/cli/toggle_test.py::TestManageMethods::test_disable_until
tests/draining/queue_test.py::test_clean_processing_hosts_cache
tests/draining/queue_test.py::test_clean_processing_hosts_cache
tests/draining/queue_test.py::test_clean_processing_hosts_cache
tests/tools/signalfx_scraper_test.py::test_main
tests/tools/signalfx_scraper_test.py::test_main
tests/tools/signalfx_scraper_test.py::test_main
  /nail/home/akshaysha/akshay/playground/clusterman/virtualenv_run/lib/python3.7/site-packages/arrow/factory.py:208: ArrowParseWarning: The .get() parsing method without a format string will parse more strictly in version 0.15.0.See https://github.com/crsmithdev/arrow/issues/612 for more details.
    ArrowParseWarning,

tests/util_test.py::test_parse_time_string_non_arrow
tests/util_test.py::test_parse_time_interval_seconds
tests/util_test.py::test_parse_time_interval_seconds_invalid
tests/cli/toggle_test.py::TestManageMethods::test_disable_until
tests/cli/toggle_test.py::TestManageMethods::test_disable_until
tests/cli/toggle_test.py::TestManageMethods::test_disable_until
  /nail/home/akshaysha/akshay/playground/clusterman/virtualenv_run/lib/python3.7/site-packages/parsedatetime/__init__.py:281: pdt20DeprecationWarning: Flag style will be deprecated in parsedatetime 2.0. Instead use the context style by instantiating `Calendar()` with argument `version=parsedatetime.VERSION_CONTEXT_STYLE`.
    pdt20DeprecationWarning)

tests/aws/auto_scaling_resource_group_test.py::test_get_launch_template_and_overrides_with_launch_config
  /nail/home/akshaysha/akshay/playground/clusterman/clusterman/aws/auto_scaling_resource_group.py:202: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    logger.warn(f"ASG {self.id} is not using LaunchTemplates, it will be unable to do smart scheduling")

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=========================================================================== 449 passed, 47 warnings in 36.53s ===========================================================================
yelp run-test: commands[4] | behave itests --no-source --no-timings --tags=-skip
Feature: make sure the autoscaler scales to the proper amount

  Scenario Outline: make sure the autoscaler requests the right number of resources -- @1.1  
    Given a cluster with 2 resource groups
    And 20 target capacity
    And 80 CPUs, 1000 MB mem, 1000 MB disk, and 0 GPUs
    And a mesos autoscaler object
    When the signal resource request is empty
    And the autoscaler runs
    Then no exception is raised
    And the autoscaler should scale rg1 to 10 capacity
    And the autoscaler should scale rg2 to 10 capacity

  Scenario Outline: make sure the autoscaler requests the right number of resources -- @1.2  
    Given a cluster with 2 resource groups
    And 20 target capacity
    And 80 CPUs, 1000 MB mem, 1000 MB disk, and 0 GPUs
    And a mesos autoscaler object
    When the signal resource request is 51 cpus
    And the autoscaler runs
    Then no exception is raised
    And the autoscaler should scale rg1 to 10 capacity
    And the autoscaler should scale rg2 to 10 capacity

  Scenario Outline: make sure the autoscaler requests the right number of resources -- @1.3  
    Given a cluster with 2 resource groups
    And 20 target capacity
    And 80 CPUs, 1000 MB mem, 1000 MB disk, and 0 GPUs
    And a mesos autoscaler object
    When the signal resource request is 56 cpus
    And the autoscaler runs
    Then no exception is raised
    And the autoscaler should scale rg1 to 10 capacity
    And the autoscaler should scale rg2 to 10 capacity

  Scenario Outline: make sure the autoscaler requests the right number of resources -- @1.4  
    Given a cluster with 2 resource groups
    And 20 target capacity
    And 80 CPUs, 1000 MB mem, 1000 MB disk, and 0 GPUs
    And a mesos autoscaler object
    When the signal resource request is 61 cpus
    And the autoscaler runs
    Then no exception is raised
    And the autoscaler should scale rg1 to 10 capacity
    And the autoscaler should scale rg2 to 10 capacity

  Scenario Outline: make sure the autoscaler requests the right number of resources -- @1.5  
    Given a cluster with 2 resource groups
    And 20 target capacity
    And 80 CPUs, 1000 MB mem, 1000 MB disk, and 0 GPUs
    And a mesos autoscaler object
    When the signal resource request is 70 cpus
    And the autoscaler runs
    Then no exception is raised
    And the autoscaler should scale rg1 to 13 capacity
    And the autoscaler should scale rg2 to 12 capacity

  Scenario Outline: make sure the autoscaler requests the right number of resources -- @1.6  
    Given a cluster with 2 resource groups
    And 20 target capacity
    And 80 CPUs, 1000 MB mem, 1000 MB disk, and 0 GPUs
    And a mesos autoscaler object
    When the signal resource request is 1000 cpus
    And the autoscaler runs
    Then no exception is raised
    And the autoscaler should scale rg1 to 50 capacity
    And the autoscaler should scale rg2 to 50 capacity

  Scenario Outline: make sure the autoscaler requests the right number of resources -- @1.7  
    Given a cluster with 2 resource groups
    And 20 target capacity
    And 80 CPUs, 1000 MB mem, 1000 MB disk, and 0 GPUs
    And a mesos autoscaler object
    When the signal resource request is 42 cpus
    And the autoscaler runs
    Then no exception is raised
    And the autoscaler should scale rg1 to 8 capacity
    And the autoscaler should scale rg2 to 8 capacity

  Scenario Outline: make sure the autoscaler requests the right number of resources -- @1.8  
    Given a cluster with 2 resource groups
    And 20 target capacity
    And 80 CPUs, 1000 MB mem, 1000 MB disk, and 0 GPUs
    And a mesos autoscaler object
    When the signal resource request is 2 cpus
    And the autoscaler runs
    Then no exception is raised
    And the autoscaler should scale rg1 to 5 capacity
    And the autoscaler should scale rg2 to 5 capacity

  Scenario Outline: make sure the autoscaler requests the right number of resources -- @1.9  
    Given a cluster with 2 resource groups
    And 20 target capacity
    And 80 CPUs, 1000 MB mem, 1000 MB disk, and 0 GPUs
    And a mesos autoscaler object
    When the signal resource request is 0 gpus
    And the autoscaler runs
    Then no exception is raised
    And the autoscaler should scale rg1 to 5 capacity
    And the autoscaler should scale rg2 to 5 capacity

  Scenario Outline: make sure the autoscaler works on empty pools -- @1.1  
    Given a cluster with 2 resource groups
    And 20 target capacity
    And 80 CPUs, 1000 MB mem, 1000 MB disk, and 0 GPUs
    And a mesos autoscaler object
    When the pool is empty
    And metrics history no
    And the signal resource request is 0 cpus
    And the autoscaler runs
    Then no exception is raised
    And the autoscaler should scale rg1 to 0 capacity
    And the autoscaler should scale rg2 to 0 capacity

  Scenario Outline: make sure the autoscaler works on empty pools -- @1.2  
    Given a cluster with 2 resource groups
    And 20 target capacity
    And 80 CPUs, 1000 MB mem, 1000 MB disk, and 0 GPUs
    And a mesos autoscaler object
    When the pool is empty
    And metrics history no
    And the signal resource request is 20 cpus
    And the autoscaler runs
    Then no exception is raised
    And the autoscaler should scale rg1 to 1 capacity
    And the autoscaler should scale rg2 to 0 capacity

  Scenario Outline: make sure the autoscaler works on empty pools -- @1.3  
    Given a cluster with 2 resource groups
    And 20 target capacity
    And 80 CPUs, 1000 MB mem, 1000 MB disk, and 0 GPUs
    And a mesos autoscaler object
    When the pool is empty
    And metrics history yes
    And the signal resource request is 20 cpus
    And the autoscaler runs
    Then no exception is raised
    And the autoscaler should scale rg1 to 21 capacity
    And the autoscaler should scale rg2 to 20 capacity

  Scenario: requesting GPUs on a pool without GPU instances is an error 
    Given a cluster with 2 resource groups
    And 20 target capacity
    And 80 CPUs, 1000 MB mem, 1000 MB disk, and 0 GPUs
    And a mesos autoscaler object
    When the signal resource request is 1 gpus
    And the autoscaler runs
    Then a ResourceRequestError is raised

  Scenario: the autoscaler does nothing when it is paused 
    Given a cluster with 2 resource groups
    And 20 target capacity
    And 80 CPUs, 1000 MB mem, 1000 MB disk, and 0 GPUs
    And a mesos autoscaler object
    When the autoscaler is paused
    And the signal resource request is 1000 cpus
    Then no exception is raised
    And the autoscaler should do nothing

  Scenario Outline: the default PendingPodsSignal works correctly -- @1.1  
    Given a cluster with 2 resource groups
    And 20 target capacity
    And 80 CPUs, 1000 MB mem, 1000 MB disk, and 0 GPUs
    And 56 CPUs allocated and 0 CPUs pending
    And a kubernetes autoscaler object
    When the autoscaler runs
    Then no exception is raised
    And the autoscaler should scale rg1 to 10 capacity
    And the autoscaler should scale rg2 to 10 capacity

  Scenario Outline: the default PendingPodsSignal works correctly -- @1.2  
    Given a cluster with 2 resource groups
    And 20 target capacity
    And 80 CPUs, 1000 MB mem, 1000 MB disk, and 0 GPUs
    And 56 CPUs allocated and 14 CPUs pending
    And a kubernetes autoscaler object
    When the autoscaler runs
    Then no exception is raised
    And the autoscaler should scale rg1 to 16 capacity
    And the autoscaler should scale rg2 to 15 capacity

  Scenario Outline: the default PendingPodsSignal works correctly -- @1.3  
    Given a cluster with 2 resource groups
    And 20 target capacity
    And 80 CPUs, 1000 MB mem, 1000 MB disk, and 0 GPUs
    And 56 CPUs allocated and 1000 CPUs pending
    And a kubernetes autoscaler object
    When the autoscaler runs
    Then no exception is raised
    And the autoscaler should scale rg1 to 50 capacity
    And the autoscaler should scale rg2 to 50 capacity

  @wip
  Scenario: the PendingPodsSignal is using up-to-date data 
    Given a cluster with 1 resource group
    And 10 target capacity
    And 40 CPUs, 500 MB mem, 500 MB disk, and 0 GPUs
    And 28 CPUs allocated and 0 CPUs pending
    And a kubernetes autoscaler object
    When the autoscaler runs only once
    And allocated CPUs changes to 40
    And the autoscaler runs only once
    Then no exception is raised
    And the autoscaler should scale rg1 to 15 capacity

  Scenario: instances are not killed if we've lost capacity recently 
    Given a cluster with 1 resource group
    And 10 target capacity
    And 40 CPUs, 500 MB mem, 500 MB disk, and 0 GPUs
    And 1 CPUs allocated and 0 CPUs pending
    And a kubernetes autoscaler object with prevent_scale_down_after_capacity_loss enabled
    When the cluster has recently lost capacity
    And the autoscaler runs only once
    Then no exception is raised
    And the autoscaler should do nothing

Feature: make sure the drainer is working properly

  Scenario: process the draining queue 
    Given a draining client
    And a message in the draining queue
    When the draining queue is processed
    Then the host should be submitted for termination
    And all queues are empty

  Scenario: process the termination queue 
    Given a draining client
    And a message in the termination queue
    When the termination queue is processed
    Then the host should be terminated
    And all queues are empty

  Scenario: process the warning queue 
    Given a draining client
    And a message in the warning queue
    When the warning queue is processed
    Then the host should be submitted for draining
    And all queues are empty

Feature: make sure we're pruning the right instances on scale-down

  Scenario: target capacity equals fulfilled capacity 
    Given a pool manager with 1 sfr resource group
    And the fulfilled capacity of resource group 1 is 10
    When we prune excess fulfilled capacity to 10
    Then 0 instances should be killed

  Scenario: no eligible instances to kill 
    Given a pool manager with 1 sfr resource group
    And the fulfilled capacity of resource group 1 is 11
    And there are no killable instances
    When we prune excess fulfilled capacity to 10
    Then 0 instances should be killed

  Scenario: the killable instance would remove too much cluster weight 
    Given a pool manager with 1 sfr resource group
    And the fulfilled capacity of resource group 1 is 15
    And the max weight to remove is 0
    When we prune excess fulfilled capacity to 10
    Then 0 instances should be killed
    And the log should contain "would take us over our max_weight_to_remove"

  Scenario: the killable instance would remove too much resource group capacity 
    Given a pool manager with 1 sfr resource group
    And the fulfilled capacity of resource group 1 is 11
    And the killable instance has weight 2
    When we prune excess fulfilled capacity to 10
    Then 0 instances should be killed
    And the log should contain "is at target capacity"

  Scenario: the killable instance would remove too many tasks 
    Given a pool manager with 1 sfr resource group
    And the fulfilled capacity of resource group 1 is 11
    And we can kill at most 1 task
    And the killable instance has 2 tasks
    When we prune excess fulfilled capacity to 10
    Then 0 instances should be killed
    And the log should contain "would take us over our max_tasks_to_kill"

  Scenario: the killable instance would reduce the non-orphaned capacity too much 
    Given a pool manager with 1 sfr resource group
    And the fulfilled capacity of resource group 1 is 11
    And the non-orphaned fulfilled capacity is 9
    When we prune excess fulfilled capacity to 10
    Then 0 instances should be killed
    And the log should contain "would take us under our target_capacity"

  Scenario: the killable instance can be pruned 
    Given a pool manager with 1 sfr resource group
    And the fulfilled capacity of resource group 1 is 11
    When we prune excess fulfilled capacity to 10
    Then 1 instance should be killed

  Scenario: don't kill stale instances until non-stale instances are up 
    Given a pool manager with 2 sfr resource groups
    And the fulfilled capacity of resource group 1 is 9
    And the fulfilled capacity of resource group 2 is 5
    And resource group 2 is stale
    When we prune excess fulfilled capacity to 11
    Then 3 instances should be killed
    And the killed instances are from resource group 2

  Scenario: don't kill everything when all resource groups are stale 
    Given a pool manager with 1 sfr resource group
    And the fulfilled capacity of resource group 1 is 9
    And resource group 1 is stale
    When we prune excess fulfilled capacity to 9
    Then 0 instances should be killed

  @skip
  Scenario: kill stale instances in an ASG 
    Given a pool manager with 1 asg resource group
    And the fulfilled capacity of resource group 1 is 10
    And we mark resource group 1 as stale
    And the fulfilled capacity of resource group 1 is 15
    And the non-orphaned fulfilled capacity is 15
    When we prune excess fulfilled capacity to 10
    Then 5 instances should be killed
    And the killed instances should be stale

Feature: make sure the MesosPoolManager is requesting the right capacities

  Scenario Outline: initialization at minimum capacity -- @1.1  
    Given a pool manager with 5 asg resource groups
    Then the resource groups should be at minimum capacity

  Scenario Outline: initialization at minimum capacity -- @1.2  
    Given a pool manager with 5 sfr resource groups
    Then the resource groups should be at minimum capacity

  Scenario Outline: balanced scale-up -- @1.1  
    Given a pool manager with 5 asg resource groups
    When we request 53 capacity
    Then the resource groups should have evenly-balanced capacity

  Scenario Outline: balanced scale-up -- @1.2  
    Given a pool manager with 5 sfr resource groups
    When we request 53 capacity
    Then the resource groups should have evenly-balanced capacity

  Scenario Outline: balanced scale-up with dry-run -- @1.1  
    Given a pool manager with 5 asg resource groups
    When we request 53 capacity and dry-run is active
    Then the resource group capacities should not change

  Scenario Outline: balanced scale-up with dry-run -- @1.2  
    Given a pool manager with 5 sfr resource groups
    When we request 53 capacity and dry-run is active
    Then the resource group capacities should not change

  Scenario Outline: balanced scale-up after external modification -- @1.1  
    Given a pool manager with 5 asg resource groups
    And the fulfilled capacity of resource group 1 is 13
    When we request 76 capacity
    Then the resource groups should have evenly-balanced capacity

  Scenario Outline: balanced scale-up after external modification -- @1.2  
    Given a pool manager with 5 sfr resource groups
    And the fulfilled capacity of resource group 1 is 13
    When we request 76 capacity
    Then the resource groups should have evenly-balanced capacity

  Scenario Outline: imbalanced scale-up -- @1.1  
    Given a pool manager with 5 asg resource groups
    And the fulfilled capacity of resource group 1 is 30
    When we request 1000 capacity
    Then the first resource group's capacity should not change
    And the remaining resource groups should have evenly-balanced capacity

  Scenario Outline: imbalanced scale-up -- @1.2  
    Given a pool manager with 5 sfr resource groups
    And the fulfilled capacity of resource group 1 is 30
    When we request 1000 capacity
    Then the first resource group's capacity should not change
    And the remaining resource groups should have evenly-balanced capacity

  Scenario Outline: balanced scale-down -- @1.1  
    Given a pool manager with 5 asg resource groups
    And we request 1000 capacity
    When we request 80 capacity
    Then the resource groups should have evenly-balanced capacity

  Scenario Outline: balanced scale-down -- @1.2  
    Given a pool manager with 5 sfr resource groups
    And we request 1000 capacity
    When we request 80 capacity
    Then the resource groups should have evenly-balanced capacity

  Scenario Outline: balanced scale-down with dry-run -- @1.1  
    Given a pool manager with 5 asg resource groups
    And we request 1000 capacity
    When we request 80 capacity and dry-run is active
    Then the resource group capacities should not change

  Scenario Outline: balanced scale-down with dry-run -- @1.2  
    Given a pool manager with 5 sfr resource groups
    And we request 1000 capacity
    When we request 80 capacity and dry-run is active
    Then the resource group capacities should not change

  Scenario Outline: imbalanced scale-down -- @1.1  
    Given a pool manager with 5 asg resource groups
    And we request 1000 capacity
    And the fulfilled capacity of resource group 1 is 1
    When we request 22 capacity
    Then the first resource group's capacity should not change
    And the remaining resource groups should have evenly-balanced capacity

  Scenario Outline: imbalanced scale-down -- @1.2  
    Given a pool manager with 5 sfr resource groups
    And we request 1000 capacity
    And the fulfilled capacity of resource group 1 is 1
    When we request 22 capacity
    Then the first resource group's capacity should not change
    And the remaining resource groups should have evenly-balanced capacity

  Scenario: one sfr is broken 
    Given a pool manager with 5 sfr resource groups
    When resource group 1 is broken
    And we request 100 capacity
    Then the first resource group's capacity should not change
    And the remaining resource groups should have evenly-balanced capacity
    And the log should contain "resource group is broken"

  @skip
  Scenario Outline: An ASG is marked stale -- @1.1  
    Given a pool manager with 1 asg resource group
    When we request 10 capacity
    And we mark resource group 1 as stale
    And we request 10 capacity
    Then resource group 1 should have 20 instances

  @skip
  Scenario Outline: An ASG is marked stale -- @1.2  
    Given a pool manager with 1 asg resource group
    When we request 10 capacity
    And we mark resource group 1 as stale
    And we request 5 capacity
    Then resource group 1 should have 15 instances

Feature: make sure we're computing spot prices correctly

  Scenario: one instance with constant price 
    Given market A has 1 instance at time 0
    And market A costs $1/hour at time 0
    When the simulator runs for 2 hours
    Then the simulated cluster costs $2 total

  Scenario: one instance with price increase 
    Given market A has 1 instance at time 0
    And market A costs $1/hour at time 0
    And market A costs $2/hour at time 1800
    When the simulator runs for 2 hours
    Then the simulated cluster costs $3 total

  Scenario: two instances in the same market are launched at the same time 
    Given market A has 2 instances at time 0
    And market A costs $1/hour at time 0
    And market A costs $2/hour at time 1800
    When the simulator runs for 2 hours
    Then the simulated cluster costs $6 total

  Scenario: two instances in the same market are launched at different times 
    Given market A has 1 instances at time 0
    And market A has 2 instances at time 1800
    And market A costs $1/hour at time 0
    And market A costs $2/hour at time 1200
    When the simulator runs for 2 hours
    Then the simulated cluster costs $6 total

  Scenario: two instances in different markets are launched at different times 
    Given market A has 1 instance at time 0
    And market B has 1 instance at time 1800
    And market A costs $1/hour at time 0
    And market A costs $2/hour at time 1200
    And market B costs $0.50/hour at time 0
    And market B costs $0.75/hour at time 4500
    When the simulator runs for 2 hours
    Then the simulated cluster costs $3.875 total

  Scenario: (per-hour billing) two instances in different markets are launched at diff. times and one is terminated 
    Given market A has 1 instance at time 0
    And market B has 1 instance at time 1920
    And market B has 0 instances at time 5400
    And market A costs $1/hour at time 0
    And market A costs $2/hour at time 1800
    And market B costs $0.50/hour at time 0
    And market B costs $0.75/hour at time 4500
    When the simulator runs for 2 hours
    Then the simulated cluster costs $3.5 total

  Scenario: (per-sec billing) two instances in different markets are launched at diff. times and one is terminated 
    Given market A has 1 instance at time 0
    And market B has 1 instance at time 1920
    And market B has 0 instances at time 5400
    And market A costs $1/hour at time 0
    And market A costs $2/hour at time 1800
    And market B costs $0.50/hour at time 0
    And market B costs $0.75/hour at time 4500
    When the simulator runs for 2 hours and billing is per-second
    Then the simulated cluster costs $4.05 total

Feature: make sure the simulator join-delay params work correctly

  Scenario Outline: instances should wait to join the cluster -- @1.1  
    Given market A has 1 instance at time 0
    When the instance takes 0 seconds to join
    And the simulator runs for 2 hours
    Then the instance start time should be 0
    And the instance join time should be 0

  Scenario Outline: instances should wait to join the cluster -- @1.2  
    Given market A has 1 instance at time 0
    When the instance takes 300 seconds to join
    And the simulator runs for 2 hours
    Then the instance start time should be 0
    And the instance join time should be 300

  Scenario: instances should join the cluster immediate if the override is set 
    Given market A has 1 instance at time 0
    When the instance takes 300 seconds to join
    And the join-delay override flag is set
    And the simulator runs for 2 hours
    Then the instance start time should be 0
    And the instance join time should be 0

  Scenario: the instance is terminated before it joins 
    Given market A has 1 instance at time 0
    And market A has 0 instances at time 120
    When the instance takes 300 seconds to join
    And the simulator runs for 2 hours
    Then no instances should join the Mesos cluster

  Scenario: the instance is terminated after it joins 
    Given market A has 1 instance at time 0
    And market A has 0 instances at time 1800
    When the instance takes 300 seconds to join
    And the simulator runs for 2 hours
    Then instances should join the Mesos cluster

Feature: make sure simulated spot fleets diversify properly

  Scenario Outline: the simulated spot fleet should be diversified -- @1.1  
    Given a simulated spot fleet resource group
    When we request 200 target capacity
    Then the simulated spot fleet should be diversified
    And the fulfilled capacity should be above the target capacity

  Scenario Outline: the simulated spot fleet should be diversified -- @1.2  
    Given a simulated spot fleet resource group
    When we request 750 target capacity
    Then the simulated spot fleet should be diversified
    And the fulfilled capacity should be above the target capacity

  Scenario Outline: the simulated spot fleet should be diversified -- @1.3  
    Given a simulated spot fleet resource group
    When we request 1500 target capacity
    Then the simulated spot fleet should be diversified
    And the fulfilled capacity should be above the target capacity

  Scenario Outline: the simulated spot fleet should refill empty markets -- @1.1  
    Given a simulated spot fleet resource group
    When capacity in one market drops
    And we request 100 target capacity
    Then the spot fleet should have no instances from the empty market
    And the fulfilled capacity should be above the target capacity

  Scenario Outline: the simulated spot fleet should refill empty markets -- @1.2  
    Given a simulated spot fleet resource group
    When capacity in one market drops
    And we request 1000 target capacity
    Then the spot fleet should have no instances from the empty market
    And the fulfilled capacity should be above the target capacity

  Scenario Outline: the simulated spot fleet should not fill markets that are over their target -- @1.1  
    Given a simulated spot fleet resource group
    When capacity in one market is high
    And we request 100 target capacity
    Then the spot fleet should not add instances from the high market
    And the fulfilled capacity should be above the target capacity

  Scenario Outline: the simulated spot fleet should not fill markets that are over their target -- @1.2  
    Given a simulated spot fleet resource group
    When capacity in one market is high
    And we request 500 target capacity
    Then the spot fleet should not add instances from the high market
    And the fulfilled capacity should be above the target capacity

7 features passed, 0 failed, 0 skipped
67 scenarios passed, 0 failed, 3 skipped
412 steps passed, 0 failed, 18 skipped, 0 undefined
Took 0m28.918s
yelp run-test: commands[5] | coverage report --show-missing --skip-covered --fail-under=70
Name                                                          Stmts   Miss Branch BrPart  Cover   Missing
---------------------------------------------------------------------------------------------------------
clusterman/args.py                                               28      2      8      2    89%   55, 187, 54->55, 183->187
clusterman/autoscaler/autoscaler.py                             195     14     62      7    91%   104-105, 148, 159-170, 173, 184-185, 213-214, 403, 102->104, 158->159, 172->173, 179->187, 189->exit, 211->213, 402->403
clusterman/autoscaler/pool_manager.py                           274     27    145     12    87%   85-92, 95-99, 103, 138, 148, 212, 222-234, 333, 458-459, 565, 78->exit, 102->103, 137->138, 147->148, 164->166, 248->250, 332->333, 434->443, 443->448, 445->448, 454->457, 457->458
clusterman/aws/auto_scaling_resource_group.py                   141      8     50      3    91%   77, 141, 268, 305-319, 71->77, 140->141, 304->305
clusterman/aws/aws_resource_group.py                            121      5     38      1    94%   106-108, 208-209, 105->106
clusterman/aws/client.py                                         61     10     16      2    82%   89, 138-146, 64->exit, 88->89
clusterman/aws/markets.py                                        50      4      6      1    91%   53, 57-58, 380, 377->380
clusterman/aws/spot_fleet_resource_group.py                     119     13     36      5    87%   81-82, 94, 110-114, 120, 144, 171, 195-197, 225, 93->94, 119->120, 143->144, 163->171, 224->225
clusterman/cli/generate_data.py                                  69     69     26      0     0%   14-184
clusterman/cli/info.py                                            8      8      0      0     0%   14-45
clusterman/cli/manage.py                                         59      1     20      3    95%   95, 89->93, 94->95, 98->93
clusterman/cli/simulate.py                                      110     51     36      2    49%   54-58, 62-72, 76-85, 95-115, 119-137, 141-155, 164-175, 211, 214-218, 210->211, 213->214
clusterman/cli/status.py                                        114    114     23      0     0%   14-257
clusterman/cli/toggle.py                                         54      7     12      4    80%   75, 90-102, 58->62, 62->65, 74->75, 79->83
clusterman/cli/util.py                                           18      4      2      0    70%   16-19
clusterman/common/sfx.py                                         54     30     23      2    36%   37, 42-48, 62-65, 75, 96-130, 162-172, 36->37, 74->75
clusterman/config.py                                             51     12     18      2    71%   27-37, 83, 70->73, 82->83
clusterman/draining/mesos.py                                    120     29     26      2    77%   40, 48, 58, 83-99, 104-110, 125-126, 140-141, 157-158, 188, 57->58, 187->188
clusterman/draining/queue.py                                    225     17     62      7    92%   241-242, 246-247, 273-274, 278-279, 342-343, 377-378, 384-385, 412, 414, 424, 168->188, 277->278, 298->exit, 341->342, 379->387, 411->412, 413->414
clusterman/interfaces/cluster_connector.py                       43      9     10      1    70%   55, 87-90, 94-95, 108-113, 104->108
clusterman/interfaces/resource_group.py                          40      3      0      0    92%   82, 87, 105
clusterman/interfaces/signal.py                                  56      1     18      3    95%   73, 72->73, 128->134, 134->137
clusterman/kubernetes/kubernetes_cluster_connector.py           178     22     88     13    85%   84-87, 127-134, 180, 203-207, 242, 261-262, 270, 275, 280, 286, 151->156, 152->151, 158->169, 161->163, 179->180, 200->203, 241->242, 260->261, 269->270, 274->275, 279->280, 283->286, 284->283
clusterman/kubernetes/util.py                                    95      1     33      4    96%   138, 55->57, 135->138, 136->135, 166->165
clusterman/math/piecewise.py                                    149      4     52      1    97%   232-235, 294->290
clusterman/math/piecewise_types.py                               21      8      0      0    62%   24, 27, 32, 35, 38, 41, 44, 47
clusterman/mesos/mesos_cluster_connector.py                      73     13     22      0    82%   63-68, 77-78, 120-127
clusterman/mesos/metrics_generators.py                           34      3     25      5    83%   85-87, 45->exit, 45->exit, 45->exit, 45->exit, 45->exit
clusterman/mesos/util.py                                         58      1      2      1    97%   97, 96->97
clusterman/monitoring_lib.py                                     76     21      0      0    72%   27-28, 35, 40, 45, 48, 77, 81, 85, 90-91, 94-95, 100, 103, 108, 111, 114, 120, 124, 128
clusterman/reports/data_transforms.py                            42     38     18      0     7%   28-55, 72-94
clusterman/reports/plots.py                                      78     51     14      1    30%   47-81, 85-121, 126-159, 163-172, 43->exit
clusterman/reports/report_types.py                                6      1     18     17    25%   33, 36->exit, 36->exit, 36->exit, 36->exit, 36->exit, 36->exit, 36->exit, 36->exit, 36->exit, 36->exit, 36->exit, 36->exit, 36->exit, 36->exit, 36->exit, 36->exit, 36->exit
clusterman/reports/reports.py                                    92     66     22      0    23%   57-69, 73-85, 96, 107-132, 136-141, 157-195
clusterman/run.py                                                18     18      6      0     0%   14-39
clusterman/signals/external_signal.py                           101      6     14      2    93%   155-162, 168->174, 179->193
clusterman/signals/pending_pods_signal.py                        33      7      8      0    78%   52-53, 60-67
clusterman/simulator/event.py                                    43     19      6      0    49%   43, 50, 56, 59, 70-72, 75-82, 85, 94-95, 98-99
clusterman/simulator/io.py                                       38      5      8      0    80%   23, 27, 41-42, 45
clusterman/simulator/simulated_cluster_connector.py              32      4     12      1    89%   32, 35, 42, 48, 41->42
clusterman/simulator/simulated_pool_manager.py                   42     23     10      0    37%   40-52, 55, 61-83, 87
clusterman/simulator/simulated_spot_fleet_resource_group.py      97      3     34      2    96%   134, 216, 245, 133->134, 151->153
clusterman/simulator/simulator.py                               194     65     58      4    63%   95-98, 122, 126-141, 166, 265-302, 313-314, 317-318, 321-322, 325-326, 329-338, 342-362, 82->exit, 94->95, 118->122, 165->166
clusterman/simulator/util.py                                      4      1      0      0    75%   19
clusterman/tools/dynamodb_rename.py                              45     45     17      0     0%   14-102
clusterman/tools/rookout.py                                       6      4      2      0    25%   19-23
clusterman/tools/signalfx_scraper.py                             51      7     16      2    78%   36-42, 54, 35->36, 53->54
clusterman/util.py                                              202     34     50      4    83%   115, 119, 125-143, 147-152, 156-161, 244, 264-269, 420, 114->115, 118->119, 243->244, 417->420
---------------------------------------------------------------------------------------------------------
TOTAL                                                          4038    908   1210    116    75%

22 files skipped due to complete coverage.
yelp run-test: commands[6] | pre-commit install -f --install-hooks
pre-commit installed at .git/hooks/pre-commit
yelp run-test: commands[7] | pre-commit run --all-files
Trim Trailing Whitespace.................................................Passed
Fix End of Files.........................................................Passed
Check Yaml...............................................................Passed
Debug Statements (Python)................................................Passed
Tests should end in _test.py.............................................Passed
Check for added large files..............................................Passed
Check for byte-order marker..............................................Passed
Fix python encoding pragma...............................................Passed
Flake8...................................................................Passed
Reorder python imports...................................................Passed
pyupgrade................................................................Passed
black....................................................................Passed
________________________________________________________________________________________ summary ________________________________________________________________________________________
  yelp: commands succeeded
  congratulations :)

```

