### PR TITLE
U/ilkinmammadzada/clusterman 681 avoid duplications

### DIFF
--- a/tests/draining/queue_test.py
+++ b/tests/draining/queue_test.py
@@ -64,6 +64,7 @@ def test_submit_instance_for_draining(mock_draining_client):
         mock_json.dumps.assert_called_with(
             {
                 "agent_id": "agt123",
+                "attempt": 1,
                 "draining_start_time": now.for_json(),
                 "group_id": "sfr123",
                 "hostname": "host123",
@@ -108,6 +109,7 @@ def test_submit_host_for_draining(mock_draining_client):
             mock_draining_client.submit_host_for_draining(
                 mock_host,
                 0,
+                5,
             )
             == mock_draining_client.client.send_message.return_value
         )
@@ -119,6 +121,7 @@ def test_submit_host_for_draining(mock_draining_client):
                 "group_id": "sfr123",
                 "scheduler": "kubernetes",
                 "agent_id": "agt123",
+                "attempt": 5,
                 "pool": "default",
                 "draining_start_time": now.for_json(),
                 "termination_reason": TerminationReason.SCALING_DOWN.value,

--- a/tests/draining/queue_test.py
+++ b/tests/draining/queue_test.py
@@ -617,6 +617,7 @@ def test_process_drain_queue(mock_draining_client):
             draining_start_time=now.for_json(),
             sender="mmb",
             receipt_handle="aaaaa",
+            attempt=2,
         )
         mock_k8s_drain.reset_mock()
         mock_k8s_drain.return_value = True
@@ -809,7 +810,7 @@ def test_process_drain_queue(mock_draining_client):
         assert not mock_k8s_uncordon.called
         assert not mock_k8s_drain.called
         assert not mock_submit_host_for_termination.called
-        mock_submit_host_for_draining.assert_called_with(mock_draining_client, mock_host_fresh)
+        mock_submit_host_for_draining.assert_called_with(mock_draining_client, mock_host_fresh, 2)
         mock_delete_drain_messages.assert_called_with(mock_draining_client, [mock_host])
 
 


### PR DESCRIPTION
### Description

Currently we add instance_id to cache only if draining is success. 
This may cause having same instance_id multiple times. 
We are changing logic little bit to have instance_id in cache in any cases, but check if it's first try 
or re-try due to failed draining. 

### Testing Done

fixed unit tests
