### PR TITLE
Add PAASTA_ENV env var for jenkins pipeline

### DIFF
--- a/jenkins.yaml
+++ b/jenkins.yaml
@@ -10,4 +10,6 @@ overrides:
       PAASTA_ENV: YELP
   debian:
     platforms: [xenial, bionic]
+    globalEnvVars:
+      PAASTA_ENV: YELP
 host_type: bionic


### PR DESCRIPTION
our internal jenkins pipelines no longer run in an environment that has hostnames that contain yelpcorp