### PR TITLE
bug fixed for draining start time

### DIFF
--- a/clusterman/draining/queue.py
+++ b/clusterman/draining/queue.py
@@ -62,7 +62,7 @@ class Host(NamedTuple):
     receipt_handle: str
     agent_id: str = ""
     pool: str = ""
-    draining_start_time: arrow.Arrow = arrow.now()
+    draining_start_time: str = arrow.now().for_json()
     scheduler: str = "mesos"
 
 
@@ -121,7 +121,7 @@ class DrainingClient:
             MessageBody=json.dumps(
                 {
                     "agent_id": host.agent_id,
-                    "draining_start_time": host.draining_start_time.for_json(),
+                    "draining_start_time": host.draining_start_time,
                     "group_id": host.group_id,
                     "hostname": host.hostname,
                     "instance_id": host.instance_id,
@@ -151,7 +151,7 @@ class DrainingClient:
             MessageBody=json.dumps(
                 {
                     "agent_id": host.agent_id,
-                    "draining_start_time": host.draining_start_time.for_json(),
+                    "draining_start_time": host.draining_start_time,
                     "group_id": host.group_id,
                     "hostname": host.hostname,
                     "instance_id": host.instance_id,
@@ -298,7 +298,7 @@ class DrainingClient:
                     should_add_to_cache = True
             elif host_to_process.scheduler == "kubernetes":
                 logger.info(f"Kubernetes host to drain and submit for termination: {host_to_process}")
-                spent_time = arrow.now() - host_to_process.draining_start_time
+                spent_time = arrow.now() - arrow.get(host_to_process.draining_start_time)
                 pool_config = staticconf.NamespaceReaders(
                     POOL_NAMESPACE.format(pool=host_to_process.pool, scheduler="kubernetes")
                 )
@@ -416,7 +416,7 @@ def host_from_instance_id(
         group_id=sfr_ids[0],
         ip=ip,
         scheduler=scheduler,
-        draining_start_time=arrow.now(),
+        draining_start_time=arrow.now().for_json(),
     )
 
 

--- a/tests/draining/queue_test.py
+++ b/tests/draining/queue_test.py
@@ -99,7 +99,7 @@ def test_submit_host_for_draining(mock_draining_client):
             scheduler="kubernetes",
             agent_id="agt123",
             pool="default",
-            draining_start_time=now,
+            draining_start_time=now.for_json(),
         )
         assert (
             mock_draining_client.submit_host_for_draining(
@@ -179,7 +179,7 @@ def test_submit_host_for_termination(mock_draining_client):
             scheduler="kubernetes",
             agent_id="agt123",
             pool="default",
-            draing_start_time=now,
+            draining_start_time=now.for_json(),
         )
         assert (
             mock_draining_client.submit_host_for_termination(
@@ -190,14 +190,14 @@ def test_submit_host_for_termination(mock_draining_client):
         )
         mock_json.dumps.assert_called_with(
             {
+                "agent_id": "agt123",
+                "draining_start_time": now.for_json(),
+                "group_id": "sfr123",
+                "hostname": "host123",
                 "instance_id": "i123",
                 "ip": "10.1.1.1",
-                "hostname": "host123",
-                "group_id": "sfr123",
-                "scheduler": "kubernetes",
-                "agent_id": "agt123",
                 "pool": "default",
-                "draining_start_time": mock_host.draining_start_time.for_json(),
+                "scheduler": "kubernetes",
             }
         )
         mock_draining_client.client.send_message.assert_called_with(
@@ -220,14 +220,14 @@ def test_submit_host_for_termination(mock_draining_client):
         )
         mock_json.dumps.assert_called_with(
             {
+                "agent_id": "agt123",
+                "draining_start_time": now.for_json(),
+                "group_id": "sfr123",
+                "hostname": "host123",
                 "instance_id": "i123",
                 "ip": "10.1.1.1",
-                "hostname": "host123",
-                "group_id": "sfr123",
-                "scheduler": "kubernetes",
-                "agent_id": "agt123",
                 "pool": "default",
-                "draining_start_time": mock_host.draining_start_time.for_json(),
+                "scheduler": "kubernetes",
             }
         )
         mock_draining_client.client.send_message.assert_called_with(
@@ -267,7 +267,7 @@ def test_get_host_to_drain(mock_draining_client):
             "group_id": "sfr123",
             "pool": "default",
             "agent_id": "agt123",
-            "draining_start_time": now,
+            "draining_start_time": now.for_json(),
         }
 
         assert mock_draining_client.get_host_to_drain() == Host(
@@ -279,7 +279,7 @@ def test_get_host_to_drain(mock_draining_client):
             group_id="sfr123",
             agent_id="agt123",
             pool="default",
-            draining_start_time=now,
+            draining_start_time=now.for_json(),
         )
         mock_json.loads.assert_called_with("Helloworld")
         mock_draining_client.client.receive_message.assert_called_with(
@@ -545,12 +545,13 @@ def test_process_drain_queue(mock_draining_client):
             agent_id="agt123",
             pool="default",
             scheduler="kubernetes",
-            draining_start_time=now,
+            draining_start_time=now.for_json(),
             sender="mmb",
             receipt_handle="aaaaa",
         )
         mock_get_host_to_drain.return_value = mock_host
-        mock_arrow.now.return_value = now
+        mock_arrow.now.return_value = arrow.get(mock_host.draining_start_time)
+        mock_arrow.get.return_value = arrow.get(mock_host.draining_start_time)
         mock_draining_client.process_drain_queue(mock_mesos_client, mock_kubernetes_client)
         assert mock_draining_client.get_host_to_drain.called
         assert not mock_submit_host_for_draining.called
@@ -571,7 +572,7 @@ def test_process_drain_queue(mock_draining_client):
             agent_id="agt123",
             pool="default",
             scheduler="kubernetes",
-            draining_start_time=now,
+            draining_start_time=now.for_json(),
             sender="mmb",
             receipt_handle="aaaaa",
         )
@@ -595,7 +596,7 @@ def test_process_drain_queue(mock_draining_client):
             agent_id="agt123",
             pool="default",
             scheduler="kubernetes",
-            draining_start_time=now,
+            draining_start_time=now.for_json(),
             sender="mmb",
             receipt_handle="aaaaa",
         )
@@ -624,7 +625,7 @@ def test_process_drain_queue(mock_draining_client):
             agent_id="agt123",
             pool="default",
             scheduler="kubernetes",
-            draining_start_time=now.shift(hours=-10000),
+            draining_start_time=now.for_json(),
             sender="mmb",
             receipt_handle="aaaaa",
         )
@@ -632,7 +633,8 @@ def test_process_drain_queue(mock_draining_client):
         mock_k8s_drain.reset_mock()
         mock_submit_host_for_draining.reset_mock()
         mock_get_host_to_drain.return_value = mock_host
-        mock_arrow.now.return_value = now
+        mock_arrow.now.return_value = arrow.get(mock_host.draining_start_time).shift(hours=100)
+        mock_arrow.get.return_value = arrow.get(mock_host.draining_start_time)
         mock_draining_client.process_drain_queue(mock_mesos_client, mock_kubernetes_client)
         assert not mock_k8s_drain.called
         assert mock_k8s_uncordon.called
@@ -647,13 +649,14 @@ def test_process_drain_queue(mock_draining_client):
             agent_id="agt123",
             pool="default",
             scheduler="kubernetes",
-            draining_start_time=now,
+            draining_start_time=now.for_json(),
             sender="mmb",
             receipt_handle="aaaaa",
         )
         mock_k8s_uncordon.reset_mock()
         mock_get_host_to_drain.return_value = mock_host
-        mock_arrow.now.return_value = now
+        mock_arrow.now.return_value = arrow.get(mock_host.draining_start_time)
+        mock_arrow.get.return_value = arrow.get(mock_host.draining_start_time)
         mock_draining_client.process_drain_queue(mock_mesos_client, mock_kubernetes_client)
         assert mock_draining_client.get_host_to_drain.called
         assert not mock_submit_host_for_draining.called
@@ -795,7 +798,7 @@ def test_host_from_instance_id():
             ip="10.1.1.1",
             agent_id="",
             pool="",
-            draining_start_time=now,
+            draining_start_time=now.for_json(),
         )
 
         mock_gethostbyaddr.side_effect = socket.error


### PR DESCRIPTION
Description
We have draining feature for Mesos, but we didn't implement it for Kubernetes.
Basically, it clean pods on victim node before terminating on AWS side.
Draining respects PDBs with threshold. Action (after threshold) can be configured.

Bug fixed for https://github.com/Yelp/clusterman/pull/181

Testing Done
New test cases were added and some of existing were changed.