### PR TITLE
node-migration: limit number of attempts for completing job

### DIFF
--- a/clusterman/migration/constants.py
+++ b/clusterman/migration/constants.py
@@ -1,0 +1,41 @@
+# Copyright 2019 Yelp Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# K8s CRD
+MIGRATION_CRD_GROUP = "clusterman.yelp.com"
+MIGRATION_CRD_VERSION = "v1"
+MIGRATION_CRD_PLURAL = "nodemigrations"
+MIGRATION_CRD_KIND = "NodeMigration"
+MIGRATION_CRD_STATUS_LABEL = "clusterman.yelp.com/migration_status"
+MIGRATION_CRD_ATTEMPTS_LABEL = "clusterman.yelp.com/attempts"
+
+# Default settings
+DEFAULT_POOL_PRESCALING = 0
+DEFAULT_NODE_BOOT_WAIT = "3m"
+DEFAULT_NODE_BOOT_TIMEOUT = "10m"
+DEFAULT_WORKER_TIMEOUT = "2h"
+DEFAULT_HEALTH_CHECK_INTERVAL = "2m"
+DEFAULT_ALLOWED_FAILED_DRAINS = 3
+DEFAULT_ORPHAN_CAPACITY_TOLLERANCE = 0
+DEFAULT_MAX_UPTIME_WORKER_SKIPS = 6
+MAX_ORPHAN_CAPACITY_TOLLERANCE = 0.2
+
+# Worker parameters
+UPTIME_CHECK_INTERVAL_SECONDS = 60 * 60  # 1 hour
+INITIAL_POOL_HEALTH_TIMEOUT_SECONDS = 15 * 60
+SUPPORTED_POOL_SCHEDULER = "kubernetes"
+
+# SFX metrics keys
+SFX_NODE_DRAIN_COUNT = "clusterman.node_migration.drain_count"
+SFX_MIGRATION_JOB_DURATION = "clusterman.node_migration.duration"
+SFX_DRAINED_NODE_UPTIME = "clusterman.node_migration.drained_node_uptime"

--- a/clusterman/migration/event_enums.py
+++ b/clusterman/migration/event_enums.py
@@ -33,6 +33,7 @@ class MigrationStatus(enum.Enum):
     COMPLETED = "completed"
     SKIPPED = "skipped"
     STOP = "stop"
+    FAILED = "failed"
 
 
 class ConditionTrait(enum.Enum):

--- a/clusterman/migration/settings.py
+++ b/clusterman/migration/settings.py
@@ -17,18 +17,16 @@ from typing import NamedTuple
 from typing import Union
 
 from clusterman.interfaces.types import ClusterNodeMetadata
+from clusterman.migration.constants import DEFAULT_ALLOWED_FAILED_DRAINS
+from clusterman.migration.constants import DEFAULT_HEALTH_CHECK_INTERVAL
+from clusterman.migration.constants import DEFAULT_MAX_UPTIME_WORKER_SKIPS
+from clusterman.migration.constants import DEFAULT_NODE_BOOT_TIMEOUT
+from clusterman.migration.constants import DEFAULT_NODE_BOOT_WAIT
+from clusterman.migration.constants import DEFAULT_ORPHAN_CAPACITY_TOLLERANCE
+from clusterman.migration.constants import DEFAULT_POOL_PRESCALING
+from clusterman.migration.constants import DEFAULT_WORKER_TIMEOUT
+from clusterman.migration.constants import MAX_ORPHAN_CAPACITY_TOLLERANCE
 from clusterman.util import parse_time_interval_seconds
-
-
-DEFAULT_POOL_PRESCALING = 0
-DEFAULT_NODE_BOOT_WAIT = "3m"
-DEFAULT_NODE_BOOT_TIMEOUT = "10m"
-DEFAULT_WORKER_TIMEOUT = "2h"
-DEFAULT_HEALTH_CHECK_INTERVAL = "2m"
-DEFAULT_ALLOWED_FAILED_DRAINS = 3
-DEFAULT_ORPHAN_CAPACITY_TOLLERANCE = 0
-DEFAULT_MAX_UPTIME_WORKER_SKIPS = 6
-MAX_ORPHAN_CAPACITY_TOLLERANCE = 0.2
 
 
 class MigrationPrecendence(enum.Enum):
@@ -104,7 +102,9 @@ class WorkerSetup(NamedTuple):
             prescaling=PoolPortion(strat_conf.get("prescaling", DEFAULT_POOL_PRESCALING)),
             precedence=MigrationPrecendence(strat_conf.get("precedence", MigrationPrecendence.default())),
             bootstrap_wait=parse_time_interval_seconds(strat_conf.get("bootstrap_wait", DEFAULT_NODE_BOOT_WAIT)),
-            bootstrap_timeout=parse_time_interval_seconds(strat_conf.get("bootstrap_timeout", DEFAULT_NODE_BOOT_WAIT)),
+            bootstrap_timeout=parse_time_interval_seconds(
+                strat_conf.get("bootstrap_timeout", DEFAULT_NODE_BOOT_TIMEOUT)
+            ),
             disable_autoscaling=config.get("disable_autoscaling", False),
             expected_duration=parse_time_interval_seconds(config.get("expected_duration", DEFAULT_WORKER_TIMEOUT)),
             ignore_pod_health=config.get("ignore_pod_health", False),

--- a/clusterman/migration/worker.py
+++ b/clusterman/migration/worker.py
@@ -283,7 +283,7 @@ def event_migration_worker(migration_event: MigrationEvent, worker_setup: Worker
             orphan_capacity_tollerance=worker_setup.orphan_capacity_tollerance,
         ):
             raise NodeMigrationError(f"Pool {migration_event.cluster}:{migration_event.pool} is not healthy")
-        node_selector = lambda node: node.agent.agent_id and not migration_event.condition.matches(node)  # noqa
+        node_selector = lambda node: node.agent.agent_id and not migration_event.matches(node)  # noqa
         migration_routine = partial(_drain_node_selection, manager, node_selector, worker_setup)
         if not limit_function_runtime(migration_routine, worker_setup.expected_duration):
             raise NodeMigrationError(f"Failed migrating nodes for event {migration_event}")

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -75,8 +75,11 @@ The following is an example configuration file for the core Clusterman service a
             # How frequently the batch should check for migration triggers.
             run_interval_seconds: 60
 
-            # Maximum number of restarts for an event worker
-            max_failed_attemps: 5
+            # Number of failed attempts tollerated for event workers.
+            # Job is marked as failed once this number of attempts is surpassed,
+            # and timespan from event creation is higher than this many times
+            # the estimated migration time for the pool.
+            failed_attemps_margin: 5
 
     clusters:
         cluster-name:

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -75,6 +75,9 @@ The following is an example configuration file for the core Clusterman service a
             # How frequently the batch should check for migration triggers.
             run_interval_seconds: 60
 
+            # Maximum number of restarts for an event worker
+            max_failed_attemps: 5
+
     clusters:
         cluster-name:
             aws_region: us-west-2

--- a/tests/migration/migration_event_test.py
+++ b/tests/migration/migration_event_test.py
@@ -14,6 +14,7 @@
 from datetime import timedelta
 from typing import Type
 
+import arrow
 import packaging.version
 import pytest
 import semver
@@ -109,10 +110,13 @@ def test_event_to_string():
             ConditionOperator.IN,
             [semver.VersionInfo.parse("1.2.3"), semver.VersionInfo.parse("3.4.5")],
         ),
+        previous_attempts=3,
+        created=arrow.get("2023-02-10T11:18:17Z"),
     )
-    assert (
-        str(event)
-        == "MigrationEvent(cluster=mesos-test, pool=bar, label_selectors=[], condition=(KERNEL in 1.2.3,3.4.5))"
+    assert str(event) == (
+        "MigrationEvent(cluster=mesos-test, pool=bar,"
+        " label_selectors=[], condition=(KERNEL in 1.2.3,3.4.5),"
+        " attempts=3, created=2023-02-10T11:18:17+00:00)"
     )
 
 


### PR DESCRIPTION
Apologies for the chunky diff, but I had to refactor a couple of things.

This will have the main node-migration batch keep track of the number of times a worker process is restart and limit that to a configured maximum (5 restarts by default). I had the number of attempted restarts also tracked in a label, so that the value will be respected across restarts, and can be easily shown in `clusterman status` when listing ongoing migrations.

I will now also look into making so that a condition like "uptime < 1d" is set, and then the job is restarted after quite some time, some nodes that aged in the meantime don't get re-recycled again, but didn't want to load too much on this single PR.