### PR TITLE
Race Condition in node pruning 2

### DIFF
--- a/clusterman/autoscaler/pool_manager.py
+++ b/clusterman/autoscaler/pool_manager.py
@@ -444,6 +444,7 @@ class PoolManager:
             self.cluster_connector.freeze_agent(node_metadata.agent)
 
             task_count_realtime = self.cluster_connector.get_task_count_realtime(node_metadata.agent)
+            #node_metadata.agent.task_count = task_count_realtime not sure yet
             if killed_task_count + task_count_realtime > self.max_tasks_to_kill:  # case 4
                 logger.info(
                     f"Killing instance {instance_id} with {task_count_realtime} tasks (realtime) would take us "

--- a/clusterman/autoscaler/pool_manager.py
+++ b/clusterman/autoscaler/pool_manager.py
@@ -423,8 +423,6 @@ class PoolManager:
                 logger.info(f"Resource group {group_id} is at target capacity; skipping {instance_id}")
                 continue
 
-            task_count_realtime = self.cluster_connector.get_task_count_realtime(node_metadata.agent)
-
             if (
                 killed_task_count + node_metadata.agent.task_count > self.max_tasks_to_kill or
                 killed_task_count + self.cluster_connector.get_task_count_realtime(

--- a/clusterman/autoscaler/pool_manager.py
+++ b/clusterman/autoscaler/pool_manager.py
@@ -423,7 +423,8 @@ class PoolManager:
                 logger.info(f"Resource group {group_id} is at target capacity; skipping {instance_id}")
                 continue
 
-            if killed_task_count + node_metadata.agent.task_count > self.max_tasks_to_kill:  # case 2
+            task_count_realtime = self.cluster_connector.get_task_count_realtime(node_metadata.agent)
+            if killed_task_count + task_count_realtime > self.max_tasks_to_kill:  # case 2
                 logger.info(
                     f"Killing instance {instance_id} with {node_metadata.agent.task_count} tasks would take us "
                     f"over our max_tasks_to_kill of {self.max_tasks_to_kill}. Skipping this instance."
@@ -439,6 +440,7 @@ class PoolManager:
                     continue
 
             logger.info(f"marking {instance_id} for termination")
+            #TODO taint node - noschedule ---
             marked_nodes[group_id].append(node_metadata)
             rem_group_capacities[group_id] -= instance_weight
             curr_capacity -= instance_weight

--- a/clusterman/autoscaler/pool_manager.py
+++ b/clusterman/autoscaler/pool_manager.py
@@ -452,6 +452,7 @@ class PoolManager:
                         f"Killing instance {instance_id} with {task_count_realtime} tasks  would take us "
                         f"over our max_tasks_per_node_to_kill of {self.max_tasks_per_node_to_kill}. Skipping this instance."
                     )
+                    # not sure if we need unfreeze or not, maybe it should be terminated in next try.
                     logger.info(f"unfreezing {instance_id} for termination")
                     self.cluster_connector.unfreeze_agent(node_metadata.agent)
                     continue

--- a/clusterman/autoscaler/pool_manager.py
+++ b/clusterman/autoscaler/pool_manager.py
@@ -406,7 +406,8 @@ class PoolManager:
             #  1) The resource group the node belongs to can't be reduced further.
             #  2) Killing the node's tasks would take over the maximum number of tasks we are willing to kill.
             #  3) Killing the node would bring us under our target_capacity of non-orphaned nodes.
-            #  4) agent.task_count may be outdated date (case 3), and pods may be terminated unintentionally.
+            #  4) Killing the node's tasks would take over the maximum number of tasks per node we are willing to kill.
+            #     But agent.task_count may be outdated date, and pods may be terminated unintentionally.
             #     Therefore, double-checking task count from kube-api to avoid that case.
             # In each of the cases, the node has been removed from consideration and we jump to the next iteration.
 

--- a/clusterman/autoscaler/pool_manager.py
+++ b/clusterman/autoscaler/pool_manager.py
@@ -424,7 +424,13 @@ class PoolManager:
                 continue
 
             task_count_realtime = self.cluster_connector.get_task_count_realtime(node_metadata.agent)
-            if killed_task_count + task_count_realtime > self.max_tasks_to_kill:  # case 2
+
+            if (
+                killed_task_count + node_metadata.agent.task_count > self.max_tasks_to_kill or
+                killed_task_count + self.cluster_connector.get_task_count_realtime(
+                    node_metadata.agent) > self.max_tasks_to_kill
+            ):  # case 2
+                # fix log to write correct count
                 logger.info(
                     f"Killing instance {instance_id} with {node_metadata.agent.task_count} tasks would take us "
                     f"over our max_tasks_to_kill of {self.max_tasks_to_kill}. Skipping this instance."
@@ -440,7 +446,9 @@ class PoolManager:
                     continue
 
             logger.info(f"marking {instance_id} for termination")
-            #TODO taint node - noschedule ---
+
+            self.cluster_connector.freeze_agent(node_metadata.agent)
+
             marked_nodes[group_id].append(node_metadata)
             rem_group_capacities[group_id] -= instance_weight
             curr_capacity -= instance_weight

--- a/clusterman/autoscaler/pool_manager.py
+++ b/clusterman/autoscaler/pool_manager.py
@@ -440,18 +440,20 @@ class PoolManager:
                     )
                     continue
 
+            logger.info(f"freezing {instance_id} for termination")
+            self.cluster_connector.freeze_agent(node_metadata.agent)
+
             task_count_realtime = self.cluster_connector.get_task_count_realtime(node_metadata.agent)
             if killed_task_count + task_count_realtime > self.max_tasks_to_kill:  # case 4
                 logger.info(
                     f"Killing instance {instance_id} with {task_count_realtime} tasks (realtime) would take us "
                     f"over our max_tasks_to_kill of {self.max_tasks_to_kill}. Skipping this instance."
                 )
+                logger.info(f"unfreezing {instance_id} for termination")
+                self.cluster_connector.unfreeze_agent(node_metadata.agent)
                 continue
 
             logger.info(f"marking {instance_id} for termination")
-
-            self.cluster_connector.freeze_agent(node_metadata.agent)
-
             marked_nodes[group_id].append(node_metadata)
             rem_group_capacities[group_id] -= instance_weight
             curr_capacity -= instance_weight

--- a/clusterman/autoscaler/pool_manager.py
+++ b/clusterman/autoscaler/pool_manager.py
@@ -444,16 +444,17 @@ class PoolManager:
             logger.info(f"freezing {instance_id} for termination")
             self.cluster_connector.freeze_agent(node_metadata.agent)
 
-            task_count_realtime = self.cluster_connector.get_task_count_realtime(node_metadata.agent)
-            #node_metadata.agent.task_count = task_count_realtime not sure yet
-            if task_count_realtime > self.max_tasks_per_node_to_kill:  # case 4
-                logger.info(
-                    f"Killing instance {instance_id} with {task_count_realtime} tasks  would take us "
-                    f"over our max_tasks_per_node_to_kill of {self.max_tasks_per_node_to_kill}. Skipping this instance."
-                )
-                logger.info(f"unfreezing {instance_id} for termination")
-                self.cluster_connector.unfreeze_agent(node_metadata.agent)
-                continue
+            if self.max_tasks_per_node_to_kill != float("inf"):
+                task_count_realtime = self.cluster_connector.get_task_count_realtime(node_metadata.agent)
+                #node_metadata.agent.task_count = task_count_realtime not sure yet
+                if task_count_realtime > self.max_tasks_per_node_to_kill:  # case 4
+                    logger.info(
+                        f"Killing instance {instance_id} with {task_count_realtime} tasks  would take us "
+                        f"over our max_tasks_per_node_to_kill of {self.max_tasks_per_node_to_kill}. Skipping this instance."
+                    )
+                    logger.info(f"unfreezing {instance_id} for termination")
+                    self.cluster_connector.unfreeze_agent(node_metadata.agent)
+                    continue
 
             logger.info(f"marking {instance_id} for termination")
             marked_nodes[group_id].append(node_metadata)

--- a/clusterman/interfaces/cluster_connector.py
+++ b/clusterman/interfaces/cluster_connector.py
@@ -46,6 +46,12 @@ class ClusterConnector(metaclass=ABCMeta):
             return AgentMetadata()
         return self._get_agent_metadata(ip_address)
 
+    def get_task_count_realtime(self, agent: Optional[AgentMetadata]) -> int:
+        #TODO add description here
+        if not agent:
+            return 0
+        return self._get_task_count_realtime(agent)
+
     @abstractmethod
     def get_resource_allocation(self, resource_name: str) -> float:  # pragma: no cover
         """Get the total amount of the given resource currently allocated for this pool.
@@ -88,6 +94,10 @@ class ClusterConnector(metaclass=ABCMeta):
 
     @abstractmethod
     def _get_agent_metadata(self, ip_address: str) -> AgentMetadata:  # pragma: no cover
+        pass
+
+    @abstractmethod
+    def _get_task_count_realtime(self, agent: AgentMetadata) -> int:
         pass
 
     @staticmethod

--- a/clusterman/interfaces/cluster_connector.py
+++ b/clusterman/interfaces/cluster_connector.py
@@ -57,6 +57,11 @@ class ClusterConnector(metaclass=ABCMeta):
         if agent:
             self._freeze_agent(agent)
 
+    def unfreeze_agent(self, agent: Optional[AgentMetadata]) -> None:
+        #TODO add description here
+        if agent:
+            self._unfreeze_agent(agent)
+
     @abstractmethod
     def get_resource_allocation(self, resource_name: str) -> float:  # pragma: no cover
         """Get the total amount of the given resource currently allocated for this pool.
@@ -107,6 +112,10 @@ class ClusterConnector(metaclass=ABCMeta):
 
     @abstractmethod
     def _freeze_agent(self, agent: AgentMetadata) -> None:
+        pass
+
+    @abstractmethod
+    def _unfreeze_agent(self, agent: AgentMetadata) -> None:
         pass
 
     @staticmethod

--- a/clusterman/interfaces/cluster_connector.py
+++ b/clusterman/interfaces/cluster_connector.py
@@ -52,6 +52,11 @@ class ClusterConnector(metaclass=ABCMeta):
             return 0
         return self._get_task_count_realtime(agent)
 
+    def freeze_agent(self, agent: Optional[AgentMetadata]) -> None:
+        #TODO add description here
+        if agent:
+            self._freeze_agent(agent)
+
     @abstractmethod
     def get_resource_allocation(self, resource_name: str) -> float:  # pragma: no cover
         """Get the total amount of the given resource currently allocated for this pool.
@@ -98,6 +103,10 @@ class ClusterConnector(metaclass=ABCMeta):
 
     @abstractmethod
     def _get_task_count_realtime(self, agent: AgentMetadata) -> int:
+        pass
+
+    @abstractmethod
+    def _freeze_agent(self, agent: AgentMetadata) -> None:
         pass
 
     @staticmethod

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -254,6 +254,14 @@ class KubernetesClusterConnector(ClusterConnector):
     def _freeze_agent(self, agent: AgentMetadata) -> None:
         body = {
             "spec": {
+                "unschedulable": True
+            }
+        }
+        self._core_api.patch_node(agent.agent_id, body)
+
+    def _unfreeze_agent(self, agent: AgentMetadata) -> None:
+        body = {
+            "spec": {
                 "unschedulable": False
             }
         }

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -241,6 +241,10 @@ class KubernetesClusterConnector(ClusterConnector):
                     break
         return count
 
+    def _get_task_count_realtime(self, agent: AgentMetadata) -> int:
+        # TODO should be implemented: describe node and get information here if possible
+        return 0
+
     @property
     def pool_label_key(self):
         return self.pool_config.read_string("pool_label_key", default="clusterman.com/pool")

--- a/clusterman/mesos/mesos_cluster_connector.py
+++ b/clusterman/mesos/mesos_cluster_connector.py
@@ -129,3 +129,6 @@ class MesosClusterConnector(ClusterConnector):
 
     def _get_task_count_realtime(self, agent: AgentMetadata) -> int:
         return agent.task_count
+
+    def _freeze_agent(self, agent: AgentMetadata) -> None:
+        return

--- a/clusterman/mesos/mesos_cluster_connector.py
+++ b/clusterman/mesos/mesos_cluster_connector.py
@@ -126,3 +126,6 @@ class MesosClusterConnector(ClusterConnector):
         """If the framework matches any of the prefixes in self.non_batch_framework_prefixes
         this will return False, otherwise we assume the task to be a batch task"""
         return not any([framework_name.startswith(prefix) for prefix in self.non_batch_framework_prefixes])
+
+    def _get_task_count_realtime(self, agent: AgentMetadata) -> int:
+        return agent.task_count

--- a/clusterman/mesos/mesos_cluster_connector.py
+++ b/clusterman/mesos/mesos_cluster_connector.py
@@ -132,3 +132,6 @@ class MesosClusterConnector(ClusterConnector):
 
     def _freeze_agent(self, agent: AgentMetadata) -> None:
         return
+
+    def _unfreeze_agent(self, agent: AgentMetadata) -> None:
+        return

--- a/clusterman/simulator/simulated_cluster_connector.py
+++ b/clusterman/simulator/simulated_cluster_connector.py
@@ -64,3 +64,6 @@ class SimulatedClusterConnector(ClusterConnector):
 
     def _get_task_count_realtime(self, agent: AgentMetadata) -> int:
         return agent.task_count
+
+    def _freeze_agent(self, agent: AgentMetadata) -> None:
+        return

--- a/clusterman/simulator/simulated_cluster_connector.py
+++ b/clusterman/simulator/simulated_cluster_connector.py
@@ -67,3 +67,6 @@ class SimulatedClusterConnector(ClusterConnector):
 
     def _freeze_agent(self, agent: AgentMetadata) -> None:
         return
+
+    def _unfreeze_agent(self, agent: AgentMetadata) -> None:
+        return

--- a/clusterman/simulator/simulated_cluster_connector.py
+++ b/clusterman/simulator/simulated_cluster_connector.py
@@ -61,3 +61,6 @@ class SimulatedClusterConnector(ClusterConnector):
 
         # if we don't know the given IP then it's orphaned
         return AgentMetadata(state=AgentState.ORPHANED)
+
+    def _get_task_count_realtime(self, agent: AgentMetadata) -> int:
+        return agent.task_count


### PR DESCRIPTION
Description
We have race condition issue while node pruning.

Clusterman try to get pod count in node and then terminate
Kube scheduler schedule new pod after Clusterman getting pod count
https://jira.yelpcorp.com/browse/CLUSTERMAN-642

Testing Done
Please fill out! Generally speaking any new features should include
additional unit or integration tests to ensure the behaviour is
working correctly.