### PR TITLE
improve logging for node-migration functionality

### DIFF
--- a/clusterman/autoscaler/pool_manager.py
+++ b/clusterman/autoscaler/pool_manager.py
@@ -588,7 +588,6 @@ class PoolManager:
 
     def is_capacity_satisfied(self) -> bool:
         """States whether current pool capacity is considered in line with expectation"""
-        # TODO: this is a pretty naive check, can likely be improved from some of the autoscaling data
         return self.non_orphan_fulfilled_capacity >= self.target_capacity
 
     @property

--- a/tests/batch/node_migration_test.py
+++ b/tests/batch/node_migration_test.py
@@ -38,7 +38,7 @@ def migration_batch():
     ):
         batch = NodeMigration()
         mock_getpool.return_value = ["bar"]
-        batch.options = Namespace(cluster="mesos-test", autorestart_interval_minutes=None)
+        batch.options = Namespace(cluster="mesos-test", autorestart_interval_minutes=None, extra_logs=False)
         batch.configure_initial()
         assert "bar" in batch.migration_configs
         yield batch

--- a/tests/migration/migration_worker_test.py
+++ b/tests/migration/migration_worker_test.py
@@ -59,7 +59,7 @@ def test_monitor_pool_health(mock_time):
         for i in range(5)
     ]
     mock_manager.is_capacity_satisfied.side_effect = [False, True, True]
-    mock_connector.has_enough_capacity_for_pods.side_effect = [False, True]
+    mock_connector.has_enough_capacity_for_pods.side_effect = [False, False, True]
     mock_connector.get_agent_metadata.side_effect = chain(
         (AgentMetadata(agent_id=i) for i in range(3)),
         repeat(AgentMetadata(agent_id="")),


### PR DESCRIPTION
Right now logs for the batch look something like this while performing a drain:
```
INFO:__main__:Spawning uptime migration worker for default pool
INFO:clusterman.autoscaler.pool_manager:Reloading cluster connector state
INFO:clusterman.kubernetes.kubernetes_cluster_connector:Reloading nodes
INFO:clusterman.kubernetes.kubernetes_cluster_connector:Reloading pods
INFO:clusterman.autoscaler.pool_manager:Reloading resource groups
INFO:clusterman.aws.spot_fleet_resource_group:Merged ec2 & s3 SFRs: []
INFO:clusterman.autoscaler.pool_manager:Loaded resource groups: ['....']
INFO:clusterman.autoscaler.pool_manager:Recalculating non-orphan fulfilled capacity
INFO:clusterman.migration.worker:1 nodes of kubestage:default will be recycled
INFO:clusterman.migration.worker:Recycling node ....
INFO:clusterman.autoscaler.pool_manager:Reloading cluster connector state
INFO:clusterman.kubernetes.kubernetes_cluster_connector:Reloading nodes
INFO:clusterman.kubernetes.kubernetes_cluster_connector:Reloading pods
INFO:clusterman.autoscaler.pool_manager:Reloading resource groups
INFO:clusterman.aws.spot_fleet_resource_group:Merged ec2 & s3 SFRs: []
INFO:clusterman.autoscaler.pool_manager:Loaded resource groups: ['....']
INFO:clusterman.autoscaler.pool_manager:Recalculating non-orphan fulfilled capacity
INFO:clusterman.autoscaler.pool_manager:Reloading cluster connector state
INFO:clusterman.kubernetes.kubernetes_cluster_connector:Reloading nodes
INFO:clusterman.kubernetes.kubernetes_cluster_connector:Reloading pods
INFO:clusterman.autoscaler.pool_manager:Reloading resource groups
INFO:clusterman.aws.spot_fleet_resource_group:Merged ec2 & s3 SFRs: []
INFO:clusterman.autoscaler.pool_manager:Loaded resource groups: ['....']
INFO:clusterman.autoscaler.pool_manager:Recalculating non-orphan fulfilled capacity
INFO:clusterman.autoscaler.pool_manager:Reloading cluster connector state
INFO:clusterman.kubernetes.kubernetes_cluster_connector:Reloading nodes
INFO:clusterman.kubernetes.kubernetes_cluster_connector:Reloading pods
INFO:clusterman.autoscaler.pool_manager:Reloading resource groups
INFO:clusterman.aws.spot_fleet_resource_group:Merged ec2 & s3 SFRs: []
INFO:clusterman.autoscaler.pool_manager:Loaded resource groups: ['....']
INFO:clusterman.autoscaler.pool_manager:Recalculating non-orphan fulfilled capacity
INFO:clusterman.autoscaler.pool_manager:Reloading cluster connector state
INFO:clusterman.kubernetes.kubernetes_cluster_connector:Reloading nodes
INFO:clusterman.kubernetes.kubernetes_cluster_connector:Reloading pods
INFO:clusterman.autoscaler.pool_manager:Reloading resource groups
INFO:clusterman.aws.spot_fleet_resource_group:Merged ec2 & s3 SFRs: []
INFO:clusterman.autoscaler.pool_manager:Loaded resource groups: ['....']
INFO:clusterman.autoscaler.pool_manager:Recalculating non-orphan fulfilled capacity
```

which contains a lot of noise from the pool manager reloading its state, and I'd like them to look more like this
```
INFO:__main__:Spawning uptime migration worker for default pool
INFO:clusterman.migration.worker:1 nodes of kubestage:default will be recycled
INFO:clusterman.migration.worker:Recycling node ....
INFO:clusterman.migration.worker:Monitoring health for kubestage:default
INFO:clusterman.migration.worker:Pool kubestage:default not healthy yet (drain_ok=False, capacity_ok=False, pods_ok=False)
INFO:clusterman.migration.worker:Pool kubestage:default not healthy yet (drain_ok=True, capacity_ok=False, pods_ok=False)
INFO:clusterman.migration.worker:Pool kubestage:default not healthy yet (drain_ok=True, capacity_ok=False, pods_ok=True)
INFO:clusterman.migration.worker:Pool kubestage:default not healthy yet (drain_ok=True, capacity_ok=True, pods_ok=True)
INFO:clusterman.migration.worker:Recycled 1 nodes out of 1 selected
INFO:clusterman.migration.worker:Completed recycling node selection from kubestage:default

```