### PR TITLE
Drainer message reading optimization

### DIFF
--- a/tests/draining/queue_test.py
+++ b/tests/draining/queue_test.py
@@ -805,6 +805,10 @@ def test_process_queues():
         "clusterman.draining.queue.KubernetesClusterConnector",
         autospec=True,
     ):
+
+        mock_draining_client.return_value.process_termination_queue.return_value = False
+        mock_draining_client.return_value.process_drain_queue.return_value = False
+        mock_draining_client.return_value.process_warning_queue.return_value = False
         with pytest.raises(LoopBreak):
             process_queues("westeros-prod")
         assert mock_draining_client.return_value.process_termination_queue.called


### PR DESCRIPTION
Currently we have performance issue with drainer, therefore there are many messages in the queue specially in the following cases:

- time between peak and non-peak, because autoscaler submits many hosts to drain.
- spot market hot time, because drainer submits many hosts to drain (forcibly).