### PR TITLE
Pending phase pods are splitted

### DIFF
--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -73,6 +73,7 @@ class KubernetesClusterConnector(ClusterConnector):
         # store the previous _nodes_by_ip for use in get_removed_nodes_before_last_reload()
         self._prev_nodes_by_ip = copy.deepcopy(self._nodes_by_ip)
         self._nodes_by_ip = self._get_nodes_by_ip()
+        logger.info("Reloading pods")
         (
             self._pods_by_ip,
             self._unschedulable_pods,
@@ -243,6 +244,8 @@ class KubernetesClusterConnector(ClusterConnector):
                     pods_by_ip[pod.status.host_ip].append(pod)
                 elif self._is_unschedulable(pod):
                     unschedulable_pods.append(pod)
+                else:
+                    logger.info(f"Skipping {pod.metadata.name} pod ({pod.status.phase})")
         return pods_by_ip, unschedulable_pods, excluded_pods_by_ip
 
     def _count_batch_tasks(self, node_ip: str) -> int:

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -239,9 +239,9 @@ class KubernetesClusterConnector(ClusterConnector):
             if self._pod_belongs_to_pool(pod):
                 if exclude_daemonset_pods and self._pod_belongs_to_daemonset(pod):
                     excluded_pods_by_ip[pod.status.host_ip].append(pod)
-                elif pod.status.phase == "Running" or self._is_pod_scheduled(pod):
+                elif pod.status.phase == "Running" or self._is_recently_scheduled(pod):
                     pods_by_ip[pod.status.host_ip].append(pod)
-                elif self._is_pod_unschedulable(pod):
+                elif self._is_unschedulable(pod):
                     pending_pods.append(pod)
         return pods_by_ip, pending_pods, excluded_pods_by_ip
 
@@ -256,10 +256,10 @@ class KubernetesClusterConnector(ClusterConnector):
                     break
         return count
 
-    def _is_pod_scheduled(self, pod: KubernetesPod) -> bool:
+    def _is_recently_scheduled(self, pod: KubernetesPod) -> bool:
         # To find pods which in pending phase but already scheduled to the node.
         # The phase of these nodes is changed to running asap,
-        # Therefore, we should consider these nodes for our next steps.
+        # Therefore, we should consider these pods for our next steps.
         if pod.status.phase != "Pending":
             return False
         if not pod.status or not pod.status.conditions:
@@ -269,7 +269,7 @@ class KubernetesClusterConnector(ClusterConnector):
                 return True
         return False
 
-    def _is_pod_unschedulable(self, pod: KubernetesPod) -> bool:
+    def _is_unschedulable(self, pod: KubernetesPod) -> bool:
         if pod.status.phase != "Pending":
             return False
         if not pod.status or not pod.status.conditions:

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -264,6 +264,7 @@ class KubernetesClusterConnector(ClusterConnector):
         for condition in pod.status.conditions:
             if condition.type == "PodScheduled" and condition.status == 'True':
                 return True
+        return False
 
     def _is_pod_unschedulable(self, pod: KubernetesPod) -> bool:
         if pod.status.phase != "Pending":

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -273,6 +273,7 @@ class KubernetesClusterConnector(ClusterConnector):
         for condition in pod.status.conditions:
             if condition.type == "PodScheduled" and condition.reason == "Unschedulable":
                 return True
+        return False
 
     @property
     def pool_label_key(self):

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -258,7 +258,7 @@ class KubernetesClusterConnector(ClusterConnector):
 
     def _is_recently_scheduled(self, pod: KubernetesPod) -> bool:
         # To find pods which in pending phase but already scheduled to the node.
-        # The phase of these nodes is changed to running asap,
+        # The phase of these pods is changed to running asap,
         # Therefore, we should consider these pods for our next steps.
         if pod.status.phase != "Pending":
             return False

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -75,9 +75,9 @@ class KubernetesClusterConnector(ClusterConnector):
         self._nodes_by_ip = self._get_nodes_by_ip()
         (
             self._pods_by_ip,
-            self._unschedulable_pending_pods,
+            self._pending_pods,
             self._excluded_pods_by_ip,
-        ) = self._get_pods_information()
+        ) = self._get_pods_by_ip_or_pending()
 
     def get_num_removed_nodes_before_last_reload(self) -> int:
         previous_nodes = self._prev_nodes_by_ip
@@ -118,7 +118,7 @@ class KubernetesClusterConnector(ClusterConnector):
         self,
     ) -> List[Tuple[KubernetesPod, PodUnschedulableReason]]:
         unschedulable_pods = []
-        for pod in self._unschedulable_pending_pods:
+        for pod in self._pending_pods:
             unschedulable_pods.append((pod, self._get_pod_unschedulable_reason(pod)))
         return unschedulable_pods
 
@@ -223,7 +223,7 @@ class KubernetesClusterConnector(ClusterConnector):
             if not self.pool or node.metadata.labels.get(pool_label_selector, None) == self.pool
         }
 
-    def _get_pods_information(
+    def _get_pods_by_ip_or_pending(
         self,
     ) -> Tuple[Mapping[str, List[KubernetesPod]], List[KubernetesPod], Mapping[str, List[KubernetesPod]],]:
         pods_by_ip: Mapping[str, List[KubernetesPod]] = defaultdict(list)

--- a/itests/steps/autoscaler.py
+++ b/itests/steps/autoscaler.py
@@ -283,7 +283,7 @@ def create_k8s_autoscaler(context, prevent_scale_down_after_capacity_loss=False)
     context.mock_cluster_connector.get_cluster_allocated_resources.return_value = ClustermanResources(
         cpus=context.allocated_cpus,
     )
-    context.mock_cluster_connector._pending_pods = []
+    context.mock_cluster_connector._unschedulable_pods = []
     if float(context.pending_cpus) > 0:
         context.mock_cluster_connector.get_unschedulable_pods = (
             lambda: KubernetesClusterConnector.get_unschedulable_pods(context.mock_cluster_connector)  # noqa
@@ -293,7 +293,7 @@ def create_k8s_autoscaler(context, prevent_scale_down_after_capacity_loss=False)
             if pod.metadata.name == "pod1"
             else PodUnschedulableReason.Unknown
         )
-        context.mock_cluster_connector._pending_pods = [
+        context.mock_cluster_connector._unschedulable_pods = [
             V1Pod(
                 metadata=V1ObjectMeta(name="pod1"),
                 status=V1PodStatus(


### PR DESCRIPTION
### Description

CLUSTERMAN-642
We use only "Running" pods for all considerations like: task_count (node), resource allocation (pool, node), definition of state (node), and etc.

We should consider Pending pods which already assigned to node, Because this pods will running asap. 