### PR TITLE
node_migration: make health monitoring interval configurable

### DIFF
--- a/clusterman/migration/settings.py
+++ b/clusterman/migration/settings.py
@@ -24,6 +24,7 @@ DEFAULT_POOL_PRESCALING = 0
 DEFAULT_NODE_BOOT_WAIT = "3m"
 DEFAULT_NODE_BOOT_TIMEOUT = "10m"
 DEFAULT_WORKER_TIMEOUT = "2h"
+DEFAULT_HEALTH_CHECK_INTERVAL = "2m"
 
 
 class MigrationPrecendence(enum.Enum):
@@ -79,6 +80,7 @@ class WorkerSetup(NamedTuple):
     bootstrap_timeout: float
     disable_autoscaling: bool
     expected_duration: float
+    health_check_interval: int
     ignore_pod_health: bool = False
 
     @classmethod
@@ -96,4 +98,7 @@ class WorkerSetup(NamedTuple):
             disable_autoscaling=config.get("disable_autoscaling", False),
             expected_duration=parse_time_interval_seconds(config.get("expected_duration", DEFAULT_WORKER_TIMEOUT)),
             ignore_pod_health=config.get("ignore_pod_health", False),
+            health_check_interval=parse_time_interval_seconds(
+                config.get("health_check_interval", DEFAULT_HEALTH_CHECK_INTERVAL)
+            ),
         )

--- a/docs/source/node_migration.rst
+++ b/docs/source/node_migration.rst
@@ -44,6 +44,8 @@ The allowed values for the migration settings are as follows:
 
 * ``ignore_pod_health``: avoid loading and checking pod information to determine pool health (false by default).
 
+* ``health_check_interval``: how much to wait between checks when monitoring pool health (2 minutes by default).
+
 * ``expected_duration``: estimated duration for migration of the whole pool; human readable time string (1 day by default).
 
 See :ref:`pool_configuration` for how an example configuration block would look like.

--- a/tests/batch/node_migration_test.py
+++ b/tests/batch/node_migration_test.py
@@ -111,6 +111,7 @@ def test_get_worker_setup(migration_batch):
         bootstrap_timeout=180.0,
         disable_autoscaling=False,
         expected_duration=7200.0,
+        health_check_interval=120,
     )
 
 


### PR DESCRIPTION
So we can tune how aggressive we are against AWS APIs. I also lowered the default value from 1m to 2m.
