### PR TITLE
Deciding source for packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,20 @@ DOCKER_TAG ?= ${PKG_NAME}-dev-$(USER)
 VIRTUALENV_RUN_TARGET = virtualenv_run-dev
 VIRTUALENV_RUN_REQUIREMENTS = requirements.txt requirements-dev.txt
 ifeq ($(findstring .yelpcorp.com,$(shell hostname -f)), .yelpcorp.com)
+	PAASTA_ENV ?= YELP
+else
+	PAASTA_ENV ?= $(shell hostname --fqdn)
+endif
+
+ifeq ($(PAASTA_ENV),YELP)
+	export PIP_INDEX_URL ?= https://pypi.yelpcorp.com/simple
+	export NPM_CONFIG_REGISTRY ?= https://npm.yelpcorp.com/
 	export DOCKER_REGISTRY ?= docker-dev.yelpcorp.com
 	export XENIAL_IMAGE_NAME ?= xenial_pkgbuild
 	export BIONIC_IMAGE_NAME ?= bionic_pkgbuild
 else
+	export PIP_INDEX_URL ?= https://pypi.python.org/simple
+	export NPM_CONFIG_REGISTRY ?= https://registry.npmjs.org
 	export DOCKER_REGISTRY ?= docker.io
 	export XENIAL_IMAGE_NAME ?= ubuntu:xenial
 	export BIONIC_IMAGE_NAME ?= ubuntu:bionic

--- a/jenkins.yaml
+++ b/jenkins.yaml
@@ -6,6 +6,8 @@ types: [paasta, debian]
 overrides:
   paasta:
     chatChannels: ['#clusterman']
+    globalEnvVars:
+      PAASTA_ENV: YELP
   debian:
     platforms: [xenial, bionic]
 host_type: bionic


### PR DESCRIPTION
jenkins jobs were migrated to k8s, therefore we can not check hostname to decide package source.