### PR TITLE
refactor drainer into actual batch

### DIFF
--- a/clusterman/args.py
+++ b/clusterman/args.py
@@ -196,7 +196,7 @@ def get_parser(description=""):  # pragma: no cover
     from clusterman.cli.simulate import add_simulate_parser
     from clusterman.cli.toggle import add_cluster_disable_parser
     from clusterman.cli.toggle import add_cluster_enable_parser
-    from clusterman.draining.queue import add_queue_parser
+    from clusterman.batch.drainer import cli_entrypoint as add_drainer_parser
     from clusterman.cli.migrate import add_migration_parser
 
     root_parser = argparse.ArgumentParser(prog="clusterman", description=description, formatter_class=help_formatter)
@@ -219,7 +219,7 @@ def get_parser(description=""):  # pragma: no cover
     add_status_parser(subparser)
     add_manager_parser(subparser)
     add_simulate_parser(subparser)
-    add_queue_parser(subparser)
+    add_drainer_parser(subparser)
     add_migration_parser(subparser)
 
     return root_parser

--- a/clusterman/batch/drainer.py
+++ b/clusterman/batch/drainer.py
@@ -1,0 +1,122 @@
+# Copyright 2019 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import argparse
+import sys
+import time
+from typing import Optional
+
+import colorlog
+import staticconf
+from yelp_batch.batch import batch_command_line_arguments
+from yelp_batch.batch import batch_configure
+from yelp_batch.batch_daemon import BatchDaemon
+
+from clusterman.args import add_cluster_arg
+from clusterman.args import add_env_config_path_arg
+from clusterman.args import subparser
+from clusterman.batch.util import BatchLoggingMixin
+from clusterman.batch.util import BatchRunningSentinelMixin
+from clusterman.config import get_pool_config_path
+from clusterman.config import load_cluster_pool_config
+from clusterman.config import setup_config
+from clusterman.draining.mesos import operator_api
+from clusterman.draining.queue import DrainingClient
+from clusterman.kubernetes.kubernetes_cluster_connector import KubernetesClusterConnector
+from clusterman.util import get_pool_name_list
+from clusterman.util import setup_logging
+
+
+class NodeDrainerBatch(BatchDaemon, BatchLoggingMixin, BatchRunningSentinelMixin):
+    notify_emails = ["compute-infra@yelp.com"]
+
+    CLI_SUBCOMMAND = "drain"
+    DEFAULT_RUN_INTERVAL_SECONDS = 5
+
+    @batch_command_line_arguments
+    def parse_args(self, parser: argparse.ArgumentParser):
+        arg_group = parser.add_argument_group("NodeDrainer batch options")
+        add_env_config_path_arg(arg_group)
+        add_cluster_arg(arg_group, required=True)
+
+    @batch_configure
+    def configure_initial(self):
+        setup_config(self.options)
+        self.run_interval = staticconf.read_int(
+            "batches.drainer.run_interval_seconds", self.DEFAULT_RUN_INTERVAL_SECONDS
+        )
+        for scheduler in ("mesos", "kubernetes"):
+            for pool in get_pool_name_list(self.options.cluster, scheduler):
+                load_cluster_pool_config(self.options.cluster, pool, scheduler, None)
+                self.add_watcher({f"{pool}.{scheduler}": get_pool_config_path(self.options.cluster, pool, scheduler)})
+        self.logger = colorlog.getLogger(__name__)
+
+    def run(self):
+        cluster_name = self.options.cluster
+        draining_client = DrainingClient(cluster_name)
+        cluster_manager_name = staticconf.read_string(f"clusters.{cluster_name}.cluster_manager")
+        always_delay_drain_processing = staticconf.read_bool(
+            f"clusters.{cluster_name}.always_delay_drain_processing", True
+        )
+        mesos_operator_client = kube_operator_client = None
+
+        try:
+            kube_operator_client = KubernetesClusterConnector(cluster_name, None)
+        except Exception:
+            self.logger.error("Cluster specified is mesos specific. Skipping kubernetes operator")
+        if cluster_manager_name == "mesos":
+            try:
+                mesos_master_url = staticconf.read_string(f"clusters.{cluster_name}.mesos_master_fqdn")
+                mesos_secret_path = staticconf.read_string("mesos.mesos_agent_secret_path", default=None)
+                mesos_operator_client = operator_api(mesos_master_url, mesos_secret_path)
+            except Exception:
+                self.logger.error("Cluster specified is kubernetes specific. Skipping mesos operator")
+
+        self.logger.info("Polling SQS for messages every 5s")
+        while self.running:
+            if kube_operator_client:
+                kube_operator_client.reload_client()
+            draining_client.clean_processing_hosts_cache()
+            warning_result = draining_client.process_warning_queue()
+            draining_result = draining_client.process_drain_queue(
+                mesos_operator_client=mesos_operator_client,
+                kube_operator_client=kube_operator_client,
+            )
+            termination_result = draining_client.process_termination_queue(
+                mesos_operator_client=mesos_operator_client,
+                kube_operator_client=kube_operator_client,
+            )
+            # sleep five seconds only if all queues are empty OR feature flag is enabled
+            if always_delay_drain_processing or (not warning_result and not draining_result and not termination_result):
+                time.sleep(self.run_interval)
+
+
+def main(args: Optional[argparse.ArgumentParser] = None):
+    if args:
+        # clean sub-command when invoked from CLI interface
+        sys.argv.pop(sys.argv.index(NodeDrainerBatch.CLI_SUBCOMMAND))
+    NodeDrainerBatch().start()
+
+
+@subparser(NodeDrainerBatch.CLI_SUBCOMMAND, "Drains and terminates instances submitted to SQS by clusterman", main)
+def cli_entrypoint(
+    subparser: argparse.ArgumentParser,
+    required_named_args: argparse.Namespace,
+    optional_named_args: argparse.Namespace,
+) -> None:
+    NodeDrainerBatch().parse_args(subparser)
+
+
+if __name__ == "__main__":
+    setup_logging()
+    main()

--- a/tests/batch/drainer_test.py
+++ b/tests/batch/drainer_test.py
@@ -1,0 +1,58 @@
+# Copyright 2019 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from unittest import mock
+
+import pytest
+import staticconf.testing
+
+from clusterman.batch.drainer import NodeDrainerBatch
+
+
+class LoopBreak(Exception):
+    pass
+
+
+def test_drainer_batch_process_queues():
+    batch = NodeDrainerBatch()
+    batch.run_interval = 5
+    batch.logger = mock.MagicMock()
+    batch.options = mock.MagicMock(cluster="westeros-prod", autorestart_interval_minutes=0)
+    with mock.patch(
+        "clusterman.batch.drainer.DrainingClient",
+        autospec=True,
+    ) as mock_draining_client, staticconf.testing.PatchConfiguration(
+        {
+            "clusters": {
+                "westeros-prod": {
+                    "mesos_master_fqdn": "westeros-prod",
+                    "cluster_manager": "mesos",
+                }
+            }
+        },
+    ), mock.patch(
+        "clusterman.batch.drainer.time.sleep", autospec=True, side_effect=LoopBreak
+    ), mock.patch(
+        "clusterman.batch.drainer.KubernetesClusterConnector",
+        autospec=True,
+    ):
+
+        mock_draining_client.return_value.process_termination_queue.return_value = False
+        mock_draining_client.return_value.process_drain_queue.return_value = False
+        mock_draining_client.return_value.process_warning_queue.return_value = False
+        with pytest.raises(LoopBreak):
+            batch.run()
+        assert mock_draining_client.return_value.process_termination_queue.called
+        assert mock_draining_client.return_value.process_drain_queue.called
+        assert mock_draining_client.return_value.clean_processing_hosts_cache.called
+        assert mock_draining_client.return_value.process_warning_queue.called


### PR DESCRIPTION
This turns the drainer queue processing logic into an actual batch so that we can get proper configuration reloading.

To maintain the current CLI interface and not break stuff, I hacked around a bit with argv, but I'd say it's an acceptable amount of terribleness.

**EDIT**: ok, the amount of hacking has definitely grown a little. I'd say we can ship this maintain compatibility with current deployments, update all command line invocations (since this allows calling the batch module directly as well), and then get rid of all the horrible hacks, giving up invoking this from the main CLI entrypoint.