### PR TITLE
Avoided error while ec2 termination

### DIFF
--- a/clusterman/draining/queue.py
+++ b/clusterman/draining/queue.py
@@ -291,7 +291,12 @@ class DrainingClient:
                     logger.error(f"Failed to up {hostname_ip} continuing to terminate anyway: {e}")
             elif host_to_terminate.scheduler == "kubernetes":
                 logger.info(f"Kubernetes hosts to delete k8s node and terminate: {host_to_terminate}")
-                terminate_host(host_to_terminate)
+                try:
+                    terminate_host(host_to_terminate)
+                except Exception as e:
+                    logger.exception(f"Failed to terminate {host_to_terminate.instance_id}: {e}")
+                    # we should stop here so as not to delete message from queue
+                    return
             else:
                 logger.info(f"Host to terminate immediately: {host_to_terminate}")
                 terminate_host(host_to_terminate)


### PR DESCRIPTION
### Description

Currently clusterman crashed if any error (for ex: ClientError can be occurred) occurs while ec2 termination. 


### Solution

Handle exception silently. Autoscaler will submit it again in case of necessity.