### PR TITLE
add kernel and lsbrelease to agent metadata

### DIFF
--- a/clusterman/interfaces/types.py
+++ b/clusterman/interfaces/types.py
@@ -24,6 +24,8 @@ class AgentMetadata(NamedTuple):
     state: AgentState = AgentState.UNKNOWN
     task_count: int = 0
     total_resources: ClustermanResources = ClustermanResources()
+    kernel: str = ""
+    lsbrelease: str = ""
 
 
 class InstanceMetadata(NamedTuple):

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -37,6 +37,8 @@ from clusterman.interfaces.types import AgentState
 from clusterman.kubernetes.util import allocated_node_resources
 from clusterman.kubernetes.util import CachedCoreV1Api
 from clusterman.kubernetes.util import get_node_ip
+from clusterman.kubernetes.util import get_node_kernel_version
+from clusterman.kubernetes.util import get_node_lsbrelease
 from clusterman.kubernetes.util import PodUnschedulableReason
 from clusterman.kubernetes.util import selector_term_matches_requirement
 from clusterman.kubernetes.util import total_node_resources
@@ -279,6 +281,8 @@ class KubernetesClusterConnector(ClusterConnector):
             state=(AgentState.RUNNING if self._pods_by_ip[node_ip] else AgentState.IDLE),
             task_count=len(self._pods_by_ip[node_ip]),
             total_resources=total_node_resources(node, self._excluded_pods_by_ip.get(node_ip, [])),
+            kernel=get_node_kernel_version(node),
+            lsbrelease=get_node_lsbrelease(node),
         )
 
     def _is_node_frozen(self, node: KubernetesNode) -> bool:

--- a/clusterman/kubernetes/util.py
+++ b/clusterman/kubernetes/util.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+import re
 import socket
 from enum import auto
 from enum import Enum
@@ -41,6 +42,7 @@ DEFAULT_KUBERNETES_DISK_REQUEST = "0"  # Kubernetes doesn't schedule based on di
 KUBERNETES_API_CACHE_SIZE = 16
 KUBERNETES_API_CACHE_TTL = 60
 KUBERNETES_API_CACHE = TTLCache(maxsize=KUBERNETES_API_CACHE_SIZE, ttl=KUBERNETES_API_CACHE_TTL)
+VERSION_MATCH_EXPR = re.compile(r"(\W|^)(?P<release>\d+\.\d+(\.\d+)?)(\W|$)")
 logger = colorlog.getLogger(__name__)
 
 
@@ -136,6 +138,26 @@ def get_node_ip(node: KubernetesNode) -> str:
         if address.type == "InternalIP":
             return address.address
     raise ValueError('Kubernetes node {node.metadata.name} has no "InternalIP" address')
+
+
+def get_node_kernel_version(node: KubernetesNode) -> str:
+    """Get kernel version from node info
+
+    :param KubernetesNode node: k8s node object
+    :return: kernel version if present
+    """
+    return getattr(node.status.node_info, "kernel_version", "")
+
+
+def get_node_lsbrelease(node: KubernetesNode) -> str:
+    """Get operating system release from node info
+
+    :param KubernetesNode node: k8s node object
+    :return: os release if present
+    """
+    os_image = getattr(node.status.node_info, "os_image", "")
+    m = VERSION_MATCH_EXPR.search(os_image)
+    return m.group("release") if m else ""
 
 
 def total_node_resources(node: KubernetesNode, excluded_pods: List[KubernetesPod]) -> ClustermanResources:

--- a/tests/kubernetes/util_test.py
+++ b/tests/kubernetes/util_test.py
@@ -1,4 +1,5 @@
 import os
+from argparse import Namespace
 
 import mock
 import pytest
@@ -6,6 +7,8 @@ from kubernetes.client.models.v1_node_selector_requirement import V1NodeSelector
 from kubernetes.client.models.v1_node_selector_term import V1NodeSelectorTerm
 
 from clusterman.kubernetes.util import CachedCoreV1Api
+from clusterman.kubernetes.util import get_node_kernel_version
+from clusterman.kubernetes.util import get_node_lsbrelease
 from clusterman.kubernetes.util import ResourceParser
 from clusterman.kubernetes.util import selector_term_matches_requirement
 
@@ -73,3 +76,33 @@ def test_selector_term_matches_requirement():
     ]
     selector_requirement = V1NodeSelectorRequirement(key="clusterman.com/pool", operator="In", values=["bar"])
     assert selector_term_matches_requirement(selector_term, selector_requirement)
+
+
+@pytest.mark.parametrize(
+    "node_info,expected",
+    (
+        # using an argparse namespace to simulate system info object
+        (Namespace(), ""),
+        (Namespace(kernel_version="1.2.3"), "1.2.3"),
+    ),
+)
+def test_get_node_kernel_version(node_info, expected):
+    node = mock.MagicMock()
+    node.status.node_info = node_info
+    assert get_node_kernel_version(node) == expected
+
+
+@pytest.mark.parametrize(
+    "node_info,expected",
+    (
+        # using an argparse namespace to simulate system info object
+        (Namespace(), ""),
+        (Namespace(os_image="Some 1.2.3 foobar"), "1.2.3"),
+        (Namespace(os_image="Some 1.02 foobar"), "1.02"),
+        (Namespace(os_image="1.2.3"), "1.2.3"),
+    ),
+)
+def test_get_node_lsbrelease(node_info, expected):
+    node = mock.MagicMock()
+    node.status.node_info = node_info
+    assert get_node_lsbrelease(node) == expected


### PR DESCRIPTION
### Description

Adds to the `AgentMetadata` tuple fields for kernel version and OS release, to be used for node selection in migration jobs (remaining comparison traits, uptime and instance type, are already present in `InstanceMetadata`).

### Testing Done

Very minimal unit tests. Everything has fallback default values, so should be quite safe to ship.
