### PR TITLE
node-migration: add orphan_capacity_tollerance option

### DIFF
--- a/clusterman/autoscaler/pool_manager.py
+++ b/clusterman/autoscaler/pool_manager.py
@@ -598,9 +598,16 @@ class PoolManager:
             and node_metadata.instance.instance_id in self.resource_groups[node_metadata.instance.group_id].instance_ids
         )
 
-    def is_capacity_satisfied(self) -> bool:
-        """States whether current pool capacity is considered in line with expectation"""
-        return self.non_orphan_fulfilled_capacity >= self.target_capacity
+    def is_capacity_satisfied(self, orphan_capacity_tollerance: float = 0) -> bool:
+        """States whether current pool capacity is considered in line with expectation
+
+        :param float orphan_capacity_tollerance: acceptable ratio of orphan capacity to still consider check satisfied
+        """
+        target_capacity = self.target_capacity  # just saving a bit of CPU since it is a computed property
+        return self.non_orphan_fulfilled_capacity >= target_capacity or (
+            self.fulfilled_capacity >= target_capacity
+            and self.non_orphan_fulfilled_capacity * (1 + orphan_capacity_tollerance) >= target_capacity
+        )
 
     @property
     def target_capacity(self) -> float:

--- a/clusterman/migration/settings.py
+++ b/clusterman/migration/settings.py
@@ -26,6 +26,8 @@ DEFAULT_NODE_BOOT_TIMEOUT = "10m"
 DEFAULT_WORKER_TIMEOUT = "2h"
 DEFAULT_HEALTH_CHECK_INTERVAL = "2m"
 DEFAULT_ALLOWED_FAILED_DRAINS = 3
+DEFAULT_ORPHAN_CAPACITY_TOLLERANCE = 0
+MAX_ORPHAN_CAPACITY_TOLLERANCE = 0.2
 
 
 class MigrationPrecendence(enum.Enum):
@@ -87,6 +89,7 @@ class WorkerSetup(NamedTuple):
     health_check_interval: int
     ignore_pod_health: bool = False
     allowed_failed_drains: int = 0
+    orphan_capacity_tollerance: float = 0
 
     @classmethod
     def from_config(cls, config: dict) -> "WorkerSetup":
@@ -107,4 +110,8 @@ class WorkerSetup(NamedTuple):
                 config.get("health_check_interval", DEFAULT_HEALTH_CHECK_INTERVAL)
             ),
             allowed_failed_drains=strat_conf.get("allowed_failed_drains", DEFAULT_ALLOWED_FAILED_DRAINS),
+            orphan_capacity_tollerance=min(
+                float(config.get("orphan_capacity_tollerance", DEFAULT_ORPHAN_CAPACITY_TOLLERANCE)),
+                MAX_ORPHAN_CAPACITY_TOLLERANCE,
+            ),
         )

--- a/docs/source/node_migration.rst
+++ b/docs/source/node_migration.rst
@@ -50,6 +50,8 @@ The allowed values for the migration settings are as follows:
 
 * ``health_check_interval``: how much to wait between checks when monitoring pool health (2 minutes by default).
 
+* ``orphan_capacity_tollerance``: acceptable ratio of orphan capacity over target capacity to still consider the pool healthy (float, 0 by default).
+
 * ``expected_duration``: estimated duration for migration of the whole pool; human readable time string (1 day by default).
 
 See :ref:`pool_configuration` for how an example configuration block would look like.

--- a/docs/source/node_migration.rst
+++ b/docs/source/node_migration.rst
@@ -50,7 +50,7 @@ The allowed values for the migration settings are as follows:
 
 * ``health_check_interval``: how much to wait between checks when monitoring pool health (2 minutes by default).
 
-* ``orphan_capacity_tollerance``: acceptable ratio of orphan capacity over target capacity to still consider the pool healthy (float, 0 by default).
+* ``orphan_capacity_tollerance``: acceptable ratio of orphan capacity over target capacity to still consider the pool healthy (float, 0 by default, max 0.2).
 
 * ``expected_duration``: estimated duration for migration of the whole pool; human readable time string (1 day by default).
 

--- a/tests/migration/migration_worker_test.py
+++ b/tests/migration/migration_worker_test.py
@@ -133,6 +133,7 @@ def test_drain_node_selection(mock_sfx, mock_monitor, mock_time):
                 ],
                 health_check_interval_seconds=4,
                 ignore_pod_health=False,
+                orphan_capacity_tollerance=0,
             ),
             call(
                 manager=mock_manager,
@@ -145,6 +146,7 @@ def test_drain_node_selection(mock_sfx, mock_monitor, mock_time):
                 ],
                 health_check_interval_seconds=4,
                 ignore_pod_health=False,
+                orphan_capacity_tollerance=0,
             ),
         ]
     )
@@ -226,6 +228,7 @@ def test_drain_node_selection_requeue(mock_sfx, mock_monitor, mock_time):
                 ],
                 health_check_interval_seconds=4,
                 ignore_pod_health=False,
+                orphan_capacity_tollerance=0,
             ),
             call(
                 manager=mock_manager,
@@ -242,6 +245,7 @@ def test_drain_node_selection_requeue(mock_sfx, mock_monitor, mock_time):
                 ],
                 health_check_interval_seconds=4,
                 ignore_pod_health=False,
+                orphan_capacity_tollerance=0,
             ),
         ]
     )


### PR DESCRIPTION
There are some pools which are large, and change a lot pretty rapidly, which cause them to always have a good chunk of orphan nodes, making node-migration job think they are unhealthy, even though they are functioning just fine. This adds an option to loosen the capacity health-check as long as the raw number for node capacity is higher than the autoscaler target.