### PR TITLE
Fix a couple of bugs in migrate CLI subcommand

### DIFF
--- a/clusterman/cli/migrate.py
+++ b/clusterman/cli/migrate.py
@@ -58,19 +58,19 @@ def add_migration_parser(
         title="migration condition", description="Defines the desired final state for the migration"
     )
     condition_group.add_argument(
-        "condition-trait",
+        "condition_trait",
         type=str,
         help="Metadata based on which nodes to migrate are selected",
         choices=[entry.value for entry in ConditionTrait],
     )
     condition_group.add_argument(
-        "condition-operator",
+        "condition_operator",
         type=str,
         help="Metadata comparison operator",
         choices=[entry.value for entry in ConditionOperator],
     )
     condition_group.add_argument(
-        "condition-target",
+        "condition_target",
         type=str,
         help="Target value for node selection condition",
     )

--- a/clusterman/cli/migrate.py
+++ b/clusterman/cli/migrate.py
@@ -17,6 +17,7 @@ import time
 from clusterman.args import add_cluster_arg
 from clusterman.args import add_cluster_config_directory_arg
 from clusterman.args import add_pool_arg
+from clusterman.args import add_scheduler_arg
 from clusterman.args import subparser
 from clusterman.kubernetes.kubernetes_cluster_connector import KubernetesClusterConnector
 from clusterman.migration.event import ConditionOperator
@@ -51,6 +52,8 @@ def add_migration_parser(
     add_cluster_arg(required_named_args, required=True)
     add_pool_arg(required_named_args)
     add_cluster_config_directory_arg(optional_named_args)
+    # For CLI compatibility reasons, as the only supported scheduler is k8s
+    add_scheduler_arg(optional_named_args)
     condition_group = subparser.add_argument_group(
         title="migration condition", description="Defines the desired final state for the migration"
     )


### PR DESCRIPTION
* The command should accept `--scheduler` the scheduler parameter, even if it's going to be ignored, as our wrappers will always set that
* I though `argparse` would translate all `-` into `_`, but looks like that's not happening for positiational parameters, so fixed that naming.