### PR TITLE
removed unnecessary freeze action

### DIFF
--- a/clusterman/autoscaler/pool_manager.py
+++ b/clusterman/autoscaler/pool_manager.py
@@ -562,7 +562,7 @@ class PoolManager:
             node_metadata: ClusterNodeMetadata,
         ) -> Tuple[int, int, int, int, int, int, int]:
             return (
-                0 if node_metadata.agent.is_frozen else 1,
+                0 if node_metadata.agent.is_draining else 1,
                 0 if node_metadata.agent.state == AgentState.ORPHANED else 1,
                 0 if node_metadata.instance.is_stale else 1,
                 0 if node_metadata.instance.uptime.total_seconds() > self.min_node_scalein_uptime else 1,

--- a/clusterman/autoscaler/pool_manager.py
+++ b/clusterman/autoscaler/pool_manager.py
@@ -456,12 +456,6 @@ class PoolManager:
                     )
                     continue
 
-            # Orphaned instances don't have agent information
-            if node_metadata.agent.state != AgentState.ORPHANED:
-                logger.info(f"freezing {node_metadata.agent.agent_id} for termination")
-                if not dry_run:
-                    self.cluster_connector.freeze_agent(node_metadata.agent.agent_id)
-
             logger.info(f"marking {instance_id} for termination")
             marked_nodes[group_id].append(node_metadata)
             rem_group_capacities[group_id] -= instance_weight

--- a/clusterman/interfaces/cluster_connector.py
+++ b/clusterman/interfaces/cluster_connector.py
@@ -47,14 +47,6 @@ class ClusterConnector(metaclass=ABCMeta):
         return self._get_agent_metadata(ip_address)
 
     @abstractmethod
-    def freeze_agent(self, agent_id: str) -> None:
-        """Stop new tasks scheduling to agent
-
-        :param agent_id: agent identifier.
-        """
-        pass
-
-    @abstractmethod
     def get_resource_allocation(self, resource_name: str) -> float:  # pragma: no cover
         """Get the total amount of the given resource currently allocated for this pool.
 

--- a/clusterman/interfaces/types.py
+++ b/clusterman/interfaces/types.py
@@ -20,7 +20,7 @@ class AgentMetadata(NamedTuple):
     allocated_resources: ClustermanResources = ClustermanResources()
     batch_task_count: int = 0
     is_safe_to_kill: bool = True
-    is_frozen: bool = False
+    is_draining: bool = False
     state: AgentState = AgentState.UNKNOWN
     task_count: int = 0
     total_resources: ClustermanResources = ClustermanResources()

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -19,7 +19,6 @@ from typing import Optional
 from typing import Set
 from typing import Tuple
 
-import arrow
 import colorlog
 import kubernetes
 import staticconf
@@ -187,16 +186,6 @@ class KubernetesClusterConnector(ClusterConnector):
         for pod in self._unschedulable_pods:
             unschedulable_pods.append((pod, self._get_pod_unschedulable_reason(pod)))
         return unschedulable_pods
-
-    def freeze_agent(self, node_name: str) -> None:
-        now = str(arrow.now().timestamp)
-        try:
-            body = {
-                "spec": {"taints": [{"effect": "NoSchedule", "key": CLUSTERMAN_TERMINATION_TAINT_KEY, "value": now}]}
-            }
-            self._core_api.patch_node(node_name, body)
-        except ApiException as e:
-            logger.warning(f"Failed to freeze {node_name}: {e}")
 
     def drain_node(self, node_name: str, disable_eviction: bool) -> bool:
         try:

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -19,6 +19,7 @@ from typing import Optional
 from typing import Set
 from typing import Tuple
 
+import arrow
 import colorlog
 import kubernetes
 import staticconf
@@ -210,8 +211,9 @@ class KubernetesClusterConnector(ClusterConnector):
     def cordon_node(self, node_name: str) -> bool:
         now = str(arrow.now().timestamp)
         try:
-            node = self._get_node_by_node_name(node_name)
+            node = self._core_api.read_node(node_name)
             if not node:
+                logger.warning(f"Node doesn't exist: {node_name}")
                 return False
             taints = (
                 list(filter(lambda x: x.key != CLUSTERMAN_TERMINATION_TAINT_KEY, node.spec.taints))
@@ -227,8 +229,9 @@ class KubernetesClusterConnector(ClusterConnector):
 
     def uncordon_node(self, node_name: str) -> bool:
         try:
-            node = self._get_node_by_node_name(node_name)
+            node = self._core_api.read_node(node_name)
             if not node:
+                logger.warning(f"Node doesn't exist: {node_name}")
                 return False
             taints = (
                 list(filter(lambda x: x.key != CLUSTERMAN_TERMINATION_TAINT_KEY, node.spec.taints))
@@ -411,7 +414,7 @@ class KubernetesClusterConnector(ClusterConnector):
             agent_id=node.metadata.name,
             allocated_resources=allocated_node_resources(self._pods_by_ip[node_ip]),
             is_safe_to_kill=self._is_node_safe_to_kill(node_ip),
-            is_frozen=self._is_node_frozen(node),
+            is_draining=self._is_node_draining(node),
             batch_task_count=self._count_batch_tasks(node_ip),
             state=(AgentState.RUNNING if self._pods_by_ip[node_ip] else AgentState.IDLE),
             task_count=len(self._pods_by_ip[node_ip]),
@@ -420,7 +423,7 @@ class KubernetesClusterConnector(ClusterConnector):
             lsbrelease=get_node_lsbrelease(node),
         )
 
-    def _is_node_frozen(self, node: KubernetesNode) -> bool:
+    def _is_node_draining(self, node: KubernetesNode) -> bool:
         if not node.spec:
             return False
 
@@ -520,13 +523,6 @@ class KubernetesClusterConnector(ClusterConnector):
             if condition.type == "PodScheduled" and condition.reason == "Unschedulable":
                 return True
         return False
-
-    def _get_ip_from_node_name(self, node_name: str) -> str:
-        return node_name.split(sep=".")[0].replace("ip-", "").replace("-", ".")
-
-    def _get_node_by_node_name(self, node_name: str) -> KubernetesNode:
-        ip = self._get_ip_from_node_name(node_name)
-        return self._nodes_by_ip.get(ip)
 
     @property
     def pool_label_key(self):

--- a/clusterman/mesos/mesos_cluster_connector.py
+++ b/clusterman/mesos/mesos_cluster_connector.py
@@ -73,10 +73,6 @@ class MesosClusterConnector(ClusterConnector):
     def get_resource_total(self, resource_name: str) -> float:
         return sum(getattr(total_agent_resources(agent), resource_name) for agent in self._agents_by_ip.values())
 
-    def freeze_agent(self, agent_id: str) -> None:
-        logger.info("Skipping freeze process because scheduler is mesos")
-        return
-
     def _get_agent_metadata(self, instance_ip: str) -> AgentMetadata:
         agent_dict = self._agents_by_ip.get(instance_ip)
         if not agent_dict:

--- a/clusterman/simulator/simulated_cluster_connector.py
+++ b/clusterman/simulator/simulated_cluster_connector.py
@@ -44,9 +44,6 @@ class SimulatedClusterConnector(ClusterConnector):
                 total += getattr(i.resources, resource_name)
         return total
 
-    def freeze_agent(self, agent_id: str) -> None:
-        return
-
     def _get_agent_metadata(self, instance_ip: str) -> AgentMetadata:
         for c in self.simulator.aws_clusters:
             for i in c.instances.values():


### PR DESCRIPTION
### Description

Currently we freeze (actually cordon) agent (node) in autoscaler before submitting for draining. But we don't need it anymore. Because we are cordoning nodes in drainer and it's not responsibility of autoscaler. Additionally we have some other places where we submit instance for draining (for ex: node_migration). We should cordon node in single place (drainer)