### PR TITLE
Avoiding to mark orphan instances as killable

### DIFF
--- a/clusterman/autoscaler/autoscaler.py
+++ b/clusterman/autoscaler/autoscaler.py
@@ -176,13 +176,12 @@ class Autoscaler:
             self.target_capacity_gauge.set(new_target_capacity, {"dry_run": dry_run})
             self._emit_requested_resource_metrics(resource_request, dry_run=dry_run)
 
-        if self.autoscaling_config.recycle_orphan_instances:
-            try:
-                self.pool_manager.terminate_expired_orphan_instances(
-                    self.autoscaling_config.orphan_instance_uptime_threshold_seconds, dry_run=dry_run
-                )
-            except Exception as e:
-                logger.error(f"Orphan instances termination failed: {e}")
+        try:
+            self.pool_manager.terminate_expired_orphan_instances(
+                self.autoscaling_config.orphan_instance_uptime_threshold_seconds, dry_run=dry_run
+            )
+        except Exception as e:
+            logger.error(f"Orphan instances termination failed: {e}")
 
         self.pool_manager.modify_target_capacity(new_target_capacity, dry_run=dry_run, no_scale_down=no_scale_down)
 

--- a/clusterman/autoscaler/config.py
+++ b/clusterman/autoscaler/config.py
@@ -26,7 +26,6 @@ class AutoscalingConfig(NamedTuple):
     target_capacity_margin: float
     prevent_scale_down_after_capacity_loss: bool = False
     instance_loss_threshold: int = 0
-    recycle_orphan_instances: bool = True
     orphan_instance_uptime_threshold_seconds: int = 1800
 
 
@@ -53,7 +52,6 @@ def get_autoscaling_config(config_namespace: str) -> AutoscalingConfig:
             "autoscaling.prevent_scale_down_after_capacity_loss", default=False
         ),
         instance_loss_threshold=reader.read_int("autoscaling.instance_loss_threshold", default=0),
-        recycle_orphan_instances=reader.read_bool("autoscaling.recycle_orphan_instances", default=True),
         orphan_instance_uptime_threshold_seconds=reader.read_int(
             "autoscaling.orphan_instance_uptime_threshold_seconds", default=1800
         ),

--- a/clusterman/autoscaler/pool_manager.py
+++ b/clusterman/autoscaler/pool_manager.py
@@ -553,6 +553,9 @@ class PoolManager:
             return False
         elif node_metadata.instance.is_cordoned:
             return False
+        # Orphan instances will be terminated by terminate_expired_orphan_instances
+        elif node_metadata.agent.state == AgentState.ORPHANED:
+            return False
         elif self.max_tasks_to_kill > node_metadata.agent.task_count:
             return True
         else:
@@ -563,10 +566,9 @@ class PoolManager:
 
         def sort_key(
             node_metadata: ClusterNodeMetadata,
-        ) -> Tuple[int, int, int, int, int, int, int]:
+        ) -> Tuple[int, int, int, int, int, int]:
             return (
                 0 if node_metadata.agent.is_frozen else 1,
-                0 if node_metadata.agent.state == AgentState.ORPHANED else 1,
                 0 if node_metadata.instance.is_stale else 1,
                 0 if node_metadata.instance.uptime.total_seconds() > self.min_node_scalein_uptime else 1,
                 0 if node_metadata.agent.state == AgentState.IDLE else 1,

--- a/tests/autoscaler/pool_manager_test.py
+++ b/tests/autoscaler/pool_manager_test.py
@@ -605,7 +605,7 @@ def test_instance_kill_order(mock_pool_manager):
     mock_pool_manager.min_node_scalein_uptime = 300
     killable_nodes = mock_pool_manager._get_prioritized_killable_nodes()
     killable_instance_ids = [node_metadata.instance.instance_id for node_metadata in killable_nodes]
-    assert killable_instance_ids == [f"i-{i}" for i in range(9)]
+    assert killable_instance_ids == [f"i-{i}" for i in range(1, 9)]
 
 
 def test_get_expired_orphan_instances(mock_pool_manager):


### PR DESCRIPTION
### Description

Currently orphan instances are terminated by autoscaler with priority. 
Our average node bootstrapping time is 5mins. 
Autoscaler may terminate (before bootstrapping finishing) these instances in case scaling-down needed.

We have `terminate_expired_orphan_instances` what takes care of orphan instances. it has setting `orphan_instance_uptime_threshold_seconds` (default 30 mins) to define expired orphan instances. 