### PR TITLE
make devenv compatible with jammy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,27 +3,18 @@ repos:
       rev: v0.9.4
       hooks:
           - id: trailing-whitespace
-            language_version: python3.6
           - id: end-of-file-fixer
-            language_version: python3.6
             exclude: ^\.activate\.sh$
           - id: check-yaml
-            language_version: python3.6
           - id: debug-statements
-            language_version: python3.6
             exclude: ^itests/environment.py$
           - id: name-tests-test
-            language_version: python3.6
           - id: check-added-large-files
-            language_version: python3.6
             exclude: ^(\.activate\.sh|.*clusterman_signals_acceptance\.tar\.gz)$
           - id: check-byte-order-marker
-            language_version: python3.6
           - id: fix-encoding-pragma
             args: [--remove]
-            language_version: python3.6
           - id: flake8
-            language_version: python3.6
             exclude: ^docs/.*
             args: [
                 '--ignore=E121,E123,E126,E133,E203,E226,E231,E241,E242,E704,W503,W504,W505,W605'
@@ -37,18 +28,15 @@ repos:
                 --remove-import, from __future__ import print_function,
                 --remove-import, from __future__ import unicode_literals
             ]
-            language_version: python3.7
     - repo: https://github.com/asottile/pyupgrade
       rev: v1.2.0
       hooks:
           - id: pyupgrade
             args: [--py3-plus]
-            language_version: python3.6
     - repo: https://github.com/psf/black
       rev: 22.3.0
       hooks:
           - id: black
-            language_version: python3.7
             args:
                 - --target-version
                 - py37

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
-asn1crypto==1.1.0
 atomicwrites==1.3.0
 attrs==19.2.0
 aws-sam-translator==1.15.1
@@ -11,7 +10,7 @@ cffi==1.12.3
 cfgv==2.0.1
 cfn-lint==0.24.4
 coverage==4.5.4
-cryptography==2.7
+cryptography==38.0.4
 distlib==0.3.4
 docker==4.1.0
 ecdsa==0.13.3


### PR DESCRIPTION
I started working on an Ubuntu Jammy host and had a bit of trouble setting up the venv and pre-commit hooks. The changes are all to dev tooling, so don't impact how the service and CLI are deployed. I think this will still be compatible with Bionic as well, but I'm not sure, github actions will tell.