### PR TITLE
Add max_capacity to status output

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,11 +14,6 @@ repos:
           - id: check-byte-order-marker
           - id: fix-encoding-pragma
             args: [--remove]
-          - id: flake8
-            exclude: ^docs/.*
-            args: [
-                '--ignore=E121,E123,E126,E133,E203,E226,E231,E241,E242,E704,W503,W504,W505,W605'
-            ]
     - repo: https://github.com/asottile/reorder_python_imports
       rev: v0.3.5
       hooks:
@@ -40,3 +35,11 @@ repos:
             args:
                 - --target-version
                 - py37
+    - repo: https://github.com/PyCQA/flake8
+      rev: 4.0.1
+      hooks:
+      -   id: flake8
+          exclude: ^docs/.*
+          args: [
+              '--ignore=E121,E123,E126,E133,E203,E226,E231,E241,E242,E704,W503,W504,W505,W605'
+          ]

--- a/clusterman/cli/status.py
+++ b/clusterman/cli/status.py
@@ -78,6 +78,8 @@ class StatusJsonObject(TypedDict):
     disabled: bool
     fulfilled_capacity: float
     target_capacity: float
+    min_capacity: float
+    max_capacity: float
     non_orphan_fulfilled_capacity: float
     resource_groups: List[ResourceGroupJsonObject]
     migrations: List[MigrationEvent]

--- a/clusterman/cli/status.py
+++ b/clusterman/cli/status.py
@@ -141,6 +141,8 @@ def _status_json(manager: PoolManager, get_node_metadatas: bool, get_migrations:
         "target_capacity": manager.target_capacity,
         "fulfilled_capacity": manager.fulfilled_capacity,
         "non_orphan_fulfilled_capacity": manager.non_orphan_fulfilled_capacity,
+        "min_capacity": manager.min_capacity,
+        "max_capacity": manager.max_capacity,
         "resource_groups": _get_resource_groups_json(manager.resource_groups.values(), node_metadatas),
         "migrations": (
             _get_migrations(manager.cluster, manager.pool)
@@ -251,7 +253,8 @@ def print_status(manager: PoolManager, args: argparse.Namespace) -> None:
     print(
         f'Resource groups (target capacity: {status_obj["target_capacity"]}, '
         f'fulfilled: {status_obj["fulfilled_capacity"]}, '
-        f'non-orphan: {status_obj["non_orphan_fulfilled_capacity"]}):'
+        f'non-orphan: {status_obj["non_orphan_fulfilled_capacity"]}, '
+        f'max: {status_obj["max_capacity"]}):'
     )
 
     for group in status_obj["resource_groups"]:


### PR DESCRIPTION
### Description

Including max_capacity in our status output is pretty trivial since our Poolmanager already tracks this and including it in the output will making finding out that we are already at capacity much simpler. Today pool owners need to check on this manually, and we've seen instances where folks are unaware if they've hit their max in clusterman configs or aws configs. This change at least means they have to look up only one of those.

Adding this to the json output allows us to potentially use `clusterman status` to check whether we've been at target_capacity==max_capacity for extended periods of time (until a better option is available).

While working on this i ran into a flake8 issue that seems to crop up w/ older versions of pre-commit (`AttributeError: 'FlakesChecker' object has no attribute 'ANNASSIGN'`), so this pulls an updated version of the hook from PyCQA/flake8 

### Testing Done
Manual run:
```
$ python -m clusterman.run status --cluster pnw-devc --scheduler kubernetes --pool default

Current status for the default pool in the pnw-devc cluster:

Resource groups (target capacity: 314, fulfilled: 359, non-orphan: 359, max: 9000):
        paasta-pnw_devc_docker_lasagna_uswest2adevc-asg: active (125 / 104)

        paasta-pnw_devc_docker_lasagna_uswest2bdevc-asg: active (125 / 105)

        paasta-pnw_devc_docker_lasagna_uswest2cdevc-asg: active (109 / 105)

Cluster statistics:
        CPU allocation: 262.3 CPUs allocated to tasks, 350.0 total
        Memory allocation: 563.89 GB memory allocated to tasks, 2.75 TB total
        Disk allocation: 454.92 GB disk space allocated to tasks, 4.01 TB total
        GPUs allocation: 0 GPUs allocated to tasks, 0 total

```
