### PR TITLE
handling multiple termination of same instance

### DIFF
--- a/clusterman/aws/aws_resource_group.py
+++ b/clusterman/aws/aws_resource_group.py
@@ -140,6 +140,13 @@ class AWSResourceGroup(ResourceGroup, metaclass=ABCMeta):
 
         instance_weights = {}
         for instance in ec2_describe_instances(instance_ids):
+            # skip if instance already terminated
+            if instance["State"].get("Name") in ["terminated", "shutting-down"]:
+                logger.warning(
+                    f"Instance {instance['InstanceId']} already terminating or terminated, so skipping",
+                )
+                instance_ids.remove(instance["InstanceId"])
+                continue
             instance_market = get_instance_market(cast(MarketDict, instance))
             if not instance_market.az:
                 logger.warning(


### PR DESCRIPTION
### Description
Jira: [CLUSTERMAN-686](https://jira.yelpcorp.com/browse/CLUSTERMAN-686)
There are cases where clusterman could try to `terminate` an already `terminated` instance. AWS complains about these case if it has already removed those `terminated` instance from their console, which could lead cman to throw errors.

Now, before terminating Clusterman would check if the instance is not already terminated; then proceeds to `terminate` them.
### Testing Done
`make test`
Tested `terminate_instances_by_id()` .
