### PR TITLE
migration: switch to handling events with CRD

### DIFF
--- a/clusterman/batch/node_migration.py
+++ b/clusterman/batch/node_migration.py
@@ -13,26 +13,25 @@
 # limitations under the License.
 from time import time
 from typing import Collection
-from typing import Generator
 from typing import Optional
 
 import colorlog
 import staticconf
-from botocore.exceptions import ClientError
 from yelp_batch.batch import batch_command_line_arguments
 from yelp_batch.batch import batch_configure
 from yelp_batch.batch_daemon import BatchDaemon
 
 from clusterman.args import add_cluster_arg
 from clusterman.args import add_env_config_path_arg
-from clusterman.aws.client import sqs
 from clusterman.batch.util import BatchLoggingMixin
 from clusterman.batch.util import BatchRunningSentinelMixin
 from clusterman.config import get_pool_config_path
 from clusterman.config import load_cluster_pool_config
 from clusterman.config import POOL_NAMESPACE
 from clusterman.config import setup_config
+from clusterman.kubernetes.kubernetes_cluster_connector import KubernetesClusterConnector
 from clusterman.migration.event import MigrationEvent
+from clusterman.migration.event_enums import MigrationStatus
 from clusterman.migration.settings import WorkerSetup
 from clusterman.util import get_pool_name_list
 from clusterman.util import setup_logging
@@ -43,7 +42,6 @@ class NodeMigration(BatchDaemon, BatchLoggingMixin, BatchRunningSentinelMixin):
 
     POOL_SCHEDULER = "kubernetes"
     POOL_SETTINGS_PARENT = "node_migration"
-    EVENT_FETCH_BATCH = 10
 
     @batch_command_line_arguments
     def parse_args(self, parser):
@@ -59,7 +57,7 @@ class NodeMigration(BatchDaemon, BatchLoggingMixin, BatchRunningSentinelMixin):
         self.migration_configs = {}
         self.events_in_progress = set()
         self.pools_accepting_events = set()
-        self.event_queue = staticconf.read_string(f"clusters.{self.options.cluster}.migration_event_queue_url")
+        self.cluster_connector = KubernetesClusterConnector(self.options.cluster, init_crd=True)
         self.run_interval = staticconf.read_int("batches.node_migration.run_interval_seconds", 60)
         self.event_visibilty_timeout = staticconf.read_int(
             "batches.node_migration.event_visibilty_timeout_seconds", 15 * 60
@@ -71,28 +69,9 @@ class NodeMigration(BatchDaemon, BatchLoggingMixin, BatchRunningSentinelMixin):
             if self.POOL_SETTINGS_PARENT in pool_config:
                 self.migration_configs[pool] = pool_config[self.POOL_SETTINGS_PARENT]
                 self.add_watcher({pool: get_pool_config_path(self.options.cluster, pool, self.POOL_SCHEDULER)})
-                if self.migration_configs[pool]["trigger"].get("event_queue", False):
+                if self.migration_configs[pool]["trigger"].get("event", False):
                     self.pools_accepting_events.add(pool)
         self.logger.info(f"Found node migration configs for pools: {list(self.migration_configs.keys())}")
-
-    def _fetch_all_from_queue(self) -> Generator[dict, None, None]:
-        """Fetch all data from SQS queue
-
-        :return: yields messages
-        """
-        try:
-            while True:
-                messages = sqs.receive_message(
-                    QueueUrl=self.event_queue,
-                    MaxNumberOfMessages=self.EVENT_FETCH_BATCH,
-                    VisibilityTimeout=self.event_visibilty_timeout,
-                    WaitTimeSeconds=10,
-                ).get("Messages", [])
-                yield from messages
-                if len(messages) < self.EVENT_FETCH_BATCH:
-                    break
-        except ClientError as e:
-            self.logger.exception(f"Issue retrieving events from {self.event_queue}: {e}")
 
     def _get_worker_setup(self, pool: str) -> Optional[WorkerSetup]:
         """Build worker setup for
@@ -107,20 +86,21 @@ class NodeMigration(BatchDaemon, BatchLoggingMixin, BatchRunningSentinelMixin):
             self.logger.exception(f"Bad migration configuration for pool {pool}: {e}")
         return None
 
-    def fetch_event_queue(self) -> Collection[MigrationEvent]:
-        """Tail a collection of SQS queue for migration trigger events"""
-        events = map(MigrationEvent.from_message, self._fetch_all_from_queue())
+    def fetch_event_crd(self) -> Collection[MigrationEvent]:
+        """Fetch migration events from Kubernetes CRDs"""
+        self.cluster_connector.reload_client()
+        events = self.cluster_connector.list_node_migration_resources(
+            [MigrationStatus.PENDING, MigrationStatus.INPROGRESS]
+        )
         return set(events) - self.events_in_progress
 
-    def delete_event(self, event: MigrationEvent) -> None:
-        """Delete event from event queue
+    def mark_event(self, event: MigrationEvent, status: MigrationStatus = MigrationStatus.COMPLETED) -> None:
+        """Set status for CRD event resource
 
-        :param MigrationEvent event: event to be deleted
+        :param MigrationEvent event: event to be marked
+        :param MigrationStatus status: status to be set
         """
-        try:
-            sqs.delete_message(QueueUrl=self.event_queue, ReceiptHandle=event.msg_receipt)
-        except ClientError as e:
-            self.logger.exception(f"Error deleting event from {self.event_queue}: {e}")
+        self.cluster_connector.mark_node_migration_resource(event.resource_name, status)
 
     def spawn_event_worker(self, event: MigrationEvent):
         """Start process recycling nodes in a pool accordingly to some event parameters
@@ -129,12 +109,12 @@ class NodeMigration(BatchDaemon, BatchLoggingMixin, BatchRunningSentinelMixin):
         """
         if event.pool not in self.pools_accepting_events:
             self.logger.warning(f"Pool {event.pool} not configured to accept migration trigger event, skipping")
-            self.delete_event(event)
+            self.mark_event(event, MigrationStatus.SKIPPED)
             return
         worker_setup = self._get_worker_setup(event.pool)
         if not worker_setup or event.cluster != self.options.cluster:
             self.logger.warning(f"Event not processable by this batch instance, skipping: {event}")
-            self.delete_event(event)
+            self.mark_event(event, MigrationStatus.SKIPPED)
             return
         self.logger.info(f"Spawning migration worker for event: {event}")
         # TODO: everything
@@ -161,7 +141,7 @@ class NodeMigration(BatchDaemon, BatchLoggingMixin, BatchRunningSentinelMixin):
             if "max_uptime" in config["trigger"]:
                 self.spawn_uptime_worker(pool, config["trigger"]["max_uptime"])
         while self.running:
-            events = self.fetch_event_queue()
+            events = self.fetch_event_crd()
             for event in events:
                 self.spawn_event_worker(event)
             time.sleep(self.run_interval)

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import copy
 from collections import defaultdict
+from typing import Collection
 from typing import List
 from typing import Mapping
 from typing import Optional
@@ -37,21 +38,29 @@ from clusterman.interfaces.types import AgentState
 from clusterman.kubernetes.util import allocated_node_resources
 from clusterman.kubernetes.util import CachedCoreV1Api
 from clusterman.kubernetes.util import get_node_ip
+from clusterman.kubernetes.util import KubeApiClientWrapper
 from clusterman.kubernetes.util import PodUnschedulableReason
 from clusterman.kubernetes.util import selector_term_matches_requirement
 from clusterman.kubernetes.util import total_node_resources
 from clusterman.kubernetes.util import total_pod_resources
+from clusterman.migration.event import MigrationEvent
+from clusterman.migration.event_enums import MigrationStatus
 from clusterman.util import strtobool
 
 
 logger = colorlog.getLogger(__name__)
 KUBERNETES_SCHEDULED_PHASES = {"Pending", "Running"}
 CLUSTERMAN_TERMINATION_TAINT_KEY = "clusterman.yelp.com/terminating"
+MIGRATION_CRD_GROUP = "clusterman.yelp.com"
+MIGRATION_CRD_VERSION = "v1"
+MIGRATION_CRD_PLURAL = "nodemigrations"
+MIGRATION_CRD_STATUS_LABEL = "clusterman.yelp.com/migration_status"
 
 
 class KubernetesClusterConnector(ClusterConnector):
     SCHEDULER = "kubernetes"
     _core_api: kubernetes.client.CoreV1Api
+    _crd_api: Optional[kubernetes.client.CustomObjectsApi]
     _pods: List[KubernetesPod]
     _prev_nodes_by_ip: Mapping[str, KubernetesNode]
     _nodes_by_ip: Mapping[str, KubernetesNode]
@@ -59,7 +68,7 @@ class KubernetesClusterConnector(ClusterConnector):
     _excluded_pods_by_ip: Mapping[str, List[KubernetesPod]]
     _pods_by_ip: Mapping[str, List[KubernetesPod]]
 
-    def __init__(self, cluster: str, pool: Optional[str]) -> None:
+    def __init__(self, cluster: str, pool: Optional[str], init_crd: bool = False) -> None:
         super().__init__(cluster, pool)
         self.kubeconfig_path = staticconf.read_string(f"clusters.{cluster}.kubeconfig_path")
         self._safe_to_evict_annotation = staticconf.read_string(
@@ -67,6 +76,7 @@ class KubernetesClusterConnector(ClusterConnector):
             default="cluster-autoscaler.kubernetes.io/safe-to-evict",
         )
         self._nodes_by_ip = {}
+        self._init_crd_client = init_crd
 
     def reload_state(self) -> None:
         logger.info("Reloading nodes")
@@ -85,6 +95,11 @@ class KubernetesClusterConnector(ClusterConnector):
 
     def reload_client(self) -> None:
         self._core_api = CachedCoreV1Api(self.kubeconfig_path)
+        self._crd_api = (
+            KubeApiClientWrapper(self.kubeconfig_path, kubernetes.client.CustomObjectsApi)
+            if self._init_crd_client
+            else None
+        )
 
     def get_num_removed_nodes_before_last_reload(self) -> int:
         previous_nodes = self._prev_nodes_by_ip
@@ -183,6 +198,50 @@ class KubernetesClusterConnector(ClusterConnector):
         except ApiException as e:
             logger.warning(f"Failed to uncordon {node_name}: {e}")
             return False
+
+    def list_node_migration_resources(self, statuses: List[MigrationStatus]) -> Collection[MigrationEvent]:
+        """Fetch node migration event resource from k8s CRD
+
+        :param List[MigrationStatus] statuses: event status to look for
+        :return: collection of migration events
+        """
+        assert self._crd_api, "CRD client was not initialized"
+        try:
+            label_filter = ",".join(status.value for status in statuses)
+            resources = self._crd_api.list_cluster_custom_object(
+                group=MIGRATION_CRD_GROUP,
+                version=MIGRATION_CRD_VERSION,
+                plural=MIGRATION_CRD_PLURAL,
+                label_selector=f"{MIGRATION_CRD_STATUS_LABEL} in ({label_filter})",
+            )
+            return set(map(MigrationEvent.from_crd, resources.get("items", [])))
+        except Exception as e:
+            logger.error(f"Failed fetching migration events: {e}")
+        return set()
+
+    def mark_node_migration_resource(self, event_name: str, status: MigrationStatus) -> None:
+        """Set status for migration event resource
+
+        :param str event_name: name of the resource CRD
+        :status MigrationStatus status: status to be set
+        """
+        assert self._crd_api, "CRD client was not initialized"
+        try:
+            self._crd_api.patch_cluster_custom_object(
+                group=MIGRATION_CRD_GROUP,
+                version=MIGRATION_CRD_VERSION,
+                plural=MIGRATION_CRD_PLURAL,
+                name=event_name,
+                body={
+                    "metadata": {
+                        "labels": {
+                            MIGRATION_CRD_STATUS_LABEL: status.value,
+                        }
+                    }
+                },
+            )
+        except Exception as e:
+            logger.error(f"Failed updating migration event status: {e}")
 
     def _evict_tasks_from_node(self, hostname: str) -> bool:
         all_evicted = True

--- a/clusterman/kubernetes/util.py
+++ b/clusterman/kubernetes/util.py
@@ -15,6 +15,7 @@ import os
 import socket
 from enum import auto
 from enum import Enum
+from functools import partial
 from typing import List
 from typing import Type
 
@@ -96,6 +97,22 @@ class CachedCoreV1Api(KubeApiClientWrapper):
             func = decorator(func)
 
         return func
+
+
+class ConciseCRDApi(KubeApiClientWrapper):
+    def __init__(self, kubeconfig_path: str, group: str, version: str, plural: str) -> None:
+        super().__init__(kubeconfig_path, kubernetes.client.CustomObjectsApi)
+        self.group = group
+        self.version = version
+        self.plural = plural
+
+    def __getattr__(self, attr):
+        return partial(
+            getattr(self._client, attr),
+            group=self.group,
+            version=self.version,
+            plural=self.plural,
+        )
 
 
 class ResourceParser:

--- a/clusterman/migration/event.py
+++ b/clusterman/migration/event.py
@@ -11,44 +11,123 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import enum
-import json
+from typing import Callable
+from typing import Dict
 from typing import List
 from typing import NamedTuple
 from typing import Union
 
+import packaging.version
+import semver
 
-class ConditionTrait(enum.Enum):
-    KERNEL = "kernel"
-    LSBRELEASE = "lsbrelease"
-    INSTANCE_TYPE = "instance_type"
-    UPTIME = "uptime"
+from clusterman.aws.markets import EC2_INSTANCE_TYPES
+from clusterman.migration.event_enums import CONDITION_OPERATOR_SUPPORT_MATRIX
+from clusterman.migration.event_enums import ConditionOperator
+from clusterman.migration.event_enums import ConditionTrait
+from clusterman.util import parse_time_interval_seconds
+
+
+ComparableVersion = Union[semver.VersionInfo, packaging.version.Version]
+ComparableConditionTarget = Union[str, int, ComparableVersion]
+
+
+def _load_version_target(target: str) -> ComparableVersion:
+    """Validate condition target as a version
+
+    :param str target: version from user input
+    :return: same value if validates as version
+    """
+    try:
+        parsed = semver.parse_version_info(target)
+    except ValueError:
+        # This allows supporting non-semver version, e.g. with less
+        # then 3 numeric components, as long as they comply with PEP440.
+        parsed = packaging.version.parse(target)
+        if not isinstance(parsed, packaging.version.Version):
+            raise ValueError(f"Invalid version string: {target}")
+    return parsed
+
+
+def _load_timespan_target(target: str) -> int:
+    """Validate and parse input timespan
+
+    :param str target: either seconds or human readable span (e.g. 5d)
+    :return: integer timespan in seconds
+    """
+    return int(target if target.isnumeric() else parse_time_interval_seconds(target))
+
+
+def _load_instance_type_target(target: str) -> str:
+    """Validate and parse instance-type migration condition target
+
+    :param str target: target user input
+    :return: list of instance types
+    """
+    target = target.lower()
+    if target not in EC2_INSTANCE_TYPES:
+        raise ValueError(f"Invalid instance type: {target}")
+    return target
+
+
+CONDITION_TARGET_LOADERS: Dict[ConditionTrait, Callable[[str], Union[str, int, List[str]]]] = {
+    ConditionTrait.KERNEL: _load_version_target,
+    ConditionTrait.LSBRELEASE: _load_version_target,
+    ConditionTrait.UPTIME: _load_timespan_target,
+    ConditionTrait.INSTANCE_TYPE: _load_instance_type_target,
+}
 
 
 class MigrationCondition(NamedTuple):
     trait: ConditionTrait
-    target: Union[str, int, List[str]]
+    operator: ConditionOperator
+    target: Union[ComparableConditionTarget, List[ComparableConditionTarget]]
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "MigrationCondition":
+        """Load condition class instance from data dictionary
+
+        :param dict data: condition data
+        :return: condition instance
+        """
+        trait = ConditionTrait(data["trait"])
+        op = ConditionOperator(data["operator"])
+        if op not in CONDITION_OPERATOR_SUPPORT_MATRIX[trait]:
+            raise ValueError(f"{op} is not support in conditions with {trait}")
+        target_loader = CONDITION_TARGET_LOADERS[trait]
+        return cls(
+            trait=trait,
+            operator=op,
+            target=(
+                list(map(target_loader, data["target"].split(",")))
+                if op in ConditionOperator.expecting_collection()
+                else target_loader(data["target"])
+            ),
+        )
 
 
 class MigrationEvent(NamedTuple):
-    msg_id: str
-    msg_receipt: str
+    resource_name: str
     cluster: str
     pool: str
+    label_selectors: List[str]
     condition: MigrationCondition
 
-    @classmethod
-    def from_message(cls, message: dict) -> "MigrationEvent":
-        """Parse migration trigger event into class instance
+    def __hash__(self) -> int:
+        """Simplified object hash since resource_name should be unique"""
+        return self[:3].__hash__()
 
-        :param str event: event data
+    @classmethod
+    def from_crd(cls, crd: dict) -> "MigrationEvent":
+        """Load migration trigger event into class instance
+
+        :param dict crd: event data
+        :return: event instance
         """
-        event_data = json.loads(message["Body"])
-        cond_key, cond_value = next(iter(event_data["condition"].items()))
+        event_data = crd["spec"]
         return cls(
-            msg_id=message["MessageId"],
-            msg_receipt=message["ReceiptHandle"],
+            resource_name=crd["metadata"]["name"],
             cluster=event_data["cluster"],
             pool=event_data["pool"],
-            condition=MigrationCondition(ConditionTrait(cond_key), cond_value),
+            label_selectors=event_data.get("label_selectors", []),
+            condition=MigrationCondition.from_dict(event_data["condition"]),
         )

--- a/clusterman/migration/event_enums.py
+++ b/clusterman/migration/event_enums.py
@@ -1,0 +1,73 @@
+# Copyright 2019 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import enum
+import operator
+from typing import Any
+from typing import Collection
+
+
+class MigrationStatus(enum.Enum):
+    PENDING = "pending"
+    INPROGRESS = "inprogress"
+    COMPLETED = "completed"
+    SKIPPED = "skipped"
+
+
+class ConditionTrait(enum.Enum):
+    KERNEL = "kernel"
+    LSBRELEASE = "lsbrelease"
+    INSTANCE_TYPE = "instance_type"
+    UPTIME = "uptime"
+
+
+class ConditionOperator(enum.Enum):
+    GT = "gt"
+    GE = "ge"
+    EQ = "eq"
+    NE = "ne"
+    LT = "lt"
+    LE = "le"
+    IN = "in"
+    NOTIN = "notin"
+
+    @classmethod
+    def expecting_collection(cls) -> Collection["ConditionOperator"]:
+        """Return operators expecting collection of object as right-operand"""
+        return (cls.IN, cls.NOTIN)
+
+    def apply(self, left: Any, right: Any) -> bool:
+        """Apply operator
+
+        :param Any left: left operand
+        :param Any right: right operand
+        :return: boolean result
+        """
+        if self == ConditionOperator.IN:
+            return left in right
+        elif self == ConditionOperator.NOTIN:
+            return left not in right
+        return getattr(operator, self.value)(left, right)
+
+
+CONDITION_OPERATOR_SUPPORT_MATRIX = {
+    ConditionTrait.KERNEL: set(ConditionOperator),
+    ConditionTrait.LSBRELEASE: set(ConditionOperator),
+    ConditionTrait.INSTANCE_TYPE: {
+        ConditionOperator.EQ,
+        ConditionOperator.NE,
+        ConditionOperator.IN,
+        ConditionOperator.NOTIN,
+    },
+    ConditionTrait.UPTIME: {ConditionOperator.GT, ConditionOperator.GE, ConditionOperator.LT, ConditionOperator.LE},
+}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -34,7 +34,6 @@ mock==3.0.5
 moto==1.3.16
 mypy==0.730
 nodeenv==1.3.3
-packaging==19.2
 parse==1.12.1
 parse-type==0.5.2
 parso==0.5.1

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -10,11 +10,13 @@ kubernetes
 matplotlib>=3.1.1
 mypy-extensions
 numpy>=1.16
+packaging
 parsedatetime
 PyStaticConfiguration
 PyYAML>=5.4
 requests>=2.22.0
 retry
+semver
 signalfx
 simplejson
 sortedcontainers

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ more-itertools==7.2.0
 mypy-extensions==0.4.2
 numpy==1.17.2
 oauthlib==3.1.0
+packaging==19.2
 parsedatetime==2.4
 protobuf==3.10.0
 py==1.8.0
@@ -38,6 +39,7 @@ requests-oauthlib==1.2.0
 retry==0.9.2
 rsa==4.6
 s3transfer==0.3.2
+semver==2.7.9
 setuptools==49.2.1
 signalfx==1.1.1
 simplejson==3.16.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,7 +82,6 @@ def main_clusterman_config():
                 "drain_queue_url": "mesos-test-draining.com",
                 "termination_queue_url": "mesos-test-terminating.com",
                 "warning_queue_url": "mesos-test-warning.com",
-                "migration_event_queue_url": "mesos-test-migration-event.com",
             },
         },
         "sensu_config": [
@@ -191,7 +190,7 @@ def clusterman_k8s_pool_config():
         },
         "node_migration": {
             "trigger": {
-                "event_queue": True,
+                "event": True,
                 "max_uptime": "90d",
             },
             "strategy": {

--- a/tests/kubernetes/kubernetes_cluster_connector_test.py
+++ b/tests/kubernetes/kubernetes_cluster_connector_test.py
@@ -37,6 +37,11 @@ from staticconf.testing import PatchConfiguration
 from clusterman.config import POOL_NAMESPACE
 from clusterman.interfaces.types import AgentState
 from clusterman.kubernetes.kubernetes_cluster_connector import KubernetesClusterConnector
+from clusterman.migration.event import MigrationCondition
+from clusterman.migration.event import MigrationEvent
+from clusterman.migration.event_enums import ConditionOperator
+from clusterman.migration.event_enums import ConditionTrait
+from clusterman.migration.event_enums import MigrationStatus
 
 
 @pytest.fixture
@@ -256,7 +261,7 @@ def pod_with_preferred_affinity():
     )
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def mock_cluster_connector(
     running_pod_1,
     running_pod_2,
@@ -308,6 +313,13 @@ def mock_cluster_connector(
         ]
         mock_cluster_connector = KubernetesClusterConnector("kubernetes-test", "bar")
         mock_cluster_connector.reload_state()
+        yield mock_cluster_connector
+
+
+@pytest.fixture
+def mock_cluster_connector_crd(mock_cluster_connector):
+    mock_cluster_connector._init_crd_client = True
+    with mock.patch.object(mock_cluster_connector, "_crd_api"):
         yield mock_cluster_connector
 
 
@@ -389,3 +401,62 @@ def test_pod_belongs_to_pool(
     assert mock_cluster_connector._pod_belongs_to_pool(pod_with_preferred_affinity)
     assert not mock_cluster_connector._pod_belongs_to_pool(pod_with_node_selector_elsewhere)
     assert not mock_cluster_connector._pod_belongs_to_pool(pod_with_required_affinity_elsewhere)
+
+
+def test_list_node_migration_resources(mock_cluster_connector_crd):
+    mock_cluster_connector_crd._crd_api.list_cluster_custom_object.return_value = {
+        "items": [
+            {
+                "metadata": {
+                    "name": f"mesos-test-bar-220912-{i}",
+                    "labels": {
+                        "clusterman.yelp.com/migration_status": "pending",
+                    },
+                },
+                "spec": {
+                    "cluster": "mesos-test",
+                    "pool": "bar",
+                    "condition": {
+                        "trait": "uptime",
+                        "operator": "lt",
+                        "target": f"9{i}d",
+                    },
+                },
+            }
+            for i in range(3)
+        ]
+    }
+    assert mock_cluster_connector_crd.list_node_migration_resources(
+        [MigrationStatus.PENDING, MigrationStatus.INPROGRESS]
+    ) == {
+        MigrationEvent(
+            resource_name=f"mesos-test-bar-220912-{i}",
+            cluster="mesos-test",
+            pool="bar",
+            label_selectors=[],
+            condition=MigrationCondition(ConditionTrait.UPTIME, ConditionOperator.LT, (90 + i) * 24 * 60 * 60),
+        )
+        for i in range(3)
+    }
+    mock_cluster_connector_crd._crd_api.list_cluster_custom_object.assert_called_once_with(
+        group="clusterman.yelp.com",
+        plural="nodemigrations",
+        version="v1",
+        label_selector="clusterman.yelp.com/migration_status in (pending,inprogress)",
+    )
+
+
+def test_list_node_migration_resources_no_init(mock_cluster_connector):
+    with pytest.raises(AssertionError):
+        mock_cluster_connector.list_node_migration_resources([MigrationStatus.PENDING])
+
+
+def test_mark_node_migration_resource(mock_cluster_connector_crd):
+    mock_cluster_connector_crd.mark_node_migration_resource("mesos-test-bar-220912-0", MigrationStatus.COMPLETED)
+    mock_cluster_connector_crd._crd_api.patch_cluster_custom_object.assert_called_once_with(
+        group="clusterman.yelp.com",
+        plural="nodemigrations",
+        version="v1",
+        name="mesos-test-bar-220912-0",
+        body={"metadata": {"labels": {"clusterman.yelp.com/migration_status": "completed"}}},
+    )

--- a/tests/kubernetes/kubernetes_cluster_connector_test.py
+++ b/tests/kubernetes/kubernetes_cluster_connector_test.py
@@ -319,7 +319,7 @@ def mock_cluster_connector(
 @pytest.fixture
 def mock_cluster_connector_crd(mock_cluster_connector):
     mock_cluster_connector._init_crd_client = True
-    with mock.patch.object(mock_cluster_connector, "_crd_api"):
+    with mock.patch.object(mock_cluster_connector, "_migration_crd_api"):
         yield mock_cluster_connector
 
 
@@ -404,7 +404,7 @@ def test_pod_belongs_to_pool(
 
 
 def test_list_node_migration_resources(mock_cluster_connector_crd):
-    mock_cluster_connector_crd._crd_api.list_cluster_custom_object.return_value = {
+    mock_cluster_connector_crd._migration_crd_api.list_cluster_custom_object.return_value = {
         "items": [
             {
                 "metadata": {
@@ -438,10 +438,7 @@ def test_list_node_migration_resources(mock_cluster_connector_crd):
         )
         for i in range(3)
     }
-    mock_cluster_connector_crd._crd_api.list_cluster_custom_object.assert_called_once_with(
-        group="clusterman.yelp.com",
-        plural="nodemigrations",
-        version="v1",
+    mock_cluster_connector_crd._migration_crd_api.list_cluster_custom_object.assert_called_once_with(
         label_selector="clusterman.yelp.com/migration_status in (pending,inprogress)",
     )
 
@@ -453,10 +450,7 @@ def test_list_node_migration_resources_no_init(mock_cluster_connector):
 
 def test_mark_node_migration_resource(mock_cluster_connector_crd):
     mock_cluster_connector_crd.mark_node_migration_resource("mesos-test-bar-220912-0", MigrationStatus.COMPLETED)
-    mock_cluster_connector_crd._crd_api.patch_cluster_custom_object.assert_called_once_with(
-        group="clusterman.yelp.com",
-        plural="nodemigrations",
-        version="v1",
+    mock_cluster_connector_crd._migration_crd_api.patch_cluster_custom_object.assert_called_once_with(
         name="mesos-test-bar-220912-0",
         body={"metadata": {"labels": {"clusterman.yelp.com/migration_status": "completed"}}},
     )

--- a/tests/kubernetes/util_test.py
+++ b/tests/kubernetes/util_test.py
@@ -6,6 +6,7 @@ from kubernetes.client.models.v1_node_selector_requirement import V1NodeSelector
 from kubernetes.client.models.v1_node_selector_term import V1NodeSelectorTerm
 
 from clusterman.kubernetes.util import CachedCoreV1Api
+from clusterman.kubernetes.util import ConciseCRDApi
 from clusterman.kubernetes.util import ResourceParser
 from clusterman.kubernetes.util import selector_term_matches_requirement
 
@@ -73,3 +74,15 @@ def test_selector_term_matches_requirement():
     ]
     selector_requirement = V1NodeSelectorRequirement(key="clusterman.com/pool", operator="In", values=["bar"])
     assert selector_term_matches_requirement(selector_term, selector_requirement)
+
+
+@mock.patch("clusterman.kubernetes.util.kubernetes")
+def test_concise_crd_api(mock_kube):
+    api = ConciseCRDApi("/foo/bar/admin.conf", "group-x", "v-y", "plur-z")
+    api.list_node_migration_resources(label_selector="foo=bar")
+    mock_kube.client.CustomObjectsApi.return_value.list_node_migration_resources.assert_called_once_with(
+        group="group-x",
+        plural="plur-z",
+        version="v-y",
+        label_selector="foo=bar",
+    )

--- a/tests/migration/migration_event_enums_test.py
+++ b/tests/migration/migration_event_enums_test.py
@@ -1,0 +1,34 @@
+# Copyright 2019 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Any
+
+import pytest
+
+from clusterman.migration.event_enums import ConditionOperator
+
+
+@pytest.mark.parametrize(
+    "op,left,right,result",
+    (
+        (ConditionOperator.LT, 1, 2, True),
+        (ConditionOperator.LT, 3, 2, False),
+        (ConditionOperator.EQ, 2, 2, True),
+        (ConditionOperator.NE, 1, 2, True),
+        (ConditionOperator.IN, 1, (1, 2, 3), True),
+        (ConditionOperator.IN, 1, (2, 3), False),
+        (ConditionOperator.NOTIN, 1, (3, 4, 5), True),
+    ),
+)
+def test_operator_apply(op: ConditionOperator, left: Any, right: Any, result: bool):
+    assert op.apply(left, right) is result

--- a/tests/migration/migration_event_test.py
+++ b/tests/migration/migration_event_test.py
@@ -1,0 +1,69 @@
+# Copyright 2019 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Type
+
+import packaging.version
+import pytest
+import semver
+
+from clusterman.migration.event import ConditionOperator
+from clusterman.migration.event import ConditionTrait
+from clusterman.migration.event import MigrationCondition
+
+
+@pytest.mark.parametrize(
+    "trait,operator,target,expected",
+    (
+        (
+            "kernel",
+            "ge",
+            "1.2.3-4567-aws",
+            MigrationCondition(
+                ConditionTrait.KERNEL, ConditionOperator.GE, semver.parse_version_info("1.2.3-4567-aws")
+            ),
+        ),
+        (
+            "lsbrelease",
+            "ge",
+            "22.04",
+            MigrationCondition(ConditionTrait.LSBRELEASE, ConditionOperator.GE, packaging.version.parse("22.04")),
+        ),
+        (
+            "instance_type",
+            "in",
+            "m5.4xlarge,r5.2xLARGE",
+            MigrationCondition(ConditionTrait.INSTANCE_TYPE, ConditionOperator.IN, ["m5.4xlarge", "r5.2xlarge"]),
+        ),
+        ("uptime", "lt", "30d", MigrationCondition(ConditionTrait.UPTIME, ConditionOperator.LT, 30 * 24 * 60 * 60)),
+        ("uptime", "le", "1337", MigrationCondition(ConditionTrait.UPTIME, ConditionOperator.LE, 1337)),
+    ),
+)
+def test_condition_from_dict(trait: str, operator: str, target: str, expected: MigrationCondition):
+    assert MigrationCondition.from_dict({"trait": trait, "operator": operator, "target": target}) == expected
+
+
+@pytest.mark.parametrize(
+    "trait,operator,target,error",
+    (
+        ("kernel", "ne", "adjksfghlasdjk", ValueError),
+        ("lsbrelease", "ne", "adjksfghlasdjk", ValueError),
+        ("instance_type", "in", "m5.4xlarge,foobar.1xsmall", ValueError),
+        ("uptime", "ge", "foobar", ValueError),
+        ("instance_type", "ge", "m5.4xlarge", ValueError),
+        ("uptime", "in", "1337", ValueError),
+    ),
+)
+def test_condition_from_input_error(trait: str, operator: str, target: str, error: Type[Exception]):
+    with pytest.raises(error):
+        MigrationCondition.from_dict({"trait": trait, "operator": operator, "target": target})


### PR DESCRIPTION
### Description
Apologies for the big diff, wasn't easy to do in smaller chunks.
This replaces all the SQS stuff in the node migration batch to use a k8s custom resource instead. I also brought in some bits from #182 since I updated the condition logic quite a bit and wanted to have the input validation parts in place.

### Testing Done
* Added unit tests as always;
* Tried out the custom resource api calls in kubestage (no comment on the readability of the python k8s library...).