### PR TITLE
enable node-migration CLI features

### DIFF
--- a/clusterman/args.py
+++ b/clusterman/args.py
@@ -197,8 +197,7 @@ def get_parser(description=""):  # pragma: no cover
     from clusterman.cli.toggle import add_cluster_disable_parser
     from clusterman.cli.toggle import add_cluster_enable_parser
     from clusterman.draining.queue import add_queue_parser
-
-    # from clusterman.cli.migrate import add_migration_parser  # TODO: uncomment when batch implementation finalized
+    from clusterman.cli.migrate import add_migration_parser
 
     root_parser = argparse.ArgumentParser(prog="clusterman", description=description, formatter_class=help_formatter)
     add_env_config_path_arg(root_parser)
@@ -221,7 +220,7 @@ def get_parser(description=""):  # pragma: no cover
     add_manager_parser(subparser)
     add_simulate_parser(subparser)
     add_queue_parser(subparser)
-    # add_migration_parser(subparser)  # TODO: uncomment when batch implementation finalized
+    add_migration_parser(subparser)
 
     return root_parser
 

--- a/clusterman/cli/migrate.py
+++ b/clusterman/cli/migrate.py
@@ -38,6 +38,7 @@ def main(args: argparse.Namespace) -> None:
         condition=condition,
     )
     connector = KubernetesClusterConnector(args.cluster, None, init_crd=True)
+    connector.reload_client()
     connector.create_node_migration_resource(event, MigrationStatus.PENDING)
 
 


### PR DESCRIPTION
Turning these on since we are about ready to start doing some testing.

When writing these, I also had forgotten that `KubernetesClusterConnector` doesn't initialize API clients automatically, so fixed that.
