### PR TITLE
node migration: limit number of worker processes

### DIFF
--- a/clusterman/batch/node_migration.py
+++ b/clusterman/batch/node_migration.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import time
 from typing import Callable
 from typing import Collection
@@ -54,7 +53,7 @@ class NodeMigration(BatchDaemon, BatchLoggingMixin, BatchRunningSentinelMixin):
 
     POOL_SETTINGS_PARENT = "node_migration"
     MIN_UPTIME_CHURNING_SECONDS = 60 * 60 * 24  # 1 day
-    DEFAULT_CPUS_PER_WORKER = 0.2
+    DEFAULT_MAX_WORKER_PROCESSES = 6
     DEFAULT_RUN_INTERVAL_SECONDS = 60
 
     @batch_command_line_arguments
@@ -75,9 +74,9 @@ class NodeMigration(BatchDaemon, BatchLoggingMixin, BatchRunningSentinelMixin):
         self.run_interval = staticconf.read_int(
             "batches.node_migration.run_interval_seconds", self.DEFAULT_RUN_INTERVAL_SECONDS
         )
-        cpus_per_worker = staticconf.read_float("batches.node_migration.cpus_per_worker", self.DEFAULT_CPUS_PER_WORKER)
-        available_cpus = float(os.environ.get("PAASTA_RESOURCE_CPUS", os.cpu_count()))
-        self.available_worker_slots = round(available_cpus / cpus_per_worker) + 1
+        self.available_worker_slots = staticconf.read_float(
+            "batches.node_migration.max_worker_processes", self.DEFAULT_MAX_WORKER_PROCESSES
+        )
         for pool in get_pool_name_list(self.options.cluster, SUPPORTED_POOL_SCHEDULER):
             load_cluster_pool_config(self.options.cluster, pool, SUPPORTED_POOL_SCHEDULER, None)
             pool_config_namespace = POOL_NAMESPACE.format(pool=pool, scheduler=SUPPORTED_POOL_SCHEDULER)

--- a/tests/batch/node_migration_test.py
+++ b/tests/batch/node_migration_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
 from argparse import Namespace
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -37,10 +38,13 @@ def migration_batch():
     ):
         batch = NodeMigration()
         mock_getpool.return_value = ["bar"]
+        os.environ["PAASTA_RESOURCE_CPUS"] = "4"
         batch.options = Namespace(cluster="mesos-test", autorestart_interval_minutes=None)
         batch.configure_initial()
         assert "bar" in batch.migration_configs
+        assert batch.available_worker_slots == 21
         yield batch
+        os.environ.pop("PAASTA_RESOURCE_CPUS", None)
 
 
 def test_fetch_event_crd(migration_batch: NodeMigration):
@@ -131,7 +135,7 @@ def test_get_worker_setup(migration_batch):
 @patch("clusterman.batch.node_migration.RestartableDaemonProcess")
 def test_spawn_worker(mock_process, migration_batch, worker_label):
     mock_routine = MagicMock()
-    migration_batch._spawn_worker(worker_label, mock_routine, 1, x=2)
+    assert migration_batch._spawn_worker(worker_label, mock_routine, 1, x=2) is True
     mock_process.assert_called_once_with(target=mock_routine, args=(1,), kwargs={"x": 2})
     assert migration_batch.migration_workers == {worker_label: mock_process.return_value}
 
@@ -139,7 +143,14 @@ def test_spawn_worker(mock_process, migration_batch, worker_label):
 @patch("clusterman.batch.node_migration.RestartableDaemonProcess")
 def test_spawn_worker_existing(mock_process, migration_batch):
     migration_batch.migration_workers["foobar"] = MagicMock(is_alive=lambda: True)
-    migration_batch._spawn_worker("foobar", MagicMock(), 1, x=2)
+    assert migration_batch._spawn_worker("foobar", MagicMock(), 1, x=2) is False
+    mock_process.assert_not_called()
+
+
+@patch("clusterman.batch.node_migration.RestartableDaemonProcess")
+def test_spawn_worker_over_capacity(mock_process, migration_batch):
+    migration_batch.migration_workers = {f"foobar{i}": MagicMock(is_alive=lambda: True) for i in range(29)}
+    assert migration_batch._spawn_worker(MigrationEvent(None, None, None, None, None), MagicMock(), 1, x=2) is False
     mock_process.assert_not_called()
 
 

--- a/tests/batch/node_migration_test.py
+++ b/tests/batch/node_migration_test.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 from argparse import Namespace
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -38,13 +37,10 @@ def migration_batch():
     ):
         batch = NodeMigration()
         mock_getpool.return_value = ["bar"]
-        os.environ["PAASTA_RESOURCE_CPUS"] = "4"
         batch.options = Namespace(cluster="mesos-test", autorestart_interval_minutes=None)
         batch.configure_initial()
         assert "bar" in batch.migration_configs
-        assert batch.available_worker_slots == 21
         yield batch
-        os.environ.pop("PAASTA_RESOURCE_CPUS", None)
 
 
 def test_fetch_event_crd(migration_batch: NodeMigration):
@@ -149,7 +145,7 @@ def test_spawn_worker_existing(mock_process, migration_batch):
 
 @patch("clusterman.batch.node_migration.RestartableDaemonProcess")
 def test_spawn_worker_over_capacity(mock_process, migration_batch):
-    migration_batch.migration_workers = {f"foobar{i}": MagicMock(is_alive=lambda: True) for i in range(29)}
+    migration_batch.migration_workers = {f"foobar{i}": MagicMock(is_alive=lambda: True) for i in range(6)}
     assert migration_batch._spawn_worker(MigrationEvent(None, None, None, None, None), MagicMock(), 1, x=2) is False
     mock_process.assert_not_called()
 


### PR DESCRIPTION
Just to avoid the number of worker processes to grow without control.

The more correct way would be reading the cpu count off of the cgroup settings when running in a container, but that gets set by PaaSTA as `PAASTA_RESOURCE_CPUS` in the environment variables, so I opted for reading that (with a fallback to standard host cpu count).
