### PR TITLE
node_migration: uptime monitoring worker

### DIFF
--- a/clusterman/migration/event.py
+++ b/clusterman/migration/event.py
@@ -49,7 +49,7 @@ def _load_version_target(target: str) -> ComparableVersion:
     return parsed
 
 
-def _load_timespan_target(target: str) -> int:
+def load_timespan_target(target: str) -> int:
     """Validate and parse input timespan
 
     :param str target: either seconds or human readable span (e.g. 5d)
@@ -73,7 +73,7 @@ def _load_instance_type_target(target: str) -> str:
 CONDITION_TARGET_LOADERS: Dict[ConditionTrait, Callable[[str], Union[str, int, List[str]]]] = {
     ConditionTrait.KERNEL: _load_version_target,
     ConditionTrait.LSBRELEASE: _load_version_target,
-    ConditionTrait.UPTIME: _load_timespan_target,
+    ConditionTrait.UPTIME: load_timespan_target,
     ConditionTrait.INSTANCE_TYPE: _load_instance_type_target,
 }
 

--- a/clusterman/migration/settings.py
+++ b/clusterman/migration/settings.py
@@ -16,6 +16,7 @@ from typing import cast
 from typing import NamedTuple
 from typing import Union
 
+from clusterman.interfaces.types import ClusterNodeMetadata
 from clusterman.util import parse_time_interval_seconds
 
 
@@ -32,6 +33,14 @@ class MigrationPrecendence(enum.Enum):
     @classmethod
     def default(cls) -> str:
         return cls.UPTIME.value
+
+    def sort_key(self, node: ClusterNodeMetadata) -> int:
+        """Key function to be passed to sorting routines"""
+        if self == MigrationPrecendence.UPTIME:
+            return -node.instance.uptime.total_seconds()
+        elif self == MigrationPrecendence.TASK_COUNT:
+            return node.agent.task_count
+        return 0
 
 
 class PoolPortion:

--- a/clusterman/migration/worker.py
+++ b/clusterman/migration/worker.py
@@ -1,0 +1,134 @@
+# Copyright 2019 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import time
+from multiprocessing import Process
+from typing import Callable
+from typing import cast
+from typing import Collection
+
+import colorlog
+
+from clusterman.autoscaler.pool_manager import AWS_RUNNING_STATES
+from clusterman.autoscaler.pool_manager import PoolManager
+from clusterman.interfaces.types import ClusterNodeMetadata
+from clusterman.kubernetes.kubernetes_cluster_connector import KubernetesClusterConnector
+from clusterman.migration.event import MigrationEvent
+from clusterman.migration.settings import WorkerSetup
+
+
+logger = colorlog.getLogger(__name__)
+UPTIME_CHECK_INTERVAL_SECONDS = 60 * 60  # 1 hour
+HEALTH_CHECK_INTERVAL_SECONDS = 60
+SUPPORTED_POOL_SCHEDULER = "kubernetes"
+
+
+class RestartableDaemonProcess:
+    def __init__(self, target, args, kwargs) -> None:
+        self.__target = target
+        self.__args = args
+        self.__kwargs = kwargs
+        self._init_proc_handle()
+
+    def _init_proc_handle(self):
+        self.process_handle = Process(target=self.__target, args=self.__args, kwargs=self.__kwargs)
+        self.process_handle.daemon = True
+
+    def restart(self):
+        if self.process_handle.is_alive():
+            self.process_handle.kill()
+        self._init_proc_handle()
+        self.process_handle.start()
+
+    def __getattr__(self, attr):
+        return getattr(self.process_handle, attr)
+
+
+def _monitor_pool_health(manager: PoolManager, timeout: float, drained: Collection[ClusterNodeMetadata]) -> bool:
+    """Monitor pool health after nodes were submitted for draining
+
+    :param PoolManager manager: pool manager instance
+    :param float timeout: timestamp after which giving up
+    :param Collection[ClusterNodeMetadata] drained: nodes which were submitted for draining
+    :return: true if capacity is fulfilled
+    """
+    draining_happened = False
+    connector = cast(KubernetesClusterConnector, manager.cluster_connector)
+    while time.time() < timeout:
+        manager.reload_state()
+        draining_happened = draining_happened or not any(
+            node.agent.agent_id == connector.get_agent_metadata(node.instance.ip_address).agent_id for node in drained
+        )
+        if draining_happened and manager.is_capacity_satisfied() and not connector.get_unschedulable_pods():
+            return True
+        time.sleep(HEALTH_CHECK_INTERVAL_SECONDS)
+    return False
+
+
+def _drain_node_selection(
+    manager: PoolManager, selector: Callable[[ClusterNodeMetadata], bool], worker_setup: WorkerSetup
+) -> bool:
+    """Drain nodes in pool according to selection criteria
+
+    :param PoolManager manager: pool manager instance
+    :param Callable[[ClusterNodeMetadata], bool] selector: selection filter
+    :param WorkerSetup worker_setup: node migration setup
+    :return: true if completed
+    """
+    nodes = manager.get_node_metadatas(AWS_RUNNING_STATES)
+    selected = sorted(filter(selector, nodes), key=worker_setup.precedence.sort_key)
+    chunk = worker_setup.rate.of(len(nodes))
+    for i in range(0, len(selected), chunk):
+        start_time = time.time()
+        selection_chunk = selected[i : i + chunk]
+        for node in selection_chunk:
+            manager.submit_for_draining(node)
+        time.sleep(worker_setup.bootstrap_wait)
+        if not _monitor_pool_health(manager, start_time + worker_setup.bootstrap_timeout, selection_chunk):
+            logger.warning(
+                f"Pool {manager.cluster}:{manager.pool} did not come back"
+                " to desired capacity, stopping selection draining"
+            )
+            return False
+    return True
+
+
+def uptime_migration_worker(cluster: str, pool: str, uptime_seconds: int, worker_setup: WorkerSetup) -> None:
+    """Worker monitoring and migrating nodes according to uptime
+
+    :parma str cluster: cluster name
+    :param str pool: pool name
+    :param int uptime_seconds: uptime threshold
+    :param WorkerSetup worker_setup: migration setup
+    """
+    manager = PoolManager(cluster, pool, SUPPORTED_POOL_SCHEDULER)
+    node_selector = lambda node: node.instance.uptime.total_seconds() > uptime_seconds  # noqa
+    if not manager.draining_client:
+        logger.warning(f"Draining client not set up for {cluster}:{pool}, giving up")
+        return
+    while True:
+        if manager.is_capacity_satisfied():
+            _drain_node_selection(manager, node_selector, worker_setup)
+        else:
+            logger.warning(f"Pool {cluster}:{pool} is currently underprovisioned, skipping uptime migration iteration")
+        time.sleep(UPTIME_CHECK_INTERVAL_SECONDS)
+        manager.reload_state()
+
+
+def event_migration_worker(migration_event: MigrationEvent, worker_setup: WorkerSetup) -> None:
+    """Worker migrating nodes according to event configuration
+
+    :param MigrationEvent migration_event: event instance
+    :param WorkerSetup worker_setup: migration setup
+    """
+    pass  # TODO

--- a/tests/autoscaler/pool_manager_test.py
+++ b/tests/autoscaler/pool_manager_test.py
@@ -166,11 +166,11 @@ class TestPruneExcessFulfilledCapacity:
     @pytest.fixture
     def mock_nodes_to_prune(self):
         return {
-            "sfr-1": [mock.Mock(instance=mock.Mock(instance_id=1))],
+            "sfr-1": [mock.Mock(instance=mock.Mock(instance_id=1, group_id="sfr-1"))],
             "sfr-3": [
-                mock.Mock(instance=mock.Mock(instance_id=4)),
-                mock.Mock(instance=mock.Mock(instance_id=5)),
-                mock.Mock(instance=mock.Mock(instance_id=6)),
+                mock.Mock(instance=mock.Mock(instance_id=4, group_id="sfr-3")),
+                mock.Mock(instance=mock.Mock(instance_id=5, group_id="sfr-3")),
+                mock.Mock(instance=mock.Mock(instance_id=6, group_id="sfr-3")),
             ],
         }
 

--- a/tests/migration/migration_worker_test.py
+++ b/tests/migration/migration_worker_test.py
@@ -1,0 +1,133 @@
+# Copyright 2019 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import time
+from datetime import timedelta
+from itertools import chain
+from itertools import repeat
+from unittest.mock import call
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from clusterman.interfaces.types import AgentMetadata
+from clusterman.interfaces.types import ClusterNodeMetadata
+from clusterman.interfaces.types import InstanceMetadata
+from clusterman.migration.settings import MigrationPrecendence
+from clusterman.migration.settings import PoolPortion
+from clusterman.migration.settings import WorkerSetup
+from clusterman.migration.worker import _drain_node_selection
+from clusterman.migration.worker import _monitor_pool_health
+from clusterman.migration.worker import RestartableDaemonProcess
+from clusterman.migration.worker import uptime_migration_worker
+
+
+@patch("clusterman.migration.worker.time")
+def test_monitor_pool_health(mock_time):
+    mock_manager = MagicMock()
+    mock_connector = mock_manager.cluster_connector
+    drained = [
+        ClusterNodeMetadata(
+            AgentMetadata(agent_id=i), InstanceMetadata(market=None, weight=None, ip_address=f"{i}.{i}.{i}.{i}")
+        )
+        for i in range(5)
+    ]
+    mock_manager.is_capacity_satisfied.side_effect = [False, True, True]
+    mock_connector.get_unschedulable_pods.side_effect = [True, False]
+    mock_connector.get_agent_metadata.side_effect = chain(
+        (AgentMetadata(agent_id=i) for i in range(3)),
+        repeat(AgentMetadata(agent_id="")),
+    )
+    mock_time.time.return_value = 0
+    assert _monitor_pool_health(mock_manager, 1, drained) is True
+    # 1st iteration still draining some nodes
+    # 2nd iteration underprovisioned capacity
+    # 3rd iteration left over unscheduable pods
+    assert mock_time.sleep.call_count == 3
+
+
+@patch("clusterman.migration.worker.time")
+@patch("clusterman.migration.worker._monitor_pool_health")
+def test_drain_node_selection(mock_monitor, mock_time):
+    mock_manager = MagicMock()
+    mock_monitor.return_value = True
+    mock_manager.get_node_metadatas.return_value = [
+        ClusterNodeMetadata(AgentMetadata(agent_id=i, task_count=30 - 2 * i), InstanceMetadata(None, None))
+        for i in range(6)
+    ]
+    mock_time.time.side_effect = range(5)
+    worker_setup = WorkerSetup(
+        rate=PoolPortion(2),
+        prescaling=None,
+        precedence=MigrationPrecendence.TASK_COUNT,
+        bootstrap_wait=1,
+        bootstrap_timeout=2,
+        disable_autoscaling=False,
+        expected_duration=3,
+    )
+    assert _drain_node_selection(mock_manager, lambda n: n.agent.agent_id > 2, worker_setup) is True
+    mock_manager.get_node_metadatas.assert_called_once_with(("running",))
+    mock_manager.submit_for_draining.assert_has_calls(
+        [
+            call(ClusterNodeMetadata(AgentMetadata(agent_id=i, task_count=30 - 2 * i), InstanceMetadata(None, None)))
+            for i in range(5, 2, -1)
+        ]
+    )
+    mock_monitor.assert_has_calls(
+        [
+            call(
+                mock_manager,
+                2,
+                [
+                    ClusterNodeMetadata(AgentMetadata(agent_id=5, task_count=20), InstanceMetadata(None, None)),
+                    ClusterNodeMetadata(AgentMetadata(agent_id=4, task_count=22), InstanceMetadata(None, None)),
+                ],
+            ),
+            call(
+                mock_manager,
+                3,
+                [
+                    ClusterNodeMetadata(AgentMetadata(agent_id=3, task_count=24), InstanceMetadata(None, None)),
+                ],
+            ),
+        ]
+    )
+
+
+@patch("clusterman.migration.worker.time")
+@patch("clusterman.migration.worker.PoolManager")
+@patch("clusterman.migration.worker._drain_node_selection")
+def test_uptime_migration_worker(mock_drain_selection, mock_manager_class, mock_time):
+    mock_setup = MagicMock()
+    mock_manager = mock_manager_class.return_value
+    mock_manager.is_capacity_satisfied.side_effect = [True, False, True]
+    with pytest.raises(StopIteration):  # using end of mock side-effect to get out of forever looop
+        uptime_migration_worker("mesos-test", "bar", 10000, mock_setup)
+    assert mock_drain_selection.call_count == 2
+    selector = mock_drain_selection.call_args_list[0][0][1]
+    assert selector(ClusterNodeMetadata(None, InstanceMetadata(None, None, uptime=timedelta(seconds=10001)))) is True
+    assert selector(ClusterNodeMetadata(None, InstanceMetadata(None, None, uptime=timedelta(seconds=9999)))) is False
+
+
+def test_restartable_daemon_process():
+    proc = RestartableDaemonProcess(lambda: time.sleep(10), tuple(), {})
+    proc.start()
+    time.sleep(0.05)
+    assert proc.is_alive()
+    old_handle = proc.process_handle
+    proc.restart()
+    time.sleep(0.05)
+    assert proc.is_alive()
+    assert proc.process_handle is not old_handle
+    proc.kill()


### PR DESCRIPTION
### Description
This is most of the juice of the actual migration logic, with worker processes being spawned and submitting nodes for draining. This just contains the uptime monitoring bit since event processing will also require some more juggling the PoolManager to support filtering nodes with label selectors.
I'm also not very satisfied of the naive `is_capacity_satisfied` approach to establish pool health, as I feel it's a bit too simplistic. Very open to hear some feedback on that.
Regarding process handling, that's very naive as well at the moment. I ticketed myself about refining it a little in a future iteration.

### Testing Done
None apart from writing unit tests.
