### PR TITLE
more node migration fixes

### DIFF
--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -96,6 +96,11 @@ class KubernetesClusterConnector(ClusterConnector):
             self._label_selectors.append(f"{node_label_selector}={self.pool}")
 
     def reload_state(self, load_pods_info: bool = True) -> None:
+        """Reload information from cluster/pool
+
+        :param bool load_pods_info: do not load data about pods.
+                                    NOTE: all resouce utilization metrics won't be available when setting this
+        """
         logger.info("Reloading nodes")
 
         self.reload_client()
@@ -111,7 +116,11 @@ class KubernetesClusterConnector(ClusterConnector):
                 else self._get_pods_info()
             )
         else:
-            self._pods_by_ip, self._unschedulable_pods, self._excluded_pods_by_ip = ({}, [], {})
+            self._pods_by_ip, self._unschedulable_pods, self._excluded_pods_by_ip = (
+                dict.fromkeys(self._nodes_by_ip, []),
+                [],
+                {},
+            )
 
     def reload_client(self) -> None:
         self._core_api = CachedCoreV1Api(self.kubeconfig_path)

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -56,6 +56,7 @@ CLUSTERMAN_TERMINATION_TAINT_KEY = "clusterman.yelp.com/terminating"
 MIGRATION_CRD_GROUP = "clusterman.yelp.com"
 MIGRATION_CRD_VERSION = "v1"
 MIGRATION_CRD_PLURAL = "nodemigrations"
+MIGRATION_CRD_KIND = "NodeMigration"
 MIGRATION_CRD_STATUS_LABEL = "clusterman.yelp.com/migration_status"
 NOT_FOUND_STATUS = 404
 # we don't want to block on eviction/deletion as we're potentially evicting/deleting a ton of pods
@@ -288,6 +289,8 @@ class KubernetesClusterConnector(ClusterConnector):
         assert self._migration_crd_api, "CRD client was not initialized"
         try:
             body = event.to_crd_body(labels={MIGRATION_CRD_STATUS_LABEL: status.value, self.pool_label_key: event.pool})
+            body["apiVersion"] = f"{MIGRATION_CRD_GROUP}/{MIGRATION_CRD_VERSION}"
+            body["kind"] = MIGRATION_CRD_KIND
             self._migration_crd_api.create_cluster_custom_object(body=body)
         except Exception as e:
             logger.error(f"Failed creating migration event resource: {e}")

--- a/tests/kubernetes/kubernetes_cluster_connector_test.py
+++ b/tests/kubernetes/kubernetes_cluster_connector_test.py
@@ -348,6 +348,11 @@ def test_get_nodes_by_ip(mock_cluster_connector):
     )
 
 
+def test_reload_state_no_pods(mock_cluster_connector):
+    mock_cluster_connector.reload_state(load_pods_info=False)
+    assert mock_cluster_connector._pods_by_ip == {"10.10.10.1": [], "10.10.10.2": [], "10.10.10.3": []}
+
+
 def test_allocation(mock_cluster_connector):
     assert mock_cluster_connector.get_resource_allocation("cpus") == 7.5
 

--- a/tests/kubernetes/kubernetes_cluster_connector_test.py
+++ b/tests/kubernetes/kubernetes_cluster_connector_test.py
@@ -479,6 +479,8 @@ def test_create_node_migration_resource(mock_cluster_connector_crd):
     )
     mock_cluster_connector_crd._migration_crd_api.create_cluster_custom_object.assert_called_once_with(
         body={
+            "apiVersion": "clusterman.yelp.com/v1",
+            "kind": "NodeMigration",
             "metadata": {
                 "name": "mesos-test-bar-111222333",
                 "labels": {


### PR DESCRIPTION
* I thought that the k8s API client would be smart enough the set kind and apiversion by itself, considering that I was already passing more or less the same information in other parameters. Turns out it's now.
* In #209 I overlooked the fact that `_pods_by_ip` has a bunch of direct lookups into it in other methods, so setting it to an empty dict would cause key error when the pool manager gets the agent-metadata for a node. Rather than going around and updating all methods to do a `.get`, with the risk of recreating the same problem in case of future changes, I went for filling the map with an empty placeholder for every node.
