### PR TITLE
fixed milli-byte issue temporary in clusterman side

### DIFF
--- a/tests/kubernetes/util_test.py
+++ b/tests/kubernetes/util_test.py
@@ -51,6 +51,11 @@ def test_resource_parser_cpu():
 
 def test_resource_parser_mem():
     assert ResourceParser.mem({"memory": "1Gi"}) == 1000.0
+    assert ResourceParser.mem({"memory": "1GB"}) == 1000.0
+    assert ResourceParser.mem({"memory": "100Mi"}) == 100.0
+    assert ResourceParser.mem({"memory": "100MB"}) == 100.0
+    assert ResourceParser.mem({"memory": "100mb"}) == 100.0
+    assert ResourceParser.mem({"memory": "1000000000m"}) == 1.0
 
 
 def test_resource_parser_disk():


### PR DESCRIPTION
### Description

Currently milli-byte is considered as mega-byte and it affects autoscaler works. Namely, autoscaler bumps capacity to the `max_capacity`. We opened an [issue](https://github.com/xolox/python-humanfriendly/issues/68) and started changes in humanfriendly. But probably it will take some times, therefore we are temporarily fixing the issue in clusterman side. 