### PR TITLE
Update jenkins.yaml

### DIFF
--- a/jenkins.yaml
+++ b/jenkins.yaml
@@ -12,4 +12,9 @@ overrides:
     platforms: [xenial, bionic, jammy]
     globalEnvVars:
       PAASTA_ENV: YELP
-host_type: bionic
+host:
+  os_release: bionic
+  min_cpu: 0.5
+  min_memory: 1
+  max_cpu: 6
+  max_memory: 6


### PR DESCRIPTION
Update jenkins yaml to use host instead of host type as part of Simplifying Jenkins

### Description

As a part of our initiative to simplify Jenkins, we can now allow developers to specify params such as memory size and cpu size for their Jenkins jobs instead of relying on predefined hosts.

### Testing Done

This has been tested on multiple internal repositories and a bulk change was done to update all repositories.
