### PR TITLE
ignored pending pod reason detection

### DIFF
--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -197,11 +197,18 @@ class KubernetesClusterConnector(ClusterConnector):
         )
 
     def get_unschedulable_pods(
-        self,
+        self, detect_reason: Optional[bool] = True
     ) -> List[Tuple[KubernetesPod, PodUnschedulableReason]]:
         unschedulable_pods = []
         for pod in self._unschedulable_pods:
-            unschedulable_pods.append((pod, self._get_pod_unschedulable_reason(pod)))
+            unschedulable_pods.append(
+                (
+                    pod,
+                    self._get_pod_unschedulable_reason(pod)
+                    if detect_reason
+                    else PodUnschedulableReason.InsufficientResources,
+                )
+            )
         return unschedulable_pods
 
     def drain_node(self, node_name: str, disable_eviction: bool) -> bool:

--- a/clusterman/mesos/metrics_generators.py
+++ b/clusterman/mesos/metrics_generators.py
@@ -43,7 +43,7 @@ SIMPLE_METADATA = {
     "non_orphan_fulfilled_capacity": lambda manager: manager.non_orphan_fulfilled_capacity,
 }
 KUBERNETES_METRICS = {
-    "unschedulable_pods": lambda manager: len(manager.cluster_connector.get_unschedulable_pods()),
+    "unschedulable_pods": lambda manager: len(manager.cluster_connector.get_unschedulable_pods(detect_reason=False)),
     "cpus_pending": lambda manager: manager.cluster_connector.get_resource_pending("cpus"),
     "mem_pending": lambda manager: manager.cluster_connector.get_resource_pending("mem"),
     "disk_pending": lambda manager: manager.cluster_connector.get_resource_pending("disk"),

--- a/clusterman/signals/pending_pods_signal.py
+++ b/clusterman/signals/pending_pods_signal.py
@@ -58,7 +58,9 @@ class PendingPodsSignal(Signal):
         retry_on_broken_pipe: bool = True,
     ) -> Union[SignalResourceRequest, List[KubernetesPod]]:
         allocated_resources = self.cluster_connector.get_cluster_allocated_resources()
-        pending_pods = self.cluster_connector.get_unschedulable_pods()
+        pending_pods = self.cluster_connector.get_unschedulable_pods(
+            detect_reason=self.parameters.get("detect_reason", True)
+        )
 
         # Get the most recent metrics _now_ and when the boost was set (if any) and merge them
         if self.parameters.get("per_pod_resource_requests"):

--- a/itests/steps/autoscaler.py
+++ b/itests/steps/autoscaler.py
@@ -286,7 +286,9 @@ def create_k8s_autoscaler(context, prevent_scale_down_after_capacity_loss=False)
     context.mock_cluster_connector._unschedulable_pods = []
     if float(context.pending_cpus) > 0:
         context.mock_cluster_connector.get_unschedulable_pods = (
-            lambda: KubernetesClusterConnector.get_unschedulable_pods(context.mock_cluster_connector)  # noqa
+            lambda detect_reason: KubernetesClusterConnector.get_unschedulable_pods(
+                context.mock_cluster_connector, detect_reason=detect_reason
+            )  # noqa
         )
         context.mock_cluster_connector._get_pod_unschedulable_reason.side_effect = lambda pod: (
             PodUnschedulableReason.InsufficientResources


### PR DESCRIPTION
### Description

We noticed that autoscaling works weirdly (doesn’t react to pending pods) for some pools.
After investigation we saw that weirdness exists only in pools which use internal signals. (autoscale_signal.internal:true)
To explain briefly these pools are using PendingPodsSignal locally (in Autoscaler component) instead of getting information from DynamoDB (ExternalSignal)

- What is difference between them?

PendingPodsSignal: considers only unschedulable pods which has InsufficientResources reason.
ExternalSignal: considers all unschedulable pods.

- Why most times PendingPodsSignal doesn’t react to pending pods? / Why most time we have many pods with Unknown reason?

Because reason detection mechanism has bug: It checks all unschedulable to be sure that if it fits to any existing nodes in the pool.. It marks fitted unschedulable pod as Unknown.
This means if you have 500 pending pods (with 5 CPU request) and 100 nodes (99 with 0 empty CPU, 1 with 5 free CPU) then Clusterman thinks that all pending pods are pending for Unknown reason. And doesn’t scale up cluster…

