### PR TITLE
migrate-cli: fix nodemigration crd labelling

### DIFF
--- a/clusterman/cli/migrate.py
+++ b/clusterman/cli/migrate.py
@@ -38,7 +38,7 @@ def main(args: argparse.Namespace) -> None:
         label_selectors=args.label_selector,
         condition=condition,
     )
-    connector = KubernetesClusterConnector(args.cluster, None, init_crd=True)
+    connector = KubernetesClusterConnector(args.cluster, args.pool, init_crd=True)
     connector.reload_client()
     connector.create_node_migration_resource(event, MigrationStatus.PENDING)
 

--- a/tests/cli/migrate_test.py
+++ b/tests/cli/migrate_test.py
@@ -37,7 +37,7 @@ def test_migrate_command(mock_connector, mock_time):
     )
     mock_time.time.return_value = 111222333
     main(mock_args)
-    mock_connector.assert_called_once_with("mesos-test", None, init_crd=True)
+    mock_connector.assert_called_once_with("mesos-test", "bar", init_crd=True)
     mock_connector.return_value.create_node_migration_resource.assert_called_once_with(
         MigrationEvent(
             resource_name="mesos-test-bar-111222333",


### PR DESCRIPTION
I overlooked that without passing the pool argument to the cluster connector the pool configuration is not properly loaded, which results in the label key for the CRD resource to be wrong.