### PR TITLE
allow stopping node-migration jobs

### DIFF
--- a/clusterman/args.py
+++ b/clusterman/args.py
@@ -197,6 +197,7 @@ def get_parser(description=""):  # pragma: no cover
     from clusterman.cli.toggle import add_cluster_disable_parser
     from clusterman.cli.toggle import add_cluster_enable_parser
     from clusterman.cli.migrate import add_migration_parser
+    from clusterman.cli.migrate import add_migration_stop_parser
 
     root_parser = argparse.ArgumentParser(prog="clusterman", description=description, formatter_class=help_formatter)
     add_env_config_path_arg(root_parser)
@@ -219,6 +220,7 @@ def get_parser(description=""):  # pragma: no cover
     add_manager_parser(subparser)
     add_simulate_parser(subparser)
     add_migration_parser(subparser)
+    add_migration_stop_parser(subparser)
 
     return root_parser
 

--- a/clusterman/migration/event_enums.py
+++ b/clusterman/migration/event_enums.py
@@ -32,6 +32,7 @@ class MigrationStatus(enum.Enum):
     INPROGRESS = "inprogress"
     COMPLETED = "completed"
     SKIPPED = "skipped"
+    STOP = "stop"
 
 
 class ConditionTrait(enum.Enum):

--- a/docs/source/node_migration.rst
+++ b/docs/source/node_migration.rst
@@ -58,6 +58,7 @@ Migration Event Trigger
 
 Migration trigger events are submitted as Kubernetes custom resources of type ``nodemigration``.
 They can be easily generated and submitted by using the ``clusterman migrate`` CLI sub-command and it related options.
+In case jobs for a pool need to be stopped, it is possible to use the ``clusterman migrate-stop`` utility.
 The manifest for the custom resource defintion is as follows:
 
 


### PR DESCRIPTION
Adds the option to interrupt ongoing node-migration jobs for a pool via a new `migrate-stop` CLI subcommand.

The way it works is simply by updating the status label of the currently pending/in-progress events, which then gets picked up by the node-migration batch which proceeds to get the corresponding worker processes terminated.