### PR TITLE
U/jfong/emit more autoscaler metrics

### DIFF
--- a/clusterman/autoscaler/autoscaler.py
+++ b/clusterman/autoscaler/autoscaler.py
@@ -45,6 +45,8 @@ from clusterman.util import Status
 
 SIGNAL_LOAD_CHECK_NAME = "signal_configuration_failed"
 TARGET_CAPACITY_GAUGE_NAME = "clusterman.autoscaler.target_capacity"
+MAX_CAPACITY_GAUGE_NAME = "clusterman.autoscaler.max_capacity"
+SETPOINT_GAUGE_NAME = "clusterman.autoscaler.setpoint"
 RESOURCE_GAUGE_BASE_NAME = "clusterman.autoscaler.requested_{resource}"
 logger = colorlog.getLogger(__name__)
 
@@ -84,6 +86,8 @@ class Autoscaler:
         gauge_dimensions = {"cluster": cluster, "pool": pool}
         monitoring_client = get_monitoring_client()
         self.target_capacity_gauge = monitoring_client.create_gauge(TARGET_CAPACITY_GAUGE_NAME, gauge_dimensions)
+        self.max_capacity_gauge = monitoring_client.create_gauge(MAX_CAPACITY_GAUGE_NAME, gauge_dimensions)
+        self.setpoint_gauge = monitoring_client.create_gauge(SETPOINT_GAUGE_NAME, gauge_dimensions)
         self.resource_request_gauges: Dict[str, Any] = {}
         for resource in SignalResourceRequest._fields:
             self.resource_request_gauges[resource] = monitoring_client.create_gauge(
@@ -175,6 +179,8 @@ class Autoscaler:
             capacity_offset = get_capacity_offset(self.cluster, self.pool, self.scheduler, timestamp)
             new_target_capacity = self._compute_target_capacity(resource_request) + capacity_offset
             self.target_capacity_gauge.set(new_target_capacity, {"dry_run": dry_run})
+            self.max_capacity_gauge.set(self.pool_manager.max_capacity, {"dry_run": dry_run})
+            self.setpoint_gauge.set(self.autoscaling_config.setpoint, {"dry_run": dry_run})
             self._emit_requested_resource_metrics(resource_request, dry_run=dry_run)
 
         try:

--- a/clusterman/autoscaler/autoscaler.py
+++ b/clusterman/autoscaler/autoscaler.py
@@ -83,7 +83,7 @@ class Autoscaler:
 
         logger.info(f"Initializing autoscaler engine for {self.pool} in {self.cluster}...")
 
-        gauge_dimensions = {"cluster": cluster, "pool": pool}
+        gauge_dimensions = get_cluster_dimensions(cluster=cluster, pool=pool, scheduler=scheduler)
         monitoring_client = get_monitoring_client()
         self.target_capacity_gauge = monitoring_client.create_gauge(TARGET_CAPACITY_GAUGE_NAME, gauge_dimensions)
         self.max_capacity_gauge = monitoring_client.create_gauge(MAX_CAPACITY_GAUGE_NAME, gauge_dimensions)

--- a/tests/autoscaler/autoscaler_test.py
+++ b/tests/autoscaler/autoscaler_test.py
@@ -89,6 +89,8 @@ def mock_autoscaler():
     mock_autoscaler.pool_manager.non_orphan_fulfilled_capacity = 0
 
     mock_autoscaler.target_capacity_gauge = mock.Mock(spec=GaugeProtocol)
+    mock_autoscaler.max_capacity_gauge = mock.Mock(spec=GaugeProtocol)
+    mock_autoscaler.setpoint_gauge = mock.Mock(spec=GaugeProtocol)
     mock_autoscaler.non_orphan_capacity_gauge = mock.Mock(spec=GaugeProtocol)
     mock_autoscaler.resource_request_gauges = {
         "mem": mock.Mock(spec=GaugeProtocol),
@@ -152,6 +154,10 @@ def test_autoscaler_run(dry_run, mock_autoscaler, run_timestamp):
         mock_autoscaler.run(dry_run=dry_run, timestamp=run_timestamp)
 
     assert mock_autoscaler.target_capacity_gauge.set.call_args == mock.call(100, {"dry_run": dry_run})
+    assert mock_autoscaler.max_capacity_gauge.set.call_args == mock.call(
+        mock_autoscaler.pool_manager.max_capacity, {"dry_run": dry_run}
+    )
+    assert mock_autoscaler.setpoint_gauge.set.call_args == mock.call(0.7, {"dry_run": dry_run})
     assert mock_autoscaler._compute_target_capacity.call_args == mock.call(resource_request)
     assert mock_autoscaler.pool_manager.modify_target_capacity.call_count == 1
 


### PR DESCRIPTION
### Description

This adds both max_capacity and setpoint to the `clusterman.autoscaler` metrics emitted by the autoscaler, for use in alerting/graphs e.g. when a pool has been at max_capacity or over setpoint for some period of time.

Note that I opted to emit these alongside the other metrics we emit from the autoscaler like target_capacity since we don't have access to the autoscalerconfig from the poolmanager, which would be the only thing we have access to from the cluster_metrics branch when emitting metadata metrics. 

Unfortunately it looks like the autoscaler-emitted metrics never actually got updated to include scheduler as part of the dimensions (so a mesos 'default' pool would emit the exact same metric name+dimensions as a kubernetes 'default' pool), so this PR corrects that problem as well. 
### Testing Done

Added one unit test to verify we're setting these values as expected, and manually applied to our kubestage autoscaler and verified the metrics were being emitted as expected: 
![Screen Shot 2023-01-12 at 12 49 48 PM](https://user-images.githubusercontent.com/2119545/212178776-0b3ca470-f1ec-477d-98dd-1ceb3bf4f3fc.png)

