### PR TITLE
Refactored kubernetes drain

### DIFF
--- a/clusterman/draining/kubernetes.py
+++ b/clusterman/draining/kubernetes.py
@@ -7,29 +7,30 @@ from clusterman.kubernetes.kubernetes_cluster_connector import KubernetesCluster
 log = colorlog.getLogger(__name__)
 
 
-def drain(connector: Optional[KubernetesClusterConnector], agent_id: str) -> bool:
-    """Cordons and safely evicts all tasks from a given node.
-    :param agent_id: a single node name to drain (as would be passed to kubectl drain)
+def drain(connector: Optional[KubernetesClusterConnector], node_name: str, disable_eviction: bool) -> bool:
+    """Cordons and evicts/deletes all tasks from a given node.
+    :param node_name: a single node name to drain (as would be passed to kubectl drain)
     :param connector: a kubernetes connector to connect kubernetes API
+    :param disable_eviction: Force drain to use delete (ignoring PDBs)
     :returns: bool
     """
     if connector:
-        log.info(f"Preparing to drain {agent_id}...")
-        return connector.drain_node(agent_id)
+        log.info(f"Preparing to drain {node_name}...")
+        return connector.drain_node(node_name, disable_eviction)
     else:
-        log.info(f"Unable to drain {agent_id} (no Kubernetes connector configured)")
+        log.info(f"Unable to drain {node_name} (no Kubernetes connector configured)")
         return False
 
 
-def uncordon(connector: Optional[KubernetesClusterConnector], agent_id: str) -> bool:
+def uncordon(connector: Optional[KubernetesClusterConnector], node_name: str) -> bool:
     """Cordons and safely evicts all tasks from a given node.
-    :param agent_id: a single node name to uncordon (as would be passed to kubectl uncordon)
+    :param node_name: a single node name to uncordon (as would be passed to kubectl uncordon)
     :param connector: a kubernetes connector to connect kubernetes API
     :returns: bool
     """
     if connector:
-        log.info(f"Preparing to uncordon {agent_id}...")
-        return connector.uncordon_node(agent_id)
+        log.info(f"Preparing to uncordon {node_name}...")
+        return connector.uncordon_node(node_name)
     else:
-        log.info(f"Unable to uncordon {agent_id} (no Kubernetes connector configured)")
+        log.info(f"Unable to uncordon {node_name} (no Kubernetes connector configured)")
         return False

--- a/clusterman/draining/queue.py
+++ b/clusterman/draining/queue.py
@@ -339,7 +339,7 @@ class DrainingClient:
                         # Todo Message can be stay in the queue up to SQS retention period, limit should be added
                         should_resend_to_queue = True
                 else:
-                    if k8s_drain(kube_operator_client, host_to_process.agent_id):  # case 3
+                    if k8s_drain(kube_operator_client, host_to_process.agent_id, disable_eviction=False):  # case 3
                         self.submit_host_for_termination(host_to_process, delay=0)
                         should_add_to_cache = True
                     else:  # case 4

--- a/tests/draining/queue_test.py
+++ b/tests/draining/queue_test.py
@@ -564,6 +564,7 @@ def test_process_drain_queue(mock_draining_client):
         mock_k8s_drain.assert_called_with(
             mock_kubernetes_client,
             "agt123",
+            False,
         )
         mock_submit_host_for_termination.assert_called_with(mock_draining_client, mock_host, delay=0)
         mock_delete_drain_messages.assert_called_with(mock_draining_client, [mock_host])
@@ -617,6 +618,7 @@ def test_process_drain_queue(mock_draining_client):
         mock_k8s_drain.assert_called_with(
             mock_kubernetes_client,
             "agt123",
+            False,
         )
         mock_submit_host_for_termination.assert_called_with(mock_draining_client, mock_host, delay=0)
         mock_delete_drain_messages.assert_called_with(mock_draining_client, [mock_host])
@@ -696,6 +698,7 @@ def test_process_drain_queue(mock_draining_client):
         mock_k8s_drain.assert_called_with(
             mock_kubernetes_client,
             "agt123",
+            False,
         )
         mock_submit_host_for_termination.assert_called_with(mock_draining_client, mock_host, delay=0)
         mock_delete_drain_messages.assert_called_with(mock_draining_client, [mock_host])


### PR DESCRIPTION
### Description

Implemented  disable_eviction flag for kubernetes drain. This enables force delete pods (ignoring PDBs) on node while draining. We will use force drain for spot interruption. 

### Testing Done

tests were changed as well
