### PR TITLE
added node_migration termination reason

### DIFF
--- a/clusterman/draining/queue.py
+++ b/clusterman/draining/queue.py
@@ -71,6 +71,7 @@ EC2_TAG_GROUP_KEYS = {
 class TerminationReason(enum.Enum):
     SCALING_DOWN = "scaling down"
     SPOT_INTERRUPTION = "spot interruption"
+    NODE_MIGRATION = "node migration"
 
 
 class Host(NamedTuple):
@@ -124,6 +125,7 @@ class DrainingClient:
         scheduler: str,
         pool: str,
         agent_id: str,
+        termination_reason: TerminationReason,
         draining_start_time: arrow.Arrow,
     ) -> None:
         return self.client.send_message(
@@ -143,7 +145,7 @@ class DrainingClient:
                     "instance_id": instance.instance_id,
                     "ip": instance.ip_address,
                     "pool": pool,
-                    "termination_reason": TerminationReason.SCALING_DOWN.value,
+                    "termination_reason": termination_reason.value,
                     "scheduler": scheduler,
                 }
             ),

--- a/clusterman/migration/worker.py
+++ b/clusterman/migration/worker.py
@@ -26,6 +26,7 @@ from clusterman.autoscaler.pool_manager import AWS_RUNNING_STATES
 from clusterman.autoscaler.pool_manager import PoolManager
 from clusterman.autoscaler.toggle import disable_autoscaling
 from clusterman.autoscaler.toggle import enable_autoscaling
+from clusterman.draining.queue import TerminationReason
 from clusterman.interfaces.types import ClusterNodeMetadata
 from clusterman.kubernetes.kubernetes_cluster_connector import KubernetesClusterConnector
 from clusterman.migration.event import MigrationEvent
@@ -134,7 +135,7 @@ def _drain_node_selection(
         selection_chunk = selected[i : i + chunk]
         for node in selection_chunk:
             logger.info(f"Recycling node {node.instance.instance_id}")
-            manager.submit_for_draining(node)
+            manager.submit_for_draining(node, TerminationReason.NODE_MIGRATION)
             node_uptime_gauge.set(node.instance.uptime.total_seconds())
             node_drain_counter.count()
         time.sleep(worker_setup.bootstrap_wait)

--- a/tests/autoscaler/pool_manager_test.py
+++ b/tests/autoscaler/pool_manager_test.py
@@ -21,6 +21,7 @@ import staticconf.testing
 from clusterman.autoscaler.pool_manager import ClusterNodeMetadata
 from clusterman.autoscaler.pool_manager import PoolManager
 from clusterman.aws.aws_resource_group import AWSResourceGroup
+from clusterman.draining.queue import TerminationReason
 from clusterman.exceptions import AllResourceGroupsAreStaleError
 from clusterman.exceptions import NoResourceGroupsFoundError
 from clusterman.exceptions import PoolManagerError
@@ -201,6 +202,7 @@ class TestPruneExcessFulfilledCapacity:
                     pool="bar",
                     agent_id=mock_nodes_to_prune["sfr-1"][0].agent.agent_id,
                     draining_start_time=now,
+                    termination_reason=TerminationReason.SCALING_DOWN,
                 ),
                 mock.call(
                     mock_nodes_to_prune["sfr-3"][0].instance,
@@ -209,6 +211,7 @@ class TestPruneExcessFulfilledCapacity:
                     pool="bar",
                     agent_id=mock_nodes_to_prune["sfr-3"][0].agent.agent_id,
                     draining_start_time=now,
+                    termination_reason=TerminationReason.SCALING_DOWN,
                 ),
                 mock.call(
                     mock_nodes_to_prune["sfr-3"][1].instance,
@@ -217,6 +220,7 @@ class TestPruneExcessFulfilledCapacity:
                     pool="bar",
                     agent_id=mock_nodes_to_prune["sfr-3"][1].agent.agent_id,
                     draining_start_time=now,
+                    termination_reason=TerminationReason.SCALING_DOWN,
                 ),
                 mock.call(
                     mock_nodes_to_prune["sfr-3"][2].instance,
@@ -225,6 +229,7 @@ class TestPruneExcessFulfilledCapacity:
                     pool="bar",
                     agent_id=mock_nodes_to_prune["sfr-3"][2].agent.agent_id,
                     draining_start_time=now,
+                    termination_reason=TerminationReason.SCALING_DOWN,
                 ),
             ]
 

--- a/tests/draining/queue_test.py
+++ b/tests/draining/queue_test.py
@@ -58,6 +58,7 @@ def test_submit_instance_for_draining(mock_draining_client):
                 pool="default",
                 agent_id="agt123",
                 draining_start_time=now,
+                termination_reason=TerminationReason.SCALING_DOWN,
             )
             == mock_draining_client.client.send_message.return_value
         )

--- a/tests/migration/migration_worker_test.py
+++ b/tests/migration/migration_worker_test.py
@@ -22,6 +22,7 @@ from unittest.mock import patch
 
 import pytest
 
+from clusterman.draining.queue import TerminationReason
 from clusterman.interfaces.types import AgentMetadata
 from clusterman.interfaces.types import ClusterNodeMetadata
 from clusterman.interfaces.types import InstanceMetadata
@@ -109,7 +110,8 @@ def test_drain_node_selection(mock_sfx, mock_monitor, mock_time):
                 ClusterNodeMetadata(
                     AgentMetadata(agent_id=i, task_count=30 - 2 * i),
                     InstanceMetadata(None, None, uptime=timedelta(days=i)),
-                )
+                ),
+                TerminationReason.NODE_MIGRATION,
             )
             for i in range(5, 2, -1)
         ]


### PR DESCRIPTION
### Description

Currently we have two reasons for draining (scale-down and spot interruption)

We should add node_migration as well to get some stats. 

### Testing Done

fixed unit tests