### PR TITLE
show node migration info in "clusterman status" output

### DIFF
--- a/clusterman/cli/status.py
+++ b/clusterman/cli/status.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import argparse
 import sys
+from typing import Collection
 from typing import Iterable
 from typing import List
 from typing import Mapping
@@ -39,6 +40,9 @@ from clusterman.cli.util import timeout_wrapper
 from clusterman.interfaces.resource_group import ResourceGroup
 from clusterman.interfaces.types import AgentState
 from clusterman.interfaces.types import ClusterNodeMetadata
+from clusterman.kubernetes.kubernetes_cluster_connector import KubernetesClusterConnector
+from clusterman.migration.event import MigrationEvent
+from clusterman.migration.event_enums import MigrationStatus
 from clusterman.util import any_of
 from clusterman.util import autoscaling_is_paused
 from clusterman.util import ClustermanResources
@@ -116,7 +120,18 @@ def _get_resource_groups_json(
     ]
 
 
-def _status_json(manager: PoolManager, get_node_metadatas: bool) -> StatusJsonObject:
+def _get_migrations(cluster: str, pool: str) -> Collection[MigrationEvent]:
+    """Get node migrations currently in flight for a pool
+
+    :param str cluster: cluster name
+    :param str pool: pool name:
+    :return: collection of migration events
+    """
+    connector = KubernetesClusterConnector(cluster, pool, init_crd=True)
+    return connector.list_node_migration_resources(statuses=[MigrationStatus.PENDING, MigrationStatus.INPROGRESS])
+
+
+def _status_json(manager: PoolManager, get_node_metadatas: bool, get_migrations: bool = False) -> StatusJsonObject:
     node_metadatas = manager.get_node_metadatas() if get_node_metadatas else []
     return {
         "disabled": autoscaling_is_paused(manager.cluster, manager.pool, manager.scheduler, arrow.now()),
@@ -124,6 +139,7 @@ def _status_json(manager: PoolManager, get_node_metadatas: bool) -> StatusJsonOb
         "fulfilled_capacity": manager.fulfilled_capacity,
         "non_orphan_fulfilled_capacity": manager.non_orphan_fulfilled_capacity,
         "resource_groups": _get_resource_groups_json(manager.resource_groups.values(), node_metadatas),
+        "migrations": _get_migrations(manager.cluster, manager.pool) if get_migrations else [],
     }
 
 
@@ -213,12 +229,13 @@ def _write_summary(manager: PoolManager) -> None:
     print(f"\tGPUs allocation: {allocated_gpus} GPUs allocated to tasks, {total_gpus} total")
 
 
-def print_status_json(manager: PoolManager):
-    print(json.dumps(_status_json(manager, get_node_metadatas=True), default=str))
+def print_status_json(manager: PoolManager, args: argparse.Namespace):
+    status_obj = _status_json(manager, get_node_metadatas=True, get_migrations=args.migrations)
+    print(json.dumps(status_obj, default=str))
 
 
 def print_status(manager: PoolManager, args: argparse.Namespace) -> None:
-    status_obj = _status_json(manager, get_node_metadatas=args.verbose)
+    status_obj = _status_json(manager, get_node_metadatas=args.verbose, get_migrations=args.migrations)
     sys.stdout.write("\n")
     print(f"Current status for the {manager.pool} pool in the {manager.cluster} cluster:\n")
     if status_obj["disabled"]:
@@ -244,12 +261,19 @@ def print_status(manager: PoolManager, args: argparse.Namespace) -> None:
     _write_summary(manager)
     sys.stdout.write("\n")
 
+    migrations = status_obj.get("migrations")
+    if migrations:
+        print("Node migrations:")
+        print("\n".join(f"- {event}" for event in migrations))
+
+    sys.stdout.write("\n")
+
 
 @timeout_wrapper
 def main(args: argparse.Namespace) -> None:  # pragma: no cover
     manager = PoolManager(args.cluster, args.pool, args.scheduler)
     if args.json:
-        print_status_json(manager)
+        print_status_json(manager, args)
     else:
         print_status(manager, args)
 
@@ -269,6 +293,13 @@ def add_status_parser(subparser, required_named_args, optional_named_args):  # p
         "--only-orphans",
         action="store_true",
         help="Only show information about orphaned instances (instances that are not in the Mesos cluster)",
+    )
+    optional_named_args.add_argument(
+        "--migrations",
+        action="store_true",
+        help=argparse.SUPPRESS,
+        # TODO: enable alongside the "migrate" CLI subcommand
+        # help="Show node migrations being applied on the pool (only available on kubernetes clusters)",
     )
     optional_named_args.add_argument(
         "-v",

--- a/clusterman/cli/status.py
+++ b/clusterman/cli/status.py
@@ -80,6 +80,7 @@ class StatusJsonObject(TypedDict):
     target_capacity: float
     non_orphan_fulfilled_capacity: float
     resource_groups: List[ResourceGroupJsonObject]
+    migrations: Collection[MigrationEvent]
 
 
 def _get_agent_json(metadata: ClusterNodeMetadata) -> AgentJsonObject:

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 import copy
 from collections import defaultdict
-from typing import Collection
 from typing import List
 from typing import Mapping
 from typing import Optional
+from typing import Set
 from typing import Tuple
 
 import arrow
@@ -215,7 +215,7 @@ class KubernetesClusterConnector(ClusterConnector):
             logger.warning(f"Failed to uncordon {node_name}: {e}")
             return False
 
-    def list_node_migration_resources(self, statuses: List[MigrationStatus]) -> Collection[MigrationEvent]:
+    def list_node_migration_resources(self, statuses: List[MigrationStatus]) -> Set[MigrationEvent]:
         """Fetch node migration event resource from k8s CRD
 
         :param List[MigrationStatus] statuses: event status to look for

--- a/clusterman/migration/event.py
+++ b/clusterman/migration/event.py
@@ -105,12 +105,19 @@ class MigrationCondition(NamedTuple):
             ),
         )
 
+    def stringify_target(self) -> str:
+        """Turn condition target into a string"""
+        return ",".join(map(str, self.target)) if isinstance(self.target, list) else str(self.target)
+
     def to_dict(self) -> dict:
         return {
             "trait": self.trait.value,
             "operator": self.operator.value,
-            "target": (",".join(map(str, self.target)) if isinstance(self.target, list) else str(self.target)),
+            "target": self.stringify_target(),
         }
+
+    def __str__(self) -> str:
+        return f"{self.trait.name} {self.operator.value} {self.stringify_target()}"
 
 
 class MigrationEvent(NamedTuple):
@@ -123,6 +130,12 @@ class MigrationEvent(NamedTuple):
     def __hash__(self) -> int:
         """Simplified object hash since resource_name should be unique"""
         return self[:3].__hash__()
+
+    def __str__(self) -> str:
+        return (
+            f"MigrationEvent(cluster={self.cluster}, pool={self.pool},"
+            f" label_selectors={self.label_selectors}, condition=({self.condition}))"
+        )
 
     def to_crd_body(self, labels: Optional[dict] = None) -> dict:
         """Pack event data into a CRD payload

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 clusterman (4.11.0) xenial bionic; urgency=low
 
-  * Drain warned kubernetes spot instances 
+  * Drain warned kubernetes spot instances
 
  -- Ilkin Mammadzada <ilkinmammadzada@yelp.com>  Wed, 28 Sep 2022 06:12:37 -0700
 

--- a/tests/kubernetes/kubernetes_cluster_connector_test.py
+++ b/tests/kubernetes/kubernetes_cluster_connector_test.py
@@ -439,7 +439,7 @@ def test_list_node_migration_resources(mock_cluster_connector_crd):
         for i in range(3)
     }
     mock_cluster_connector_crd._migration_crd_api.list_cluster_custom_object.assert_called_once_with(
-        label_selector="clusterman.yelp.com/migration_status in (pending,inprogress)",
+        label_selector="clusterman.yelp.com/migration_status in (pending,inprogress),clusterman.com/pool=bar",
     )
 
 
@@ -471,7 +471,10 @@ def test_create_node_migration_resource(mock_cluster_connector_crd):
         body={
             "metadata": {
                 "name": "mesos-test-bar-111222333",
-                "labels": {"clusterman.yelp.com/migration_status": "pending"},
+                "labels": {
+                    "clusterman.yelp.com/migration_status": "pending",
+                    "clusterman.com/pool": "bar",
+                },
             },
             "spec": {
                 "cluster": "mesos-test",

--- a/tests/migration/migration_event_test.py
+++ b/tests/migration/migration_event_test.py
@@ -95,6 +95,24 @@ def test_condition_to_dict(condition, expected):
     assert condition.to_dict() == expected
 
 
+def test_event_to_string():
+    event = MigrationEvent(
+        resource_name="mesos-test-bar-111222333",
+        cluster="mesos-test",
+        pool="bar",
+        label_selectors=[],
+        condition=MigrationCondition(
+            ConditionTrait.KERNEL,
+            ConditionOperator.IN,
+            [semver.parse_version_info("1.2.3"), semver.parse_version_info("3.4.5")],
+        ),
+    )
+    assert (
+        str(event)
+        == "MigrationEvent(cluster=mesos-test, pool=bar, label_selectors=[], condition=(KERNEL in 1.2.3,3.4.5))"
+    )
+
+
 def test_event_to_crd_body():
     assert MigrationEvent(
         resource_name="mesos-test-bar-111222333",


### PR DESCRIPTION
* Add a pool label to the migration CRD resources so that they are easier to filter when we don't just want to list all the ones available in a cluster. Chosen the same label key being used for nodes (I know it's redundant info since the pool value is also contained in the event themselves, but I'd rather make k8s work a bit more than having to do client-side filtering here).
* Simply adds an extra section to the `clusterman status` output with the migration events currently being processed (if any). I put this behind its own parameter for the time being so that there's no risk of people encountering possible issues while doing other stuff. I guess it will eventually go with the `verbose` flag.