### PR TITLE
emit monitoring metrics for node-migration workers

### DIFF
--- a/clusterman/migration/worker.py
+++ b/clusterman/migration/worker.py
@@ -132,7 +132,7 @@ def _drain_node_selection(
         for node in selection_chunk:
             logger.info(f"Recycling node {node.instance.instance_id}")
             manager.submit_for_draining(node)
-            node_uptime_gauge.set(node.instance.uptime.total_seconds(), {"ip": node.instance.ip_address})
+            node_uptime_gauge.set(node.instance.uptime.total_seconds())
             node_drain_counter.count()
         time.sleep(worker_setup.bootstrap_wait)
         if not _monitor_pool_health(

--- a/clusterman/migration/worker.py
+++ b/clusterman/migration/worker.py
@@ -30,6 +30,7 @@ from clusterman.interfaces.types import ClusterNodeMetadata
 from clusterman.kubernetes.kubernetes_cluster_connector import KubernetesClusterConnector
 from clusterman.migration.event import MigrationEvent
 from clusterman.migration.settings import WorkerSetup
+from clusterman.monitoring_lib import get_monitoring_client
 from clusterman.util import limit_function_runtime
 
 
@@ -38,6 +39,10 @@ UPTIME_CHECK_INTERVAL_SECONDS = 60 * 60  # 1 hour
 HEALTH_CHECK_INTERVAL_SECONDS = 60
 INITIAL_POOL_HEALTH_TIMEOUT_SECONDS = 15 * 60
 SUPPORTED_POOL_SCHEDULER = "kubernetes"
+
+SFX_NODE_DRAIN_COUNT = "clusterman.node_migration.drain_count"
+SFX_MIGRATION_JOB_DURATION = "clusterman.node_migration.duration"
+SFX_DRAINED_NODE_UPTIME = "clusterman.node_migration.drained_node_uptime"
 
 
 class RestartableDaemonProcess:
@@ -112,14 +117,23 @@ def _drain_node_selection(
     """
     nodes = manager.get_node_metadatas(AWS_RUNNING_STATES)
     selected = sorted(filter(selector, nodes), key=worker_setup.precedence.sort_key)
+    if not selected:
+        return True
+    monitoring_info = {"cluster": manager.cluster, "pool": manager.pool}
+    node_drain_counter = get_monitoring_client().create_counter(SFX_NODE_DRAIN_COUNT, monitoring_info)
+    job_timer = get_monitoring_client().create_timer(SFX_MIGRATION_JOB_DURATION, monitoring_info)
+    node_uptime_gauge = get_monitoring_client().create_gauge(SFX_DRAINED_NODE_UPTIME, monitoring_info)
     chunk = worker_setup.rate.of(len(nodes))
     logger.info(f"{len(selected)} nodes of {manager.cluster}:{manager.pool} will be recycled")
+    job_timer.start()
     for i in range(0, len(selected), chunk):
         start_time = time.time()
         selection_chunk = selected[i : i + chunk]
         for node in selection_chunk:
             logger.info(f"Recycling node {node.instance.instance_id}")
             manager.submit_for_draining(node)
+            node_uptime_gauge.set(node.instance.uptime.total_seconds(), {"ip": node.instance.ip_address})
+            node_drain_counter.count()
         time.sleep(worker_setup.bootstrap_wait)
         if not _monitor_pool_health(
             manager, start_time + worker_setup.bootstrap_timeout, selection_chunk, worker_setup.ignore_pod_health
@@ -128,9 +142,11 @@ def _drain_node_selection(
                 f"Pool {manager.cluster}:{manager.pool} did not come back"
                 " to desired capacity, stopping selection draining"
             )
+            job_timer.stop()
             return False
         logger.info(f"Recycled {min(i + chunk, len(selected))} nodes out of {len(selected)} selected")
     logger.info(f"Completed recycling node selection from {manager.cluster}:{manager.pool}")
+    job_timer.stop()
     return True
 
 

--- a/tests/migration/migration_worker_test.py
+++ b/tests/migration/migration_worker_test.py
@@ -85,7 +85,7 @@ def test_drain_node_selection(mock_sfx, mock_monitor, mock_time):
     mock_manager.get_node_metadatas.return_value = [
         ClusterNodeMetadata(
             AgentMetadata(agent_id=i, task_count=30 - 2 * i),
-            InstanceMetadata(None, None, ip_address=f"{i}.{i}.{i}.{i}", uptime=timedelta(days=i)),
+            InstanceMetadata(None, None, uptime=timedelta(days=i)),
         )
         for i in range(6)
     ]
@@ -106,7 +106,7 @@ def test_drain_node_selection(mock_sfx, mock_monitor, mock_time):
             call(
                 ClusterNodeMetadata(
                     AgentMetadata(agent_id=i, task_count=30 - 2 * i),
-                    InstanceMetadata(None, None, ip_address=f"{i}.{i}.{i}.{i}", uptime=timedelta(days=i)),
+                    InstanceMetadata(None, None, uptime=timedelta(days=i)),
                 )
             )
             for i in range(5, 2, -1)
@@ -120,11 +120,11 @@ def test_drain_node_selection(mock_sfx, mock_monitor, mock_time):
                 [
                     ClusterNodeMetadata(
                         AgentMetadata(agent_id=5, task_count=20),
-                        InstanceMetadata(None, None, ip_address="5.5.5.5", uptime=timedelta(days=5)),
+                        InstanceMetadata(None, None, uptime=timedelta(days=5)),
                     ),
                     ClusterNodeMetadata(
                         AgentMetadata(agent_id=4, task_count=22),
-                        InstanceMetadata(None, None, ip_address="4.4.4.4", uptime=timedelta(days=4)),
+                        InstanceMetadata(None, None, uptime=timedelta(days=4)),
                     ),
                 ],
                 False,
@@ -135,7 +135,7 @@ def test_drain_node_selection(mock_sfx, mock_monitor, mock_time):
                 [
                     ClusterNodeMetadata(
                         AgentMetadata(agent_id=3, task_count=24),
-                        InstanceMetadata(None, None, ip_address="3.3.3.3", uptime=timedelta(days=3)),
+                        InstanceMetadata(None, None, uptime=timedelta(days=3)),
                     ),
                 ],
                 False,
@@ -147,9 +147,9 @@ def test_drain_node_selection(mock_sfx, mock_monitor, mock_time):
     assert mock_drain_count_sfx.count.call_count == 3
     mock_uptime_stats_sfx.set.assert_has_calls(
         [
-            call(432000.0, {"ip": "5.5.5.5"}),
-            call(345600.0, {"ip": "4.4.4.4"}),
-            call(259200.0, {"ip": "3.3.3.3"}),
+            call(432000.0),
+            call(345600.0),
+            call(259200.0),
         ]
     )
 

--- a/tests/migration/migration_worker_test.py
+++ b/tests/migration/migration_worker_test.py
@@ -74,11 +74,19 @@ def test_monitor_pool_health(mock_time):
 
 @patch("clusterman.migration.worker.time")
 @patch("clusterman.migration.worker._monitor_pool_health")
-def test_drain_node_selection(mock_monitor, mock_time):
+@patch("clusterman.migration.worker.get_monitoring_client")
+def test_drain_node_selection(mock_sfx, mock_monitor, mock_time):
+    mock_sfx = mock_sfx.return_value
+    mock_drain_count_sfx = mock_sfx.create_counter.return_value
+    mock_uptime_stats_sfx = mock_sfx.create_gauge.return_value
+    mock_job_duration_sfx = mock_sfx.create_timer.return_value
     mock_manager = MagicMock()
     mock_monitor.return_value = True
     mock_manager.get_node_metadatas.return_value = [
-        ClusterNodeMetadata(AgentMetadata(agent_id=i, task_count=30 - 2 * i), InstanceMetadata(None, None))
+        ClusterNodeMetadata(
+            AgentMetadata(agent_id=i, task_count=30 - 2 * i),
+            InstanceMetadata(None, None, ip_address=f"{i}.{i}.{i}.{i}", uptime=timedelta(days=i)),
+        )
         for i in range(6)
     ]
     mock_time.time.side_effect = range(5)
@@ -95,7 +103,12 @@ def test_drain_node_selection(mock_monitor, mock_time):
     mock_manager.get_node_metadatas.assert_called_once_with(("running",))
     mock_manager.submit_for_draining.assert_has_calls(
         [
-            call(ClusterNodeMetadata(AgentMetadata(agent_id=i, task_count=30 - 2 * i), InstanceMetadata(None, None)))
+            call(
+                ClusterNodeMetadata(
+                    AgentMetadata(agent_id=i, task_count=30 - 2 * i),
+                    InstanceMetadata(None, None, ip_address=f"{i}.{i}.{i}.{i}", uptime=timedelta(days=i)),
+                )
+            )
             for i in range(5, 2, -1)
         ]
     )
@@ -105,8 +118,14 @@ def test_drain_node_selection(mock_monitor, mock_time):
                 mock_manager,
                 2,
                 [
-                    ClusterNodeMetadata(AgentMetadata(agent_id=5, task_count=20), InstanceMetadata(None, None)),
-                    ClusterNodeMetadata(AgentMetadata(agent_id=4, task_count=22), InstanceMetadata(None, None)),
+                    ClusterNodeMetadata(
+                        AgentMetadata(agent_id=5, task_count=20),
+                        InstanceMetadata(None, None, ip_address="5.5.5.5", uptime=timedelta(days=5)),
+                    ),
+                    ClusterNodeMetadata(
+                        AgentMetadata(agent_id=4, task_count=22),
+                        InstanceMetadata(None, None, ip_address="4.4.4.4", uptime=timedelta(days=4)),
+                    ),
                 ],
                 False,
             ),
@@ -114,10 +133,23 @@ def test_drain_node_selection(mock_monitor, mock_time):
                 mock_manager,
                 3,
                 [
-                    ClusterNodeMetadata(AgentMetadata(agent_id=3, task_count=24), InstanceMetadata(None, None)),
+                    ClusterNodeMetadata(
+                        AgentMetadata(agent_id=3, task_count=24),
+                        InstanceMetadata(None, None, ip_address="3.3.3.3", uptime=timedelta(days=3)),
+                    ),
                 ],
                 False,
             ),
+        ]
+    )
+    mock_job_duration_sfx.start.assert_called_once_with()
+    mock_job_duration_sfx.stop.assert_called_once_with()
+    assert mock_drain_count_sfx.count.call_count == 3
+    mock_uptime_stats_sfx.set.assert_has_calls(
+        [
+            call(432000.0, {"ip": "5.5.5.5"}),
+            call(345600.0, {"ip": "4.4.4.4"}),
+            call(259200.0, {"ip": "3.3.3.3"}),
         ]
     )
 


### PR DESCRIPTION
I guess this is a reasonable way to implement them, but very open to suggestions.
