### PR TITLE
pool_manager: consider uptime in selecting killable nodes

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -128,6 +128,7 @@ The following is an example configuration file for a particular Clusterman pool:
         max_weight_to_add: 100
         max_weight_to_remove: 100
         max_tasks_to_kill: 100
+        min_node_scalein_uptime_seconds: 300
 
 
     autoscale_signal:
@@ -156,7 +157,9 @@ The following is an example configuration file for a particular Clusterman pool:
 The ``resource-groups`` section provides information for loading resource groups in the pool manager.
 
 The ``scaling_limits`` section provides global pool-level limits on scaling that the autoscaler and
-other Clusterman commands should respect.
+other Clusterman commands should respect. The field ``min_node_scalein_uptime_seconds`` is an optional
+setting allowing to indicate a timespan in which freshly bootstrapped nodes are deprioritized in the
+selection for termination.
 
 The ``autoscale_signal`` section defines the autoscaling signal used by this pool.  This section is optional. If it is
 not present, then the ``autoscale_signal`` from the service configuration will be used.

--- a/tests/autoscaler/pool_manager_test.py
+++ b/tests/autoscaler/pool_manager_test.py
@@ -573,21 +573,23 @@ def test_instance_kill_order(mock_pool_manager):
         return_value=[
             _make_metadata("sfr-0", "i-7", batch_tasks=100),
             _make_metadata("sfr-0", "i-0", agent_state=AgentState.ORPHANED),
-            _make_metadata("sfr-0", "i-2", tasks=1, is_stale=True),
-            _make_metadata("sfr-0", "i-1", agent_state=AgentState.IDLE),
+            _make_metadata("sfr-0", "i-1", tasks=1, is_stale=True),
+            _make_metadata("sfr-0", "i-3", agent_state=AgentState.IDLE),
             _make_metadata("sfr-0", "i-4", tasks=1),
             _make_metadata("sfr-0", "i-5", tasks=100),
-            _make_metadata("sfr-0", "i-3", tasks=100, is_stale=True),
+            _make_metadata("sfr-0", "i-2", tasks=100, is_stale=True),
             _make_metadata("sfr-0", "i-6", batch_tasks=1),
-            _make_metadata("sfr-0", "i-8", agent_state=AgentState.UNKNOWN),
-            _make_metadata("sfr-0", "i-9", tasks=100000),
-            _make_metadata("sfr-0", "i-10", is_safe_to_kill=False),
+            _make_metadata("sfr-0", "i-9", agent_state=AgentState.UNKNOWN),
+            _make_metadata("sfr-0", "i-10", tasks=100000),
+            _make_metadata("sfr-0", "i-11", is_safe_to_kill=False),
+            _make_metadata("sfr-0", "i-8", agent_state=AgentState.IDLE, uptime=60),
         ]
     )
     mock_pool_manager.max_tasks_to_kill = 1000
+    mock_pool_manager.min_node_scalein_uptime = 300
     killable_nodes = mock_pool_manager._get_prioritized_killable_nodes()
     killable_instance_ids = [node_metadata.instance.instance_id for node_metadata in killable_nodes]
-    assert killable_instance_ids == [f"i-{i}" for i in range(8)]
+    assert killable_instance_ids == [f"i-{i}" for i in range(9)]
 
 
 def test_get_expired_orphan_instances(mock_pool_manager):


### PR DESCRIPTION
### Description
* Adds a new setting which can be used to indicate a grace period for new hosts being bootstrapped into a pool before they are prioritized for termination. This is off by default so that can selectively be applied to pools which may need it to prevent capacity flapping.
* In doing so I also changed the kill priority around staleness, as I while reading this I thought that it'd make more sense to kill node which are voluntarily marked as stale rather than ones which are just healthy but idling. Happy to revert if this reasoning is wrong.

### Testing Done
Just fixed/extended unit testing. Of course will do slow roll out if approved.