### PR TITLE
Remove exception when requesting a resource a pool doesn't have

### DIFF
--- a/clusterman/autoscaler/autoscaler.py
+++ b/clusterman/autoscaler/autoscaler.py
@@ -30,7 +30,6 @@ from clusterman.autoscaler.config import get_autoscaling_config
 from clusterman.autoscaler.pool_manager import PoolManager
 from clusterman.config import POOL_NAMESPACE
 from clusterman.exceptions import NoSignalConfiguredException
-from clusterman.exceptions import ResourceRequestError
 from clusterman.interfaces.signal import Signal
 from clusterman.kubernetes.kubernetes_cluster_connector import KubernetesClusterConnector
 from clusterman.monitoring_lib import get_monitoring_client
@@ -399,9 +398,11 @@ class Autoscaler:
 
             if resource_total == 0:
                 if resource_request_value > 0:
-                    raise ResourceRequestError(
+                    logger.warning(
                         f"Signal requested {resource_request_value} for {resource} "
-                        "but the cluster doesn't have any of that resource"
+                        "but the cluster doesn't have any of that resource - continuing "
+                        "under the assumption that the resource will be added soon (e.g., "
+                        "after a Puppet run"
                     )
                 requested_resource_usage_pcts[resource] = 0
             else:

--- a/clusterman/autoscaler/autoscaler.py
+++ b/clusterman/autoscaler/autoscaler.py
@@ -402,7 +402,7 @@ class Autoscaler:
                         f"Signal requested {resource_request_value} for {resource} "
                         "but the cluster doesn't have any of that resource - continuing "
                         "under the assumption that the resource will be added soon (e.g., "
-                        "after a Puppet run"
+                        "after a Puppet run)"
                     )
                 requested_resource_usage_pcts[resource] = 0
             else:

--- a/itests/autoscaler_scaling.feature
+++ b/itests/autoscaler_scaling.feature
@@ -48,15 +48,6 @@ Feature: make sure the autoscaler scales to the proper amount
         | 20 cpus   | 1          | 0          |     no |
         | 20 cpus   | 21         | 20         |    yes |
 
-    Scenario: requesting GPUs on a pool without GPU instances is an error
-       Given a cluster with 2 resource groups
-         And 20 target capacity
-         And 80 CPUs, 1000 MB mem, 1000 MB disk, and 0 GPUs
-         And a mesos autoscaler object
-        When the signal resource request is 1 gpus
-         And the autoscaler runs
-        Then a ResourceRequestError is raised
-
     Scenario: the autoscaler does nothing when it is paused
        Given a cluster with 2 resource groups
          And 20 target capacity


### PR DESCRIPTION
This is triggering when scaling a GPU-enabled pool from 0 since our bootstrap doesn't immediatly register these nodes as having any GPU capacity right now