### PR TITLE
Fix awscli conflict

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ RUN     apt-get update \
             lsb-release \
             make \
             openssh-client \
-            python3.6 \
             python3.7 \
             python3-distutils \
             python-pip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN     apt-get update \
             make \
             openssh-client \
             python3.7 \
-            python3-distutils \
+            python3.7-distutils \
             python-pip \
             python-setuptools \
             stdin2scribe \

--- a/acceptance/run_instance.py
+++ b/acceptance/run_instance.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.6
+#!/usr/bin/python3.7
 # Copyright 2019 Yelp Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,9 @@ Depends:
 # unfortunately needed for numpy to work
     libatlas3-base,
 # needed so that we can grab signals from s3
-    awscli,
+# that said, we have an internal fork that conflicts with this
+# once that's gone, we should re-add this (aws-cli vs awscli)
+#    awscli,
     ${misc:Depends},
     ${python:Depends},
     ${shlibs:Depends},

--- a/debian/control
+++ b/debian/control
@@ -11,6 +11,7 @@ Depends:
 # needed so that we can grab signals from s3
 # that said, we have an internal fork that conflicts with this
 # once that's gone, we should re-add this (aws-cli vs awscli)
+# instead of adding this with `jammyOrLater:Depends`
 #    awscli,
     ${misc:Depends},
     ${python:Depends},

--- a/debian/control
+++ b/debian/control
@@ -16,5 +16,6 @@ Depends:
     ${python:Depends},
     ${shlibs:Depends},
     ${bionicOrLater:Depends},
+    ${jammyOrLater:Depends},
 Architecture: any
 Description: Cluster scaling and management - y/clusterman

--- a/debian/rules
+++ b/debian/rules
@@ -16,6 +16,15 @@ else
     extra_substvars = -VbionicOrLater:Depends=""
 endif
 
+# and then do the same thing for awscli - of which we used to have a patched version called aws-cli pre-jammy.
+# once jammy boxes are the oldest things we install clusterman on, we can get rid of this and just include this
+# directly in debian/control
+ifeq ($(shell (. /etc/os-release && dpkg --compare-versions $$VERSION_ID "ge" "22.04" && echo yes || echo no)),yes)
+    extra_substvars = -VjammyOrLater:Depends="awscli"
+else
+    extra_substvars = -VjammyOrLater:Depends="aws-cli"
+endif
+
 
 %:
 	dh $@ --with python-virtualenv

--- a/debian/rules
+++ b/debian/rules
@@ -22,6 +22,10 @@ endif
 ifeq ($(shell (. /etc/os-release && dpkg --compare-versions $$VERSION_ID "ge" "22.04" && echo yes || echo no)),yes)
     extra_substvars = -VjammyOrLater:Depends="awscli"
 else
+	# aws-cli only exists internally, so lets make sure that we only use it internally
+    ifneq ($(shell echo ${PAASTA_ENV}), YELP)
+        extra_substvars = -VjammyOrLater:Depends="awscli"
+    endif
     extra_substvars = -VjammyOrLater:Depends="aws-cli"
 endif
 

--- a/debian/rules
+++ b/debian/rules
@@ -23,10 +23,11 @@ ifeq ($(shell (. /etc/os-release && dpkg --compare-versions $$VERSION_ID "ge" "2
     extra_substvars = -VjammyOrLater:Depends="awscli"
 else
 	# aws-cli only exists internally, so lets make sure that we only use it internally
-    ifneq ($(shell echo ${PAASTA_ENV}), YELP)
+    ifeq ($(shell echo ${PAASTA_ENV}), YELP)
+        extra_substvars = -VjammyOrLater:Depends="aws-cli"
+    else
         extra_substvars = -VjammyOrLater:Depends="awscli"
     endif
-    extra_substvars = -VjammyOrLater:Depends="aws-cli"
 endif
 
 

--- a/package/Makefile
+++ b/package/Makefile
@@ -6,6 +6,12 @@ PACKAGE_VERSION ?= $(shell cd $(CURDIR)/.. && python setup.py --version)
 ACCEPTANCE_DIR:=$(CURDIR)/../acceptance
 
 ifeq ($(findstring .yelpcorp.com,$(shell hostname -f)), .yelpcorp.com)
+	PAASTA_ENV ?= YELP
+else
+	PAASTA_ENV ?= $(shell hostname --fqdn)
+endif
+
+ifeq ($(PAASTA_ENV),YELP)
 	export DOCKER_REGISTRY ?= docker-dev.yelpcorp.com
 	export XENIAL_IMAGE_NAME ?= xenial_pkgbuild
 	export BIONIC_IMAGE_NAME ?= bionic_pkgbuild
@@ -19,17 +25,17 @@ endif
 
 UID:=`id -u`
 GID:=`id -g`
-DOCKER_BUILD_RUN:=docker run -t -e CI=${CI} -v $(CURDIR)/..:/src:ro -v $(CURDIR)/dist:/dist:rw
+DOCKER_BUILD_RUN:=docker run -t -e CI=${CI} -e PAASTA_ENV=${PAASTA_ENV} -v $(CURDIR)/..:/src:ro -v $(CURDIR)/dist:/dist:rw
 VERSIONED_FILES:=$(shell cd $(CURDIR)/.. && git ls-files -z --cached --modified | xargs -0 -I@ echo -n "'@' ")
 DOCKER_WORKDIR:=mkdir -p /work && cd /src && cp -vP --parents $(VERSIONED_FILES) /work/ && cp -r completions /work/ && cd /work
 
 itest_%: export EXTRA_VOLUME_MOUNTS=/nail/etc/services/services.yaml:/nail/etc/services/services.yaml:ro
 itest_%: package_% dist/%/Packages.gz
-	./debian-itest-runner $* $(SYSTEM_PKG_NAME) $(PACKAGE_VERSION)
+	./debian-itest-runner $* $(SYSTEM_PKG_NAME) $(PACKAGE_VERSION) $(PAASTA_ENV)
 
 itest_%-external: export EXTRA_VOLUME_MOUNTS=$(ACCEPTANCE_DIR)/srv-configs/clusterman-external.yaml:/nail/srv/configs/clusterman.yaml:ro
 itest_%-external: package_%_external dist/%/Packages.gz
-	./debian-itest-runner $* $(SYSTEM_PKG_NAME) $(PACKAGE_VERSION)
+	./debian-itest-runner $* $(SYSTEM_PKG_NAME) $(PACKAGE_VERSION) $(PAASTA_ENV)
 
 dist/%/Packages.gz:
 	$(DOCKER_BUILD_RUN) $(SYSTEM_PKG_NAME)_$*_container /bin/bash -c "\

--- a/package/debian-itest-runner
+++ b/package/debian-itest-runner
@@ -8,6 +8,7 @@ trap cleanup SIGINT
 DISTRIB_CODENAME=$1
 PACKAGE_NAME=$2
 PACKAGE_VERSION=$3
+PAASTA_ENV=$4
 declare -A CODENAME_TO_IMAGE=( ["xenial"]=${XENIAL_IMAGE_NAME} ["bionic"]=${BIONIC_IMAGE_NAME} ["jammy"]=${JAMMY_IMAGE_NAME})
 DOCKER_IMAGE=${CODENAME_TO_IMAGE[$DISTRIB_CODENAME]}
 CONTAINER_NAME=clusterman_debian_itest_${DISTRIB_CODENAME}
@@ -37,6 +38,6 @@ fi
 
 docker network connect "clusterman_${DISTRIB_CODENAME}_default" "${CONTAINER}"
 docker network connect "clusterman_${DISTRIB_CODENAME}_acceptance" "${CONTAINER}"
-docker exec ${EXAMPLE_FLAG} "${CONTAINER}" /itest/ubuntu.sh "${PACKAGE_NAME}" "${PACKAGE_VERSION}"
+docker exec ${EXAMPLE_FLAG} "${CONTAINER}" /itest/ubuntu.sh "${PACKAGE_NAME}" "${PACKAGE_VERSION}" "${PAASTA_ENV}"
 cleanup
 docker rm "${CONTAINER_NAME}"

--- a/package/itest/ubuntu.sh
+++ b/package/itest/ubuntu.sh
@@ -36,7 +36,8 @@ if [ "${DISTRIB_CODENAME}" = "jammy" ]; then
 fi
 # our debian/control will already install py3.7, but we want to install it ahead of time so that
 # we can also get the right pip version installed as well
-apt-get install -y --force-yes python3.7 python3-pip
+# TODO: remove awscli here once we no longer puppet aws-cli
+apt-get install -y --force-yes python3.7 python3-pip awscli
 dpkg -i /dist/${DISTRIB_CODENAME}/clusterman_${PACKAGE_VERSION}_amd64.deb || true
 # dpkg -i will have left some dependencies uninstalled, so this will install them
 apt-get install -y --force-yes --fix-broken

--- a/package/itest/ubuntu.sh
+++ b/package/itest/ubuntu.sh
@@ -37,11 +37,16 @@ if [ "${PAASTA_ENV}" != "YELP" ]; then
 fi
 # our debian/control will already install py3.7, but we want to install it ahead of time so that
 # we can also get the right pip version installed as well.
-# we also install python3-yaml here to avoid issues on newer ubuntus
-# where distutils has been split into a python3-distutils package
-# and it seems to install to the wrong place (i.e., python3.7 ... doesn't find it)
 apt-get install -y --force-yes python3.7 python3-pip python3-yaml
 # Install package directly with any needed dependencies
+
+# we also install python3-distutils here to avoid issues on newer ubuntus
+# where disutils isn't included with python (and even though clusterman depends on it, the right
+# version isn't installed in this itest container)
+if  [ "${DISTRIB_CODENAME}" != "xenial" ]; then
+apt-get install -y --force-yes python3.7-distutils
+fi
+
 apt-get install -y --force-yes ./dist/${DISTRIB_CODENAME}/clusterman_${PACKAGE_VERSION}_amd64.deb
 
 # Sometimes our acceptance tests run in parallel on the same box, so we need to use different CIDR ranges
@@ -52,7 +57,7 @@ else
 fi
 
 export ACCEPTANCE_ROOT=/itest
-python3.7 -m pip install boto3 simplejson
+python3.7 -m pip install boto3 simplejson pyyaml
 python3.7 /itest/run_instance.py \
     http://moto-ec2:5000/ \
     http://moto-s3:5000/ \

--- a/package/itest/ubuntu.sh
+++ b/package/itest/ubuntu.sh
@@ -38,7 +38,7 @@ fi
 # we can also get the right pip version installed as well
 apt-get install -y --force-yes python3.7 python3-pip
 # Install package directly with any needed dependencies
-apt-get install ./dist/${DISTRIB_CODENAME}/clusterman_${PACKAGE_VERSION}_amd64.deb
+apt-get install -y --force-yes ./dist/${DISTRIB_CODENAME}/clusterman_${PACKAGE_VERSION}_amd64.deb
 
 # Sometimes our acceptance tests run in parallel on the same box, so we need to use different CIDR ranges
 if [ "${DISTRIB_CODENAME}" = "xenial" ]; then

--- a/package/itest/ubuntu.sh
+++ b/package/itest/ubuntu.sh
@@ -49,7 +49,7 @@ else
 fi
 
 export ACCEPTANCE_ROOT=/itest
-python3.7 -m pip install boto3 simplejson
+python3.7 -m pip install boto3 simplejson pyyaml
 python3.7 /itest/run_instance.py \
     http://moto-ec2:5000/ \
     http://moto-s3:5000/ \

--- a/package/itest/ubuntu.sh
+++ b/package/itest/ubuntu.sh
@@ -18,6 +18,7 @@ highlight_exec() {
 
 PACKAGE_NAME="$1"
 PACKAGE_VERSION="$2"
+PAASTA_ENV="$3"
 
 # This will get DISTRIB_CODENAME
 source /etc/lsb-release
@@ -31,7 +32,7 @@ ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 apt-get update && apt-get install -y software-properties-common
 # we really only need this externally, but we use a python not included
 # by ubuntu - so add the deadsnakes ppa to bring that in
-if [ "${DISTRIB_CODENAME}" = "jammy" ]; then
+if [ "${PAASTA_ENV}" != "YELP" ]; then
     add-apt-repository ppa:deadsnakes/ppa
 fi
 # our debian/control will already install py3.7, but we want to install it ahead of time so that

--- a/package/itest/ubuntu.sh
+++ b/package/itest/ubuntu.sh
@@ -36,8 +36,7 @@ if [ "${DISTRIB_CODENAME}" = "jammy" ]; then
 fi
 # our debian/control will already install py3.7, but we want to install it ahead of time so that
 # we can also get the right pip version installed as well
-# TODO: remove awscli here once we no longer puppet aws-cli
-apt-get install -y --force-yes python3.7 python3-pip awscli
+apt-get install -y --force-yes python3.7 python3-pip
 dpkg -i /dist/${DISTRIB_CODENAME}/clusterman_${PACKAGE_VERSION}_amd64.deb || true
 # dpkg -i will have left some dependencies uninstalled, so this will install them
 apt-get install -y --force-yes --fix-broken

--- a/package/itest/ubuntu.sh
+++ b/package/itest/ubuntu.sh
@@ -36,8 +36,11 @@ if [ "${PAASTA_ENV}" != "YELP" ]; then
     add-apt-repository ppa:deadsnakes/ppa
 fi
 # our debian/control will already install py3.7, but we want to install it ahead of time so that
-# we can also get the right pip version installed as well
-apt-get install -y --force-yes python3.7 python3-pip
+# we can also get the right pip version installed as well.
+# we also install python3-yaml here to avoid issues on newer ubuntus
+# where distutils has been split into a python3-distutils package
+# and it seems to install to the wrong place (i.e., python3.7 ... doesn't find it)
+apt-get install -y --force-yes python3.7 python3-pip python3-yaml
 # Install package directly with any needed dependencies
 apt-get install -y --force-yes ./dist/${DISTRIB_CODENAME}/clusterman_${PACKAGE_VERSION}_amd64.deb
 
@@ -49,7 +52,7 @@ else
 fi
 
 export ACCEPTANCE_ROOT=/itest
-python3.7 -m pip install boto3 simplejson pyyaml
+python3.7 -m pip install boto3 simplejson
 python3.7 /itest/run_instance.py \
     http://moto-ec2:5000/ \
     http://moto-s3:5000/ \

--- a/package/itest/ubuntu.sh
+++ b/package/itest/ubuntu.sh
@@ -38,7 +38,7 @@ fi
 # we can also get the right pip version installed as well
 apt-get install -y --force-yes python3.7 python3-pip
 # Install package directly with any needed dependencies
-gdebi -nq /dist/${DISTRIB_CODENAME}/clusterman_${PACKAGE_VERSION}_amd64.deb
+apt-get install ./dist/${DISTRIB_CODENAME}/clusterman_${PACKAGE_VERSION}_amd64.deb
 
 # Sometimes our acceptance tests run in parallel on the same box, so we need to use different CIDR ranges
 if [ "${DISTRIB_CODENAME}" = "xenial" ]; then

--- a/package/itest/ubuntu.sh
+++ b/package/itest/ubuntu.sh
@@ -37,9 +37,8 @@ fi
 # our debian/control will already install py3.7, but we want to install it ahead of time so that
 # we can also get the right pip version installed as well
 apt-get install -y --force-yes python3.7 python3-pip
-dpkg -i /dist/${DISTRIB_CODENAME}/clusterman_${PACKAGE_VERSION}_amd64.deb || true
-# dpkg -i will have left some dependencies uninstalled, so this will install them
-apt-get install -y --force-yes --fix-broken
+# Install package directly with any needed dependencies
+gdebi -nq /dist/${DISTRIB_CODENAME}/clusterman_${PACKAGE_VERSION}_amd64.deb
 
 # Sometimes our acceptance tests run in parallel on the same box, so we need to use different CIDR ranges
 if [ "${DISTRIB_CODENAME}" = "xenial" ]; then

--- a/tox.ini
+++ b/tox.ini
@@ -65,7 +65,7 @@ usedevelop = false
 commands =
 
 [testenv:acceptance]
-basepython = python3.6
+basepython = python3.7
 envdir = .tox/acceptance
 passenv = COMPOSE_PROJECT_NAME PIP_INDEX_URL
 deps =


### PR DESCRIPTION
We install a forked aws-cli internally, and that conflicts with the upstream awscli.

`dpkg -I` on the bionic package says:
```
Depends: python3.7, libatlas3-base, libc6 (>= 2.26), libexpat1 (>= 2.1~beta3),
libgcc1 (>= 1:3.0), libstdc++6 (>= 5.2), libyaml-0-2, zlib1g (>= 1:1.2.0),
aws-cli
```

and on the jammy package:
```
Depends: python3.7, libatlas3-base, libc6 (>= 2.32), libgcc-s1 (>= 3.0),
libstdc++6 (>= 11), libyaml-0-2, awscli
```

I also installed this on the a kubestage box using `sudo apt-get install ./clusterman_4.10.4_amd64.deb` and got:
```
The following packages will be upgraded:
  clusterman
```
as opposed to what I get from installing the current mispackaged version
with `sudo apt-get install clusterman=4.10.4`
```
The following additional packages will be installed:
  awscli
The following NEW packages will be installed:
  awscli
The following packages will be upgraded:
  clusterman
```