### PR TITLE
node-migration: allow better log distinction across pools

### DIFF
--- a/clusterman/migration/worker.py
+++ b/clusterman/migration/worker.py
@@ -36,7 +36,7 @@ from clusterman.monitoring_lib import get_monitoring_client
 from clusterman.util import limit_function_runtime
 
 
-logger = colorlog.getLogger(__name__)
+module_logger = colorlog.getLogger(__name__)
 UPTIME_CHECK_INTERVAL_SECONDS = 60 * 60  # 1 hour
 INITIAL_POOL_HEALTH_TIMEOUT_SECONDS = 15 * 60
 SUPPORTED_POOL_SCHEDULER = "kubernetes"
@@ -90,6 +90,7 @@ def _monitor_pool_health(
     :return: tuple of health status, and nodes failing to drain
     """
     still_to_drain = []
+    logger = module_logger.getChild(manager.pool)
     draining_happened, capacity_satisfied, pods_healthy = False, False, False
     connector = cast(KubernetesClusterConnector, manager.cluster_connector)
     logger.info(f"Monitoring health for {manager.cluster}:{manager.pool}")
@@ -127,6 +128,7 @@ def _drain_node_selection(
     :param WorkerSetup worker_setup: node migration setup
     :return: true if completed
     """
+    logger = module_logger.getChild(manager.pool)
     nodes = manager.get_node_metadatas(AWS_RUNNING_STATES)
     selected = sorted(filter(selector, nodes), key=worker_setup.precedence.sort_key)
     if not selected:
@@ -186,6 +188,7 @@ def uptime_migration_worker(
     :param int uptime_seconds: uptime threshold
     :param WorkerSetup worker_setup: migration setup
     """
+    logger = module_logger.getChild(pool)
     manager = PoolManager(cluster, pool, SUPPORTED_POOL_SCHEDULER, fetch_state=False)
     node_selector = lambda node: node.instance.uptime.total_seconds() > uptime_seconds  # noqa
     if not manager.draining_client:
@@ -214,6 +217,7 @@ def event_migration_worker(migration_event: MigrationEvent, worker_setup: Worker
     :param WorkerSetup worker_setup: migration setup
     """
     pool_lock_acquired = False
+    logger = module_logger.getChild(migration_event.pool)
     manager = PoolManager(migration_event.cluster, migration_event.pool, SUPPORTED_POOL_SCHEDULER, fetch_state=False)
     connector = cast(KubernetesClusterConnector, manager.cluster_connector)
     connector.set_label_selectors(migration_event.label_selectors, add_to_existing=True)

--- a/tests/migration/migration_worker_test.py
+++ b/tests/migration/migration_worker_test.py
@@ -52,7 +52,7 @@ def event_worker_setup():
 
 @patch("clusterman.migration.worker.time")
 def test_monitor_pool_health(mock_time):
-    mock_manager = MagicMock()
+    mock_manager = MagicMock(pool="foobar")
     mock_connector = mock_manager.cluster_connector
     drained = [
         ClusterNodeMetadata(
@@ -82,7 +82,7 @@ def test_drain_node_selection(mock_sfx, mock_monitor, mock_time):
     mock_drain_count_sfx = mock_sfx.create_counter.return_value
     mock_uptime_stats_sfx = mock_sfx.create_gauge.return_value
     mock_job_duration_sfx = mock_sfx.create_timer.return_value
-    mock_manager = MagicMock()
+    mock_manager = MagicMock(pool="foobar")
     mock_monitor.return_value = (True, [])
     mock_manager.get_node_metadatas.return_value = [
         ClusterNodeMetadata(
@@ -166,7 +166,7 @@ def test_drain_node_selection(mock_sfx, mock_monitor, mock_time):
 @patch("clusterman.migration.worker._monitor_pool_health")
 @patch("clusterman.migration.worker.get_monitoring_client")
 def test_drain_node_selection_requeue(mock_sfx, mock_monitor, mock_time):
-    mock_manager = MagicMock()
+    mock_manager = MagicMock(pool="foobar")
     mock_nodes = [
         ClusterNodeMetadata(
             AgentMetadata(agent_id=i, task_count=30 - 2 * i),


### PR DESCRIPTION
This just makes it easier to get for the logs relative to a given pool when there are multiple jobs running at the same time.