### PR TITLE
Optimized Kubernetes Metrics collection

### DIFF
--- a/clusterman/util.py
+++ b/clusterman/util.py
@@ -97,6 +97,14 @@ class ClustermanResources(NamedTuple):
             gpus=self.gpus * scalar,
         )
 
+    def __add__(self, other) -> "ClustermanResources":
+        return ClustermanResources(
+            cpus=self.cpus + other.cpus,
+            mem=self.mem + other.mem,
+            disk=self.disk + other.disk,
+            gpus=self.gpus + other.gpus,
+        )
+
     def __lt__(self, other) -> bool:
         return self.cpus < other.cpus and self.mem < other.mem and self.disk < other.disk and self.gpus < other.gpus
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 clusterman (4.16.4) xenial bionic; urgency=low
 
-  * Added monitoring metrics for drainer  
+  * Added monitoring metrics for drainer
 
  -- Ilkin Mammadzada <ilkinmammadzada@yelp.com>  Thu, 03 Nov 2022 07:26:31 -0700
 


### PR DESCRIPTION
### Description

Currently we call `get_unschedulable_pods` 4 more times to calculate pending cpu, mem, disk, gpu.
We can keep total pending resources in memory and serve it with high performance.
