### PR TITLE
node-migration: add max_uptime_worker_skips setting

### DIFF
--- a/clusterman/migration/settings.py
+++ b/clusterman/migration/settings.py
@@ -27,6 +27,7 @@ DEFAULT_WORKER_TIMEOUT = "2h"
 DEFAULT_HEALTH_CHECK_INTERVAL = "2m"
 DEFAULT_ALLOWED_FAILED_DRAINS = 3
 DEFAULT_ORPHAN_CAPACITY_TOLLERANCE = 0
+DEFAULT_MAX_UPTIME_WORKER_SKIPS = 6
 MAX_ORPHAN_CAPACITY_TOLLERANCE = 0.2
 
 
@@ -90,6 +91,7 @@ class WorkerSetup(NamedTuple):
     ignore_pod_health: bool = False
     allowed_failed_drains: int = 0
     orphan_capacity_tollerance: float = 0
+    max_uptime_worker_skips: int = 0
 
     @classmethod
     def from_config(cls, config: dict) -> "WorkerSetup":
@@ -114,4 +116,5 @@ class WorkerSetup(NamedTuple):
                 float(config.get("orphan_capacity_tollerance", DEFAULT_ORPHAN_CAPACITY_TOLLERANCE)),
                 MAX_ORPHAN_CAPACITY_TOLLERANCE,
             ),
+            max_uptime_worker_skips=config.get("max_uptime_worker_skips", DEFAULT_MAX_UPTIME_WORKER_SKIPS),
         )

--- a/docs/source/node_migration.rst
+++ b/docs/source/node_migration.rst
@@ -52,6 +52,8 @@ The allowed values for the migration settings are as follows:
 
 * ``orphan_capacity_tollerance``: acceptable ratio of orphan capacity over target capacity to still consider the pool healthy (float, 0 by default, max 0.2).
 
+* ``max_uptime_worker_skips``: maximum number of times the uptime monitoring worker can skip churning nodes due to unsatisfied pool capacity (6 by default, set to 0 to always allow skipping).
+
 * ``expected_duration``: estimated duration for migration of the whole pool; human readable time string (1 day by default).
 
 See :ref:`pool_configuration` for how an example configuration block would look like.

--- a/tests/batch/node_migration_test.py
+++ b/tests/batch/node_migration_test.py
@@ -116,6 +116,7 @@ def test_get_worker_setup(migration_batch):
         expected_duration=7200.0,
         health_check_interval=120,
         allowed_failed_drains=3,
+        max_uptime_worker_skips=6,
     )
 
 


### PR DESCRIPTION
Allow the uptime workers to eventually get the node draining going even when pool capacity is currently not fully satisfied.
It's just an in-memory value, so it'll get lost with restarts, but don't really see that as a bit issue.
