### PR TITLE
node migration: event migration worker

### DIFF
--- a/clusterman/autoscaler/toggle.py
+++ b/clusterman/autoscaler/toggle.py
@@ -1,0 +1,59 @@
+# Copyright 2019 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import time
+from typing import Union
+
+import staticconf
+
+from clusterman.aws.client import dynamodb
+from clusterman.util import AUTOSCALER_PAUSED
+from clusterman.util import CLUSTERMAN_STATE_TABLE
+from clusterman.util import parse_time_string
+
+
+def disable_autoscaling(cluster: str, pool: str, scheduler: str, until: Union[str, int, float]):
+    """Disable autoscaling for a pool
+
+    :param str cluster: name of the cluster
+    :param str pool: name of the pool
+    :param str scheduler: cluster scheduler
+    :param str until: how long should it remain disabled
+    """
+    expiration = parse_time_string(until).timestamp if isinstance(until, str) else int(until)
+    state = {
+        "state": {"S": AUTOSCALER_PAUSED},
+        "entity": {"S": f"{cluster}.{pool}.{scheduler}"},
+        "timestamp": {"N": str(int(time.time()))},
+        "expiration_timestamp": {"N": str(expiration)},
+    }
+    dynamodb.put_item(
+        TableName=staticconf.read("aws.state_table", default=CLUSTERMAN_STATE_TABLE),
+        Item=state,
+    )
+
+
+def enable_autoscaling(cluster: str, pool: str, scheduler: str):
+    """Re-enable autoscaling for a pool
+
+    :param str cluster: name of the cluster
+    :param str pool: name of the pool
+    :param str scheduler: cluster scheduler
+    """
+    dynamodb.delete_item(
+        TableName=staticconf.read("aws.state_table", default=CLUSTERMAN_STATE_TABLE),
+        Key={
+            "state": {"S": AUTOSCALER_PAUSED},
+            "entity": {"S": f"{cluster}.{pool}.{scheduler}"},
+        },
+    )

--- a/clusterman/batch/node_migration.py
+++ b/clusterman/batch/node_migration.py
@@ -148,6 +148,7 @@ class NodeMigration(BatchDaemon, BatchLoggingMixin, BatchRunningSentinelMixin):
             migration_event=event,
             worker_setup=worker_setup,
         )
+        self.mark_event(event, MigrationStatus.INPROGRESS)
         self.events_in_progress.add(event)
 
     def spawn_uptime_worker(self, pool: str, uptime: Union[int, str]):

--- a/clusterman/cli/util.py
+++ b/clusterman/cli/util.py
@@ -1,8 +1,24 @@
+# Copyright 2019 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import argparse
-import signal
 import socket
+from functools import partial
 
 import colorlog
+
+from clusterman.util import limit_function_runtime
+
 
 logger = colorlog.getLogger(__name__)
 TIMEOUT_TIME_SECONDS = 10
@@ -10,18 +26,13 @@ TIMEOUT_TIME_SECONDS = 10
 
 def timeout_wrapper(main):
     def wrapper(args: argparse.Namespace):
-
         # After 10s, prints a warning message if the command is running from the wrong place
-        def timeout_handler(signum, frame):
+        def timeout_handler():
             warning_string = "This command is taking a long time to run; are you running from the right account?"
             if "yelpcorp" in socket.getfqdn():
                 warning_string += "\nHINT: try ssh'ing to adhoc-prod or another box in the right account."
             logger.warning(warning_string)
 
-        signal.signal(signal.SIGALRM, timeout_handler)
-        signal.alarm(TIMEOUT_TIME_SECONDS)
-
-        main(args)
-        signal.alarm(0)  # Cancel the alarm if we've gotten here
+        limit_function_runtime(partial(main, args), TIMEOUT_TIME_SECONDS, timeout_handler)
 
     return wrapper

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -274,6 +274,15 @@ class KubernetesClusterConnector(ClusterConnector):
         except Exception as e:
             logger.error(f"Failed creating migration event resource: {e}")
 
+    def has_enough_capacity_for_pods(self) -> bool:
+        """Checks whether there are unschedulable pods due to insufficient resources
+
+        :return: True if no unschedulable pods are due to resource constraints
+        """
+        return not any(
+            reason == PodUnschedulableReason.InsufficientResources for _, reason in self.get_unschedulable_pods()
+        )
+
     def _evict_tasks_from_node(self, hostname: str) -> bool:
         all_evicted = True
         pods_to_evict = [

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -73,7 +73,7 @@ class KubernetesClusterConnector(ClusterConnector):
     _unschedulable_pods: List[KubernetesPod]
     _excluded_pods_by_ip: Mapping[str, List[KubernetesPod]]
     _pods_by_ip: Mapping[str, List[KubernetesPod]]
-    _label_selectors: Collection[str]
+    _label_selectors: List[str]
 
     def __init__(self, cluster: str, pool: Optional[str], init_crd: bool = False) -> None:
         super().__init__(cluster, pool)
@@ -117,10 +117,10 @@ class KubernetesClusterConnector(ClusterConnector):
             else None
         )
 
-    def set_label_selectors(self, label_selectors: Collection[str], add_to_existing: bool = False) -> None:
+    def set_label_selectors(self, label_selectors: List[str], add_to_existing: bool = False) -> None:
         """Set label selectors for node listing purposes
 
-        :param Collection[str] label_selectors: list of selectors (joined with logic and)
+        :param List[str] label_selectors: list of selectors (joined with logic and)
         :param bool add_to_existing: if set add to existing selectors rather than replacing
         """
         self._label_selectors = sorted(

--- a/clusterman/migration/settings.py
+++ b/clusterman/migration/settings.py
@@ -23,7 +23,7 @@ from clusterman.util import parse_time_interval_seconds
 DEFAULT_POOL_PRESCALING = 0
 DEFAULT_NODE_BOOT_WAIT = "3m"
 DEFAULT_NODE_BOOT_TIMEOUT = "10m"
-DEFAULT_WORKER_TIMEOUT = "1d"
+DEFAULT_WORKER_TIMEOUT = "2h"
 
 
 class MigrationPrecendence(enum.Enum):
@@ -65,6 +65,9 @@ class PoolPortion:
         if not isinstance(other, PoolPortion):
             raise NotImplementedError()
         return self.init_value == other.init_value
+
+    def __bool__(self) -> bool:
+        return self.value > 0
 
 
 class WorkerSetup(NamedTuple):

--- a/clusterman/migration/worker.py
+++ b/clusterman/migration/worker.py
@@ -35,6 +35,7 @@ from clusterman.util import limit_function_runtime
 logger = colorlog.getLogger(__name__)
 UPTIME_CHECK_INTERVAL_SECONDS = 60 * 60  # 1 hour
 HEALTH_CHECK_INTERVAL_SECONDS = 60
+INITIAL_POOL_HEALTH_TIMEOUT_SECONDS = 15 * 60
 SUPPORTED_POOL_SCHEDULER = "kubernetes"
 
 
@@ -59,12 +60,19 @@ class RestartableDaemonProcess:
         return getattr(self.process_handle, attr)
 
 
-def _monitor_pool_health(manager: PoolManager, timeout: float, drained: Collection[ClusterNodeMetadata]) -> bool:
+class NodeMigrationError(Exception):
+    pass
+
+
+def _monitor_pool_health(
+    manager: PoolManager, timeout: float, drained: Collection[ClusterNodeMetadata], check_pods: bool = True
+) -> bool:
     """Monitor pool health after nodes were submitted for draining
 
     :param PoolManager manager: pool manager instance
     :param float timeout: timestamp after which giving up
     :param Collection[ClusterNodeMetadata] drained: nodes which were submitted for draining
+    :param bool check_pods: check that pods can successfully be schedules
     :return: true if capacity is fulfilled
     """
     draining_happened = False
@@ -74,7 +82,11 @@ def _monitor_pool_health(manager: PoolManager, timeout: float, drained: Collecti
         draining_happened = draining_happened or not any(
             node.agent.agent_id == connector.get_agent_metadata(node.instance.ip_address).agent_id for node in drained
         )
-        if draining_happened and manager.is_capacity_satisfied() and not connector.get_unschedulable_pods():
+        if (
+            draining_happened
+            and manager.is_capacity_satisfied()
+            and not (check_pods and connector.get_unschedulable_pods())
+        ):
             return True
         time.sleep(HEALTH_CHECK_INTERVAL_SECONDS)
     return False
@@ -93,10 +105,12 @@ def _drain_node_selection(
     nodes = manager.get_node_metadatas(AWS_RUNNING_STATES)
     selected = sorted(filter(selector, nodes), key=worker_setup.precedence.sort_key)
     chunk = worker_setup.rate.of(len(nodes))
+    logger.info(f"{len(selected)} nodes of {manager.cluster}:{manager.pool} will be recycled")
     for i in range(0, len(selected), chunk):
         start_time = time.time()
         selection_chunk = selected[i : i + chunk]
         for node in selection_chunk:
+            logger.info(f"Recycling node {node.instance.instance_id}")
             manager.submit_for_draining(node)
         time.sleep(worker_setup.bootstrap_wait)
         if not _monitor_pool_health(manager, start_time + worker_setup.bootstrap_timeout, selection_chunk):
@@ -143,6 +157,7 @@ def event_migration_worker(migration_event: MigrationEvent, worker_setup: Worker
     manager.reload_state()
     try:
         if worker_setup.disable_autoscaling:
+            logger.info(f"Disabling autoscaling for {migration_event.cluster}:{migration_event.pool}")
             disable_autoscaling(
                 migration_event.cluster,
                 migration_event.pool,
@@ -154,16 +169,25 @@ def event_migration_worker(migration_event: MigrationEvent, worker_setup: Worker
             offset = worker_setup.prescaling.of(len(nodes))
             avg_weight = mean(node.instance.weight for node in nodes)
             original_capacity = manager.target_capacity
-            manager.modify_target_capacity(manager.target_capacity + offset * avg_weight)
+            prescaled_capacity = round(manager.target_capacity + offset * avg_weight)
+            manager.modify_target_capacity(prescaled_capacity)
             prescaling_applied = True
+        if not _monitor_pool_health(
+            manager, time.time() + INITIAL_POOL_HEALTH_TIMEOUT_SECONDS, drained=[], check_pods=False
+        ):
+            raise NodeMigrationError(f"Pool {migration_event.cluster}:{migration_event.pool} is not healthy")
         node_selector = lambda node: node.agent.agent_id and not migration_event.condition.matches(node)  # noqa
         migration_routine = partial(_drain_node_selection, manager, node_selector, worker_setup)
-        limit_function_runtime(migration_routine, worker_setup.expected_duration)
+        if not limit_function_runtime(migration_routine, worker_setup.expected_duration):
+            raise NodeMigrationError(f"Failed migrating nodes for event {migration_event}")
     except Exception as e:
         logger.error(f"Issue while processing migration event {migration_event}: {e}")
         raise
     finally:
         if worker_setup.disable_autoscaling:
+            logger.info(f"Re-enabling autoscaling for {migration_event.cluster}:{migration_event.pool}")
             enable_autoscaling(migration_event.cluster, migration_event.pool, SUPPORTED_POOL_SCHEDULER)
-        if worker_setup.prescaling and prescaling_applied:
+        if worker_setup.prescaling and prescaling_applied and prescaled_capacity >= manager.target_capacity:
+            # Only restoring original capacity of the target remained equal or lower than
+            # our set target (i.e. the autoscaler didn't have to scale up in the meantime)
             manager.modify_target_capacity(original_capacity)

--- a/tests/batch/node_migration_test.py
+++ b/tests/batch/node_migration_test.py
@@ -109,7 +109,7 @@ def test_get_worker_setup(migration_batch):
         bootstrap_wait=180.0,
         bootstrap_timeout=180.0,
         disable_autoscaling=False,
-        expected_duration=86400.0,
+        expected_duration=7200.0,
     )
 
 

--- a/tests/cli/toggle_test.py
+++ b/tests/cli/toggle_test.py
@@ -45,7 +45,7 @@ class TestManageMethods:
             ensure_account_id("sample_cluster")
 
     @mock.patch("clusterman.cli.toggle.autoscaling_is_paused")
-    @mock.patch("clusterman.cli.toggle.dynamodb")
+    @mock.patch("clusterman.autoscaler.toggle.dynamodb")
     def test_enable(
         self,
         mock_dynamodb,
@@ -68,7 +68,7 @@ class TestManageMethods:
             enable(args)
 
     @mock.patch("clusterman.cli.toggle.autoscaling_is_paused")
-    @mock.patch("clusterman.cli.toggle.dynamodb")
+    @mock.patch("clusterman.autoscaler.toggle.dynamodb")
     def test_disable(
         self,
         mock_dynamodb,
@@ -91,7 +91,7 @@ class TestManageMethods:
             disable(args)
 
     @mock.patch("clusterman.cli.toggle.autoscaling_is_paused")
-    @mock.patch("clusterman.cli.toggle.dynamodb")
+    @mock.patch("clusterman.autoscaler.toggle.dynamodb")
     def test_disable_until(
         self,
         mock_dynamodb,

--- a/tests/kubernetes/kubernetes_cluster_connector_test.py
+++ b/tests/kubernetes/kubernetes_cluster_connector_test.py
@@ -338,6 +338,15 @@ def test_get_agent_metadata(mock_cluster_connector, ip_address, expected_state):
     assert agent_metadata.state == expected_state
 
 
+def test_get_nodes_by_ip(mock_cluster_connector):
+    mock_cluster_connector._core_api.list_node.reset_mock()
+    mock_cluster_connector.set_label_selectors(["foobar.clusterman.com/something=stuff"], add_to_existing=True)
+    mock_cluster_connector._get_nodes_by_ip()
+    mock_cluster_connector._core_api.list_node.assert_called_once_with(
+        label_selector="clusterman.com/pool=bar,foobar.clusterman.com/something=stuff",
+    )
+
+
 def test_allocation(mock_cluster_connector):
     assert mock_cluster_connector.get_resource_allocation("cpus") == 7.5
 

--- a/tests/migration/conftest.py
+++ b/tests/migration/conftest.py
@@ -1,0 +1,31 @@
+# Copyright 2019 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+import semver
+
+from clusterman.migration.event import ConditionOperator
+from clusterman.migration.event import ConditionTrait
+from clusterman.migration.event import MigrationCondition
+from clusterman.migration.event import MigrationEvent
+
+
+@pytest.fixture
+def mock_migration_event():
+    yield MigrationEvent(
+        resource_name="mesos-test-bar-111222333",
+        cluster="mesos-test",
+        pool="bar",
+        label_selectors=[],
+        condition=MigrationCondition(ConditionTrait.KERNEL, ConditionOperator.GE, semver.VersionInfo.parse("1.2.3")),
+    )

--- a/tests/migration/migration_event_enums_test.py
+++ b/tests/migration/migration_event_enums_test.py
@@ -11,11 +11,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from datetime import timedelta
 from typing import Any
 
+import packaging.version
 import pytest
+import semver
 
+from clusterman.aws.markets import InstanceMarket
+from clusterman.interfaces.types import AgentMetadata
+from clusterman.interfaces.types import ClusterNodeMetadata
+from clusterman.interfaces.types import InstanceMetadata
 from clusterman.migration.event_enums import ConditionOperator
+from clusterman.migration.event_enums import ConditionTrait
 
 
 @pytest.mark.parametrize(
@@ -32,3 +40,20 @@ from clusterman.migration.event_enums import ConditionOperator
 )
 def test_operator_apply(op: ConditionOperator, left: Any, right: Any, result: bool):
     assert op.apply(left, right) is result
+
+
+@pytest.mark.parametrize(
+    "enum_val,expected",
+    (
+        (ConditionTrait.INSTANCE_TYPE, "m6a.4xlarge"),
+        (ConditionTrait.UPTIME, 10 * 24 * 60 * 60),
+        (ConditionTrait.KERNEL, semver.VersionInfo.parse("3.2.1")),
+        (ConditionTrait.LSBRELEASE, packaging.version.parse("20.04")),
+    ),
+)
+def test_trait_get_from(enum_val, expected):
+    node_metadata = ClusterNodeMetadata(
+        agent=AgentMetadata(kernel="3.2.1", lsbrelease="20.04"),
+        instance=InstanceMetadata(market=InstanceMarket("m6a.4xlarge", None), weight=None, uptime=timedelta(days=10)),
+    )
+    assert enum_val.get_from(node_metadata) == expected

--- a/tests/migration/migration_event_test.py
+++ b/tests/migration/migration_event_test.py
@@ -25,6 +25,7 @@ from clusterman.interfaces.types import InstanceMetadata
 from clusterman.migration.event import ConditionOperator
 from clusterman.migration.event import ConditionTrait
 from clusterman.migration.event import MigrationCondition
+from clusterman.migration.event import MigrationEvent
 
 
 @pytest.mark.parametrize(

--- a/tests/migration/migration_worker_test.py
+++ b/tests/migration/migration_worker_test.py
@@ -25,6 +25,7 @@ import pytest
 from clusterman.interfaces.types import AgentMetadata
 from clusterman.interfaces.types import ClusterNodeMetadata
 from clusterman.interfaces.types import InstanceMetadata
+from clusterman.kubernetes.util import PodUnschedulableReason
 from clusterman.migration.settings import MigrationPrecendence
 from clusterman.migration.settings import PoolPortion
 from clusterman.migration.settings import WorkerSetup
@@ -59,7 +60,15 @@ def test_monitor_pool_health(mock_time):
         for i in range(5)
     ]
     mock_manager.is_capacity_satisfied.side_effect = [False, True, True]
-    mock_connector.get_unschedulable_pods.side_effect = [True, False]
+    mock_connector.get_unschedulable_pods.side_effect = [
+        [
+            (MagicMock(), PodUnschedulableReason.Unknown),
+            (MagicMock(), PodUnschedulableReason.InsufficientResources),
+        ],
+        [
+            (MagicMock(), PodUnschedulableReason.Unknown),
+        ],
+    ]
     mock_connector.get_agent_metadata.side_effect = chain(
         (AgentMetadata(agent_id=i) for i in range(3)),
         repeat(AgentMetadata(agent_id="")),

--- a/tests/migration/migration_worker_test.py
+++ b/tests/migration/migration_worker_test.py
@@ -15,6 +15,7 @@ import time
 from datetime import timedelta
 from itertools import chain
 from itertools import repeat
+from unittest.mock import ANY
 from unittest.mock import call
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -29,8 +30,22 @@ from clusterman.migration.settings import PoolPortion
 from clusterman.migration.settings import WorkerSetup
 from clusterman.migration.worker import _drain_node_selection
 from clusterman.migration.worker import _monitor_pool_health
+from clusterman.migration.worker import event_migration_worker
 from clusterman.migration.worker import RestartableDaemonProcess
 from clusterman.migration.worker import uptime_migration_worker
+
+
+@pytest.fixture
+def event_worker_setup():
+    yield WorkerSetup(
+        rate=PoolPortion(2),
+        prescaling=PoolPortion(1),
+        precedence=MigrationPrecendence.TASK_COUNT,
+        bootstrap_wait=1,
+        bootstrap_timeout=2,
+        disable_autoscaling=True,
+        expected_duration=3,
+    )
 
 
 @patch("clusterman.migration.worker.time")
@@ -118,6 +133,68 @@ def test_uptime_migration_worker(mock_drain_selection, mock_manager_class, mock_
     selector = mock_drain_selection.call_args_list[0][0][1]
     assert selector(ClusterNodeMetadata(None, InstanceMetadata(None, None, uptime=timedelta(seconds=10001)))) is True
     assert selector(ClusterNodeMetadata(None, InstanceMetadata(None, None, uptime=timedelta(seconds=9999)))) is False
+
+
+@patch("clusterman.migration.worker.time")
+@patch("clusterman.migration.worker.PoolManager")
+@patch("clusterman.migration.worker.enable_autoscaling")
+@patch("clusterman.migration.worker.disable_autoscaling")
+@patch("clusterman.migration.worker._drain_node_selection")
+@patch("clusterman.migration.worker.limit_function_runtime", lambda f, _: f())
+def test_event_migration_worker(
+    mock_drain_selection,
+    mock_disable_scaling,
+    mock_enable_scaling,
+    mock_manager_class,
+    mock_time,
+    mock_migration_event,
+    event_worker_setup,
+):
+    mock_time.time.return_value = 0
+    mock_manager = mock_manager_class.return_value
+    mock_manager.get_node_metadatas.return_value = [
+        ClusterNodeMetadata(
+            AgentMetadata(agent_id=i, task_count=30 - 2 * i, kernel=f"1.2.{i}"), InstanceMetadata(market=None, weight=4)
+        )
+        for i in range(1, 6)
+    ]
+    mock_manager.target_capacity = 19
+    event_migration_worker(mock_migration_event, event_worker_setup)
+    mock_manager.modify_target_capacity.assert_has_calls([call(23), call(19)])
+    mock_disable_scaling.assert_called_once_with("mesos-test", "bar", "kubernetes", 3)
+    mock_enable_scaling.assert_called_once_with("mesos-test", "bar", "kubernetes")
+    mock_drain_selection.assert_called_once_with(mock_manager, ANY, event_worker_setup)
+    selector = mock_drain_selection.call_args_list[0][0][1]
+    assert list(filter(selector, mock_manager.get_node_metadatas.return_value)) == [
+        ClusterNodeMetadata(
+            AgentMetadata(agent_id=i, task_count=30 - 2 * i, kernel=f"1.2.{i}"), InstanceMetadata(market=None, weight=4)
+        )
+        for i in range(1, 3)
+    ]
+
+
+@patch("clusterman.migration.worker.time")
+@patch("clusterman.migration.worker.PoolManager")
+@patch("clusterman.migration.worker.enable_autoscaling")
+@patch("clusterman.migration.worker.disable_autoscaling")
+@patch("clusterman.migration.worker._drain_node_selection")
+def test_event_migration_worker_error(
+    mock_drain_selection,
+    mock_disable_scaling,
+    mock_enable_scaling,
+    mock_manager_class,
+    mock_time,
+    mock_migration_event,
+    event_worker_setup,
+):
+    mock_time.time.return_value = 0
+    mock_manager = mock_manager_class.return_value
+    mock_manager.get_node_metadatas.side_effect = Exception(123)
+    with pytest.raises(Exception):
+        event_migration_worker(mock_migration_event, event_worker_setup)
+    mock_disable_scaling.assert_called_once_with("mesos-test", "bar", "kubernetes", 3)
+    mock_enable_scaling.assert_called_once_with("mesos-test", "bar", "kubernetes")
+    mock_manager.modify_target_capacity.assert_not_called()
 
 
 def test_restartable_daemon_process():

--- a/tests/migration/migration_worker_test.py
+++ b/tests/migration/migration_worker_test.py
@@ -140,6 +140,7 @@ def test_uptime_migration_worker(mock_drain_selection, mock_manager_class, mock_
 @patch("clusterman.migration.worker.enable_autoscaling")
 @patch("clusterman.migration.worker.disable_autoscaling")
 @patch("clusterman.migration.worker._drain_node_selection")
+@patch("clusterman.migration.worker._monitor_pool_health", lambda *_, **__: True)
 @patch("clusterman.migration.worker.limit_function_runtime", lambda f, _: f())
 def test_event_migration_worker(
     mock_drain_selection,

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import sys
+import time
 
 import arrow
 import mock
@@ -25,8 +26,10 @@ from clusterman.util import ask_for_choice
 from clusterman.util import ask_for_confirmation
 from clusterman.util import autoscaling_is_paused
 from clusterman.util import color_conditions
+from clusterman.util import FunctionTimeoutError
 from clusterman.util import get_cluster_name_list
 from clusterman.util import get_pool_name_list
+from clusterman.util import limit_function_runtime
 from clusterman.util import parse_time_interval_seconds
 from clusterman.util import parse_time_string
 from clusterman.util import sensu_checkin
@@ -242,3 +245,9 @@ def test_splay_event_time(mock_hash):
     mock_hash.return_value = frequency - 1  # make `hash(key) % frequency` returns its max value
     for timestamp in range(20):
         assert 0 <= splay_event_time(frequency, "key", timestamp) < frequency
+
+
+def test_limit_function_runtime():
+    assert limit_function_runtime(lambda: 123, 1) == 123
+    with pytest.raises(FunctionTimeoutError):
+        limit_function_runtime(lambda: time.sleep(10), 1)


### PR DESCRIPTION
### Description
Last few pieces of the puzzle after #197. Basically a very similar implementation, just with filtering done based on the information contained in the migration event.

To make things look a bit nicer I had to modify a couple of bits in other place, so will need a bit of care in deploying this one (broke changes into different commits to make then a bit easier to review):
* updated k8s cluster manager class to actually use label selectors rather than list all hosts and then filter by label later.
* I needed some good way to enforce timeout, so I reworked the SIGALRM based implementation used by CLI handlers to be a bit more generic
* Same goes for the autoscaler toggles in dynamodb, so that I could reuse the code in the worker function.

This will very likely need a bit more polish on top of this, but should be a decent base implementation for the system.


### Testing Done
As always, just unit tests for now.