### PR TITLE
drainer: take advantage of EC2 API caching when terminating hosts

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 clusterman (4.16.4) xenial bionic; urgency=low
 
-  * Added monitoring metrics for drainer  
+  * Added monitoring metrics for drainer
 
  -- Ilkin Mammadzada <ilkinmammadzada@yelp.com>  Thu, 03 Nov 2022 07:26:31 -0700
 

--- a/tests/draining/queue_test.py
+++ b/tests/draining/queue_test.py
@@ -22,7 +22,6 @@ from clusterman.aws.spot_fleet_resource_group import SpotFleetResourceGroup
 from clusterman.draining.queue import DrainingClient
 from clusterman.draining.queue import Host
 from clusterman.draining.queue import host_from_instance_id
-from clusterman.draining.queue import terminate_host
 from clusterman.draining.queue import TerminationReason
 
 
@@ -414,7 +413,7 @@ def test_delete_terminate_message(mock_draining_client):
 
 
 def test_process_termination_queue(mock_draining_client):
-    with mock.patch("clusterman.draining.queue.terminate_host", autospec=True,) as mock_terminate, mock.patch(
+    with mock.patch.object(mock_draining_client, "terminate_host", autospec=True,) as mock_terminate, mock.patch(
         "clusterman.draining.queue.down",
         autospec=True,
     ) as mock_down, mock.patch("clusterman.draining.queue.up", autospec=True,) as mock_up, mock.patch(
@@ -869,11 +868,11 @@ def test_process_warning_queue(mock_draining_client):
         mock_delete_warning_messages.assert_called_with(mock_draining_client, [mock_host])
 
 
-def test_terminate_host():
+def test_terminate_host(mock_draining_client):
     mock_host = mock.Mock(instance_id="i123", sender="sfr", group_id="sfr123")
     mock_sfr = mock.Mock()
     with mock.patch.dict("clusterman.draining.queue.RESOURCE_GROUPS", {"sfr": mock_sfr}, clear=True):
-        terminate_host(mock_host)
+        mock_draining_client.terminate_host(mock_host)
         mock_sfr.assert_called_with("sfr123")
         mock_sfr.return_value.terminate_instances_by_id.assert_called_with(["i123"])
 


### PR DESCRIPTION
This bit of instance termination code was still doing unneeded calls to EC2 APIs as it re-initialized resource groups objects from scratch. Since we already enumerate them all, I changed the caching to store all the resource group objects, rather than only the group IDs, so that they could be used later one in the termination code. It will eat up a bit more memory, but shouldn't be too much more memory.
