### PR TITLE
node-migration: allow requeue nodes failing to drain

### DIFF
--- a/clusterman/autoscaler/pool_manager.py
+++ b/clusterman/autoscaler/pool_manager.py
@@ -583,6 +583,21 @@ class PoolManager:
             if node_metadata.agent.state not in (AgentState.ORPHANED, AgentState.UNKNOWN)
         )
 
+    def is_node_still_in_pool(self, node_metadata: ClusterNodeMetadata) -> bool:
+        """Checks if the node is still present and active in any resource group.
+        Useful to check for instance termination.
+
+        :param ClusterNodeMetadata node_metadata: node metadata wrapper
+        :return: true if still in pool
+        """
+        return (
+            # check cluster connector is still detecting node
+            node_metadata.agent.agent_id
+            == self.cluster_connector.get_agent_metadata(node_metadata.instance.ip_address).agent_id
+            # check instance ID is still in resource group
+            and node_metadata.instance.instance_id in self.resource_groups[node_metadata.instance.group_id].instance_ids
+        )
+
     def is_capacity_satisfied(self) -> bool:
         """States whether current pool capacity is considered in line with expectation"""
         return self.non_orphan_fulfilled_capacity >= self.target_capacity

--- a/clusterman/migration/settings.py
+++ b/clusterman/migration/settings.py
@@ -25,6 +25,7 @@ DEFAULT_NODE_BOOT_WAIT = "3m"
 DEFAULT_NODE_BOOT_TIMEOUT = "10m"
 DEFAULT_WORKER_TIMEOUT = "2h"
 DEFAULT_HEALTH_CHECK_INTERVAL = "2m"
+DEFAULT_ALLOWED_FAILED_DRAINS = 3
 
 
 class MigrationPrecendence(enum.Enum):
@@ -85,6 +86,7 @@ class WorkerSetup(NamedTuple):
     expected_duration: float
     health_check_interval: int
     ignore_pod_health: bool = False
+    allowed_failed_drains: int = 0
 
     @classmethod
     def from_config(cls, config: dict) -> "WorkerSetup":
@@ -104,4 +106,5 @@ class WorkerSetup(NamedTuple):
             health_check_interval=parse_time_interval_seconds(
                 config.get("health_check_interval", DEFAULT_HEALTH_CHECK_INTERVAL)
             ),
+            allowed_failed_drains=strat_conf.get("allowed_failed_drains", DEFAULT_ALLOWED_FAILED_DRAINS),
         )

--- a/clusterman/migration/worker.py
+++ b/clusterman/migration/worker.py
@@ -93,13 +93,7 @@ def _monitor_pool_health(
     while time.time() < timeout:
         manager.reload_state(load_pods_info=not ignore_pod_health)
         still_to_drain = (
-            [
-                node
-                for node in drained
-                if node.agent.agent_id == connector.get_agent_metadata(node.instance.ip_address).agent_id
-            ]
-            if not draining_happened
-            else []
+            [node for node in drained if manager.is_node_still_in_pool(node)] if not draining_happened else []
         )
         draining_happened = draining_happened or not bool(still_to_drain)
         # TODO: replace these with use of walrus operator in if-statement once on py38

--- a/docs/source/node_migration.rst
+++ b/docs/source/node_migration.rst
@@ -42,6 +42,7 @@ The allowed values for the migration settings are as follows:
     * ``az_name_alphabetical``: group nodes by availability zone, and select group in alphabetical order;
   * ``bootstrap_wait``: indicative time necessary for a node to be ready to run workloads after boot; human readable time string (3 minutes by default).
   * ``bootstrap_timeout``: maximum wait for nodes to be ready after boot; human readable time string (10 minutes by default).
+  * ``allowed_failed_drains``: allow for up to this many nodes to fail draining and be requeued before aborting (3 by default)
 
 * ``disable_autoscaling``: turn off autoscaler while recycling instances (false by default).
 

--- a/tests/batch/node_migration_test.py
+++ b/tests/batch/node_migration_test.py
@@ -115,6 +115,7 @@ def test_get_worker_setup(migration_batch):
         disable_autoscaling=False,
         expected_duration=7200.0,
         health_check_interval=120,
+        allowed_failed_drains=3,
     )
 
 

--- a/tests/migration/migration_worker_test.py
+++ b/tests/migration/migration_worker_test.py
@@ -67,7 +67,7 @@ def test_monitor_pool_health(mock_time):
         repeat(AgentMetadata(agent_id="")),
     )
     mock_time.time.return_value = 0
-    assert _monitor_pool_health(mock_manager, 1, drained, 120) is True
+    assert _monitor_pool_health(mock_manager, 1, drained, 120) == (True, [])
     # 1st iteration still draining some nodes
     # 2nd iteration underprovisioned capacity
     # 3rd iteration left over unscheduable pods
@@ -83,7 +83,7 @@ def test_drain_node_selection(mock_sfx, mock_monitor, mock_time):
     mock_uptime_stats_sfx = mock_sfx.create_gauge.return_value
     mock_job_duration_sfx = mock_sfx.create_timer.return_value
     mock_manager = MagicMock()
-    mock_monitor.return_value = True
+    mock_monitor.return_value = (True, [])
     mock_manager.get_node_metadatas.return_value = [
         ClusterNodeMetadata(
             AgentMetadata(agent_id=i, task_count=30 - 2 * i),
@@ -161,6 +161,93 @@ def test_drain_node_selection(mock_sfx, mock_monitor, mock_time):
 
 
 @patch("clusterman.migration.worker.time")
+@patch("clusterman.migration.worker._monitor_pool_health")
+@patch("clusterman.migration.worker.get_monitoring_client")
+def test_drain_node_selection_requeue(mock_sfx, mock_monitor, mock_time):
+    mock_manager = MagicMock()
+    mock_nodes = [
+        ClusterNodeMetadata(
+            AgentMetadata(agent_id=i, task_count=30 - 2 * i),
+            InstanceMetadata(None, None, uptime=timedelta(days=i)),
+        )
+        for i in range(6)
+    ]
+    mock_monitor.side_effect = [(True, []) if i != 0 else (False, [mock_nodes[4]]) for i in range(5)]
+    mock_manager.get_node_metadatas.return_value = mock_nodes
+    mock_time.time.side_effect = range(5)
+    worker_setup = WorkerSetup(
+        rate=PoolPortion(2),
+        prescaling=None,
+        precedence=MigrationPrecendence.TASK_COUNT,
+        bootstrap_wait=1,
+        bootstrap_timeout=2,
+        disable_autoscaling=False,
+        expected_duration=3,
+        health_check_interval=4,
+        allowed_failed_drains=3,
+    )
+    assert _drain_node_selection(mock_manager, lambda n: n.agent.agent_id > 2, worker_setup) is True
+    mock_manager.get_node_metadatas.assert_called_once_with(("running",))
+    mock_manager.submit_for_draining.assert_has_calls(
+        [
+            call(
+                ClusterNodeMetadata(
+                    AgentMetadata(agent_id=i, task_count=30 - 2 * i),
+                    InstanceMetadata(None, None, uptime=timedelta(days=i)),
+                ),
+                TerminationReason.NODE_MIGRATION,
+            )
+            for i in range(5, 2, -1)
+        ]
+        + [
+            call(
+                ClusterNodeMetadata(
+                    AgentMetadata(agent_id=4, task_count=30 - 2 * 4),
+                    InstanceMetadata(None, None, uptime=timedelta(days=4)),
+                ),
+                TerminationReason.NODE_MIGRATION,
+            )
+        ]
+    )
+    mock_monitor.assert_has_calls(
+        [
+            call(
+                manager=mock_manager,
+                timeout=2,
+                drained=[
+                    ClusterNodeMetadata(
+                        AgentMetadata(agent_id=5, task_count=20),
+                        InstanceMetadata(None, None, uptime=timedelta(days=5)),
+                    ),
+                    ClusterNodeMetadata(
+                        AgentMetadata(agent_id=4, task_count=22),
+                        InstanceMetadata(None, None, uptime=timedelta(days=4)),
+                    ),
+                ],
+                health_check_interval_seconds=4,
+                ignore_pod_health=False,
+            ),
+            call(
+                manager=mock_manager,
+                timeout=3,
+                drained=[
+                    ClusterNodeMetadata(
+                        AgentMetadata(agent_id=3, task_count=24),
+                        InstanceMetadata(None, None, uptime=timedelta(days=3)),
+                    ),
+                    ClusterNodeMetadata(
+                        AgentMetadata(agent_id=4, task_count=22),
+                        InstanceMetadata(None, None, uptime=timedelta(days=4)),
+                    ),
+                ],
+                health_check_interval_seconds=4,
+                ignore_pod_health=False,
+            ),
+        ]
+    )
+
+
+@patch("clusterman.migration.worker.time")
 @patch("clusterman.migration.worker.PoolManager")
 @patch("clusterman.migration.worker._drain_node_selection")
 def test_uptime_migration_worker(mock_drain_selection, mock_manager_class, mock_time):
@@ -180,7 +267,7 @@ def test_uptime_migration_worker(mock_drain_selection, mock_manager_class, mock_
 @patch("clusterman.migration.worker.enable_autoscaling")
 @patch("clusterman.migration.worker.disable_autoscaling")
 @patch("clusterman.migration.worker._drain_node_selection")
-@patch("clusterman.migration.worker._monitor_pool_health", lambda *_, **__: True)
+@patch("clusterman.migration.worker._monitor_pool_health", lambda *_, **__: (True, []))
 @patch("clusterman.migration.worker.limit_function_runtime", lambda f, _: f())
 def test_event_migration_worker(
     mock_drain_selection,

--- a/tests/migration/migration_worker_test.py
+++ b/tests/migration/migration_worker_test.py
@@ -62,9 +62,9 @@ def test_monitor_pool_health(mock_time):
     ]
     mock_manager.is_capacity_satisfied.side_effect = [False, True, True]
     mock_connector.has_enough_capacity_for_pods.side_effect = [False, False, True]
-    mock_connector.get_agent_metadata.side_effect = chain(
-        (AgentMetadata(agent_id=i) for i in range(3)),
-        repeat(AgentMetadata(agent_id="")),
+    mock_manager.is_node_still_in_pool.side_effect = chain(
+        (True for i in range(3)),
+        repeat(False),
     )
     mock_time.time.return_value = 0
     assert _monitor_pool_health(mock_manager, 1, drained, 120) == (True, [])


### PR DESCRIPTION
Just what it says on the tin. I made it configurable so that it's possible to decide how many drain failures to tolerate. I picked a non-0 but small default value as I think any workload would benefit from the setting, but if you think it'd be better to have the feature off by default happy to make the change.
