### PR TITLE
cli tooling to trigger node migration events

### DIFF
--- a/clusterman/args.py
+++ b/clusterman/args.py
@@ -198,6 +198,8 @@ def get_parser(description=""):  # pragma: no cover
     from clusterman.cli.toggle import add_cluster_enable_parser
     from clusterman.draining.queue import add_queue_parser
 
+    # from clusterman.cli.migrate import add_migration_parser  # TODO: uncomment when batch implementation finalized
+
     root_parser = argparse.ArgumentParser(prog="clusterman", description=description, formatter_class=help_formatter)
     add_env_config_path_arg(root_parser)
     root_parser.add_argument(
@@ -219,6 +221,7 @@ def get_parser(description=""):  # pragma: no cover
     add_manager_parser(subparser)
     add_simulate_parser(subparser)
     add_queue_parser(subparser)
+    # add_migration_parser(subparser)  # TODO: uncomment when batch implementation finalized
 
     return root_parser
 

--- a/clusterman/batch/node_migration.py
+++ b/clusterman/batch/node_migration.py
@@ -57,7 +57,7 @@ class NodeMigration(BatchDaemon, BatchLoggingMixin, BatchRunningSentinelMixin):
         self.migration_configs = {}
         self.events_in_progress = set()
         self.pools_accepting_events = set()
-        self.cluster_connector = KubernetesClusterConnector(self.options.cluster, init_crd=True)
+        self.cluster_connector = KubernetesClusterConnector(self.options.cluster, None, init_crd=True)
         self.run_interval = staticconf.read_int("batches.node_migration.run_interval_seconds", 60)
         self.event_visibilty_timeout = staticconf.read_int(
             "batches.node_migration.event_visibilty_timeout_seconds", 15 * 60

--- a/clusterman/cli/migrate.py
+++ b/clusterman/cli/migrate.py
@@ -1,0 +1,79 @@
+# Copyright 2019 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import argparse
+import time
+
+from clusterman.args import add_cluster_arg
+from clusterman.args import add_cluster_config_directory_arg
+from clusterman.args import add_pool_arg
+from clusterman.args import subparser
+from clusterman.kubernetes.kubernetes_cluster_connector import KubernetesClusterConnector
+from clusterman.migration.event import ConditionOperator
+from clusterman.migration.event import ConditionTrait
+from clusterman.migration.event import MigrationCondition
+from clusterman.migration.event import MigrationEvent
+from clusterman.migration.event_enums import MigrationStatus
+
+
+def main(args: argparse.Namespace) -> None:
+    condition = MigrationCondition.from_dict(
+        {name.split("_", 1)[1]: val for name, val in vars(args).items() if name.startswith("condition_")},
+    )
+    event = MigrationEvent(
+        resource_name="-".join((args.cluster, args.pool, str(int(time.time())))),
+        cluster=args.cluster,
+        pool=args.pool,
+        label_selectors=args.label_selector,
+        condition=condition,
+    )
+    connector = KubernetesClusterConnector(args.cluster, None, init_crd=True)
+    connector.create_node_migration_resource(event, MigrationStatus.PENDING)
+
+
+@subparser("migrate", "trigger node migration for a pool", main)
+def add_migration_parser(
+    subparser: argparse.ArgumentParser,
+    required_named_args: argparse._ArgumentGroup,
+    optional_named_args: argparse._ArgumentGroup,
+):  # pragma: no cover
+    add_cluster_arg(required_named_args, required=True)
+    add_pool_arg(required_named_args)
+    add_cluster_config_directory_arg(optional_named_args)
+    condition_group = subparser.add_argument_group(
+        title="migration condition", description="Defines the desired final state for the migration"
+    )
+    condition_group.add_argument(
+        "condition-trait",
+        type=str,
+        help="Metadata based on which nodes to migrate are selected",
+        choices=[entry.value for entry in ConditionTrait],
+    )
+    condition_group.add_argument(
+        "condition-operator",
+        type=str,
+        help="Metadata comparison operator",
+        choices=[entry.value for entry in ConditionOperator],
+    )
+    condition_group.add_argument(
+        "condition-target",
+        type=str,
+        help="Target value for node selection condition",
+    )
+    optional_named_args.add_argument(
+        "--label-selector",
+        type=str,
+        action="append",
+        help="Further filter node selection with label selector expression",
+        default=[],
+    )

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -242,6 +242,21 @@ class KubernetesClusterConnector(ClusterConnector):
         except Exception as e:
             logger.error(f"Failed updating migration event status: {e}")
 
+    def create_node_migration_resource(
+        self, event: MigrationEvent, status: MigrationStatus = MigrationStatus.PENDING
+    ) -> None:
+        """Create CRD resource for node migration
+
+        :param MigrationEvent event: event to submit
+        :param MigrationStatus status: event status (pending by default)
+        """
+        assert self._migration_crd_api, "CRD client was not initialized"
+        try:
+            body = event.to_crd_body(labels={MIGRATION_CRD_STATUS_LABEL: status.value})
+            self._migration_crd_api.create_cluster_custom_object(body=body)
+        except Exception as e:
+            logger.error(f"Failed creating migration event resource: {e}")
+
     def _evict_tasks_from_node(self, hostname: str) -> bool:
         all_evicted = True
         pods_to_evict = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ requests-oauthlib==1.2.0
 retry==0.9.2
 rsa==4.6
 s3transfer==0.3.2
-semver==2.7.9
+semver==2.13.0
 setuptools==49.2.1
 signalfx==1.1.1
 simplejson==3.16.0

--- a/tests/cli/migrate_test.py
+++ b/tests/cli/migrate_test.py
@@ -1,0 +1,52 @@
+# Copyright 2019 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import argparse
+from unittest.mock import patch
+
+import packaging.version
+
+from clusterman.cli.migrate import main
+from clusterman.migration.event import MigrationCondition
+from clusterman.migration.event import MigrationEvent
+from clusterman.migration.event_enums import ConditionOperator
+from clusterman.migration.event_enums import ConditionTrait
+from clusterman.migration.event_enums import MigrationStatus
+
+
+@patch("clusterman.cli.migrate.time")
+@patch("clusterman.cli.migrate.KubernetesClusterConnector")
+def test_migrate_command(mock_connector, mock_time):
+    mock_args = argparse.Namespace(
+        cluster="mesos-test",
+        pool="bar",
+        label_selector=[],
+        condition_trait="lsbrelease",
+        condition_operator="ge",
+        condition_target="22.04",
+    )
+    mock_time.time.return_value = 111222333
+    main(mock_args)
+    mock_connector.assert_called_once_with("mesos-test", None, init_crd=True)
+    mock_connector.return_value.create_node_migration_resource.assert_called_once_with(
+        MigrationEvent(
+            resource_name="mesos-test-bar-111222333",
+            cluster="mesos-test",
+            pool="bar",
+            label_selectors=[],
+            condition=MigrationCondition(
+                ConditionTrait.LSBRELEASE, ConditionOperator.GE, packaging.version.parse("22.04")
+            ),
+        ),
+        MigrationStatus.PENDING,
+    )

--- a/tests/kubernetes/kubernetes_cluster_connector_test.py
+++ b/tests/kubernetes/kubernetes_cluster_connector_test.py
@@ -454,3 +454,30 @@ def test_mark_node_migration_resource(mock_cluster_connector_crd):
         name="mesos-test-bar-220912-0",
         body={"metadata": {"labels": {"clusterman.yelp.com/migration_status": "completed"}}},
     )
+
+
+def test_create_node_migration_resource(mock_cluster_connector_crd):
+    mock_cluster_connector_crd.create_node_migration_resource(
+        MigrationEvent(
+            resource_name="mesos-test-bar-111222333",
+            cluster="mesos-test",
+            pool="bar",
+            label_selectors=[],
+            condition=MigrationCondition(ConditionTrait.LSBRELEASE, ConditionOperator.GE, "22.04"),
+        ),
+        MigrationStatus.PENDING,
+    )
+    mock_cluster_connector_crd._migration_crd_api.create_cluster_custom_object.assert_called_once_with(
+        body={
+            "metadata": {
+                "name": "mesos-test-bar-111222333",
+                "labels": {"clusterman.yelp.com/migration_status": "pending"},
+            },
+            "spec": {
+                "cluster": "mesos-test",
+                "pool": "bar",
+                "label_selectors": [],
+                "condition": {"trait": "lsbrelease", "operator": "ge", "target": "22.04"},
+            },
+        },
+    )


### PR DESCRIPTION
### Description
This adds a simple CLI interface allowing to trigger migration event, compatibly with what it started getting implemented in #180 and #191. I left the entry point commented out so that if a new version gets released with this in it, it won't confuse people.

### Testing Done
Just the usual unit testing.