### PR TITLE
Kubernetes draining feature

### DIFF
--- a/clusterman/autoscaler/pool_manager.py
+++ b/clusterman/autoscaler/pool_manager.py
@@ -25,6 +25,7 @@ from typing import Sequence
 from typing import Tuple
 from typing import Type
 
+import arrow
 import colorlog
 import staticconf
 from kubernetes.client.models.v1_pod import V1Pod as KubernetesPod
@@ -196,6 +197,9 @@ class PoolManager:
                                 self.resource_groups[group_id].__class__,
                             ),
                             scheduler=self.scheduler,
+                            pool=self.pool,
+                            agent_id=node_metadata.agent.agent_id,
+                            draining_start_time=arrow.now(),
                         )
             else:
                 for group_id, node_metadatas in marked_nodes_by_group.items():

--- a/clusterman/draining/kubernetes.py
+++ b/clusterman/draining/kubernetes.py
@@ -1,0 +1,35 @@
+from typing import Optional
+
+import colorlog
+
+from clusterman.kubernetes.kubernetes_cluster_connector import KubernetesClusterConnector
+
+log = colorlog.getLogger(__name__)
+
+
+def drain(connector: Optional[KubernetesClusterConnector], agent_id: str) -> bool:
+    """Cordons and safely evicts all tasks from a given node.
+    :param agent_id: a single node name to drain (as would be passed to kubectl drain)
+    :param connector: a kubernetes connector to connect kubernetes API
+    :returns: bool
+    """
+    if connector:
+        log.info(f"Preparing to drain {agent_id}...")
+        return connector.drain_node(agent_id)
+    else:
+        log.info(f"Unable to drain {agent_id} (no Kubernetes connector configured)")
+        return False
+
+
+def uncordon(connector: Optional[KubernetesClusterConnector], agent_id: str) -> bool:
+    """Cordons and safely evicts all tasks from a given node.
+    :param agent_id: a single node name to uncordon (as would be passed to kubectl uncordon)
+    :param connector: a kubernetes connector to connect kubernetes API
+    :returns: bool
+    """
+    if connector:
+        log.info(f"Preparing to uncordon {agent_id}...")
+        return connector.uncordon_node(agent_id)
+    else:
+        log.info(f"Unable to uncordon {agent_id} (no Kubernetes connector configured)")
+        return False

--- a/clusterman/draining/queue.py
+++ b/clusterman/draining/queue.py
@@ -79,13 +79,13 @@ class DrainingClient:
         )
 
     def submit_instance_for_draining(
-            self,
-            instance: InstanceMetadata,
-            sender: Type[AWSResourceGroup],
-            scheduler: str,
-            pool: str,
-            agent_id: str,
-            draining_start_time: arrow.Arrow,
+        self,
+        instance: InstanceMetadata,
+        sender: Type[AWSResourceGroup],
+        scheduler: str,
+        pool: str,
+        agent_id: str,
+        draining_start_time: arrow.Arrow,
     ) -> None:
         return self.client.send_message(
             QueueUrl=self.drain_queue_url,
@@ -98,7 +98,7 @@ class DrainingClient:
             MessageBody=json.dumps(
                 {
                     "agent_id": agent_id,
-                    "draining_start_time": draining_start_time,
+                    "draining_start_time": draining_start_time.for_json(),
                     "group_id": instance.group_id,
                     "hostname": instance.hostname,
                     "instance_id": instance.instance_id,
@@ -121,7 +121,7 @@ class DrainingClient:
             MessageBody=json.dumps(
                 {
                     "agent_id": host.agent_id,
-                    "draining_start_time": host.draining_start_time,
+                    "draining_start_time": host.draining_start_time.for_json(),
                     "group_id": host.group_id,
                     "hostname": host.hostname,
                     "instance_id": host.instance_id,
@@ -151,7 +151,7 @@ class DrainingClient:
             MessageBody=json.dumps(
                 {
                     "agent_id": host.agent_id,
-                    "draining_start_time": host.draining_start_time,
+                    "draining_start_time": host.draining_start_time.for_json(),
                     "group_id": host.group_id,
                     "hostname": host.hostname,
                     "instance_id": host.instance_id,
@@ -407,6 +407,7 @@ def host_from_instance_id(
         group_id=sfr_ids[0],
         ip=ip,
         scheduler=scheduler,
+        draining_start_time=arrow.now(),
     )
 
 

--- a/clusterman/draining/queue.py
+++ b/clusterman/draining/queue.py
@@ -58,6 +58,9 @@ class Host(NamedTuple):
     ip: str
     sender: str
     receipt_handle: str
+    agent_id: str = ""
+    pool: str = ""
+    draining_start_time: arrow.Arrow = arrow.now()
     scheduler: str = "mesos"
 
 
@@ -74,7 +77,13 @@ class DrainingClient:
         )
 
     def submit_instance_for_draining(
-        self, instance: InstanceMetadata, sender: Type[AWSResourceGroup], scheduler: str
+            self,
+            instance: InstanceMetadata,
+            sender: Type[AWSResourceGroup],
+            scheduler: str,
+            pool: str,
+            agent_id: str,
+            draining_start_time: arrow.Arrow,
     ) -> None:
         return self.client.send_message(
             QueueUrl=self.drain_queue_url,
@@ -86,10 +95,13 @@ class DrainingClient:
             },
             MessageBody=json.dumps(
                 {
+                    "agent_id": agent_id,
+                    "draining_start_time": draining_start_time,
+                    "group_id": instance.group_id,
+                    "hostname": instance.hostname,
                     "instance_id": instance.instance_id,
                     "ip": instance.ip_address,
-                    "hostname": instance.hostname,
-                    "group_id": instance.group_id,
+                    "pool": pool,
                     "scheduler": scheduler,
                 }
             ),
@@ -106,10 +118,13 @@ class DrainingClient:
             },
             MessageBody=json.dumps(
                 {
+                    "agent_id": host.agent_id,
+                    "draining_start_time": host.draining_start_time,
+                    "group_id": host.group_id,
+                    "hostname": host.hostname,
                     "instance_id": host.instance_id,
                     "ip": host.ip,
-                    "hostname": host.hostname,
-                    "group_id": host.group_id,
+                    "pool": host.pool,
                     "scheduler": host.scheduler,
                 }
             ),
@@ -133,10 +148,13 @@ class DrainingClient:
             },
             MessageBody=json.dumps(
                 {
+                    "agent_id": host.agent_id,
+                    "draining_start_time": host.draining_start_time,
+                    "group_id": host.group_id,
+                    "hostname": host.hostname,
                     "instance_id": host.instance_id,
                     "ip": host.ip,
-                    "hostname": host.hostname,
-                    "group_id": host.group_id,
+                    "pool": host.pool,
                     "scheduler": host.scheduler,
                 }
             ),

--- a/clusterman/draining/queue.py
+++ b/clusterman/draining/queue.py
@@ -307,14 +307,14 @@ class DrainingClient:
                 should_resend_to_queue = False
 
                 if spent_time.total_seconds() > draining_time_threshold_seconds:
-                    if force_terminate:
+                    if not host_to_process.agent_id or force_terminate:
                         self.submit_host_for_termination(host_to_process, delay=0)
                         should_add_to_cache = True
                     else:
                         if not k8s_uncordon(kube_operator_client, host_to_process.agent_id):
                             should_resend_to_queue = True
                 else:
-                    if k8s_drain(kube_operator_client, host_to_process.agent_id):
+                    if not host_to_process.agent_id or k8s_drain(kube_operator_client, host_to_process.agent_id):
                         self.submit_host_for_termination(host_to_process, delay=0)
                         should_add_to_cache = True
                     else:

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -181,6 +181,7 @@ class KubernetesClusterConnector(ClusterConnector):
             return False
 
     def _evict_tasks_from_node(self, hostname: str) -> bool:
+        all_evicted = True
         pods_to_evict = [
             pod for pod in self._list_all_pods_on_node(hostname) if not self._pod_belongs_to_daemonset(pod)
         ]
@@ -206,9 +207,9 @@ class KubernetesClusterConnector(ClusterConnector):
                 logger.info(f"{pod.metadata.name} ({pod.metadata.namespace}) was evicted")
             except ApiException as e:
                 logger.warning(f"Failed to evict {pod.metadata.name} ({pod.metadata.namespace}): {e.status}-{e.reason}")
-                return False
+                all_evicted = False
 
-        return True
+        return all_evicted
 
     def _list_all_pods_on_node(self, node_name: str) -> List[KubernetesPod]:
         return self._core_api.list_pod_for_all_namespaces(field_selector=f"spec.nodeName={node_name}")

--- a/itests/steps/draining.py
+++ b/itests/steps/draining.py
@@ -73,6 +73,8 @@ def queue_setup(context, queue_name):
                 "ip": "1.2.3.4",
                 "hostname": "the-host",
                 "group_id": context.sfr_id,
+                "agent_id": "agt123",
+                "pool": "default",
             }
         ),
     )
@@ -94,7 +96,7 @@ def warning_queue_setup(context):
 
 @behave.when("the draining queue is processed")
 def drain_queue_process(context):
-    with mock.patch("clusterman.draining.queue.drain",), staticconf.testing.PatchConfiguration(
+    with mock.patch("clusterman.draining.queue.mesos_drain",), staticconf.testing.PatchConfiguration(
         {"drain_termination_timeout_seconds": {"sfr": 0}},
     ):
         context.draining_client.process_drain_queue(mock.Mock(), mock.Mock())


### PR DESCRIPTION
### Description

We have draining feature for Mesos, but we didn't implement it for Kubernetes.
Basically, it clean pods on victim node before terminating on AWS side.
Draining respects PDBs with threshold. Action (after threshold) can be configured.

### Testing Done

New test cases were added and some of existing were changed.
