### PR TITLE
Make pending pods signal much more aggressive.

### DIFF
--- a/clusterman/signals/pending_pods_signal.py
+++ b/clusterman/signals/pending_pods_signal.py
@@ -30,7 +30,7 @@ def _get_resource_request(
             # This is a temporary measure to try to improve scaling behaviour when Clusterman thinks
             # there are enough resources but no single box can hold a new pod.  The goal is to replace
             # this with a more intelligent solution in the future.
-            resource_request += total_pod_resources(pod) * 2
+            resource_request += total_pod_resources(pod) * 5
 
     return resource_request + allocated_resources
 

--- a/itests/autoscaler_scaling.feature
+++ b/itests/autoscaler_scaling.feature
@@ -72,7 +72,7 @@ Feature: make sure the autoscaler scales to the proper amount
       Examples:
         | pending   | rg1_target | rg2_target |
         | 0         | 10         | 10         |
-        | 14        | 16         | 15         |
+        | 14        | 23         | 22         |
         | 1000      | 50         | 50         |
 
     @wip

--- a/tests/signals/pending_pods_signal_test.py
+++ b/tests/signals/pending_pods_signal_test.py
@@ -70,7 +70,7 @@ def test_get_resource_request_no_pending_pods(allocated_resources):
 def test_get_resource_request_only_pending_pods(pending_pods):
     assert _get_resource_request(ClustermanResources(), pending_pods) == SignalResourceRequest(
         cpus=15,
-        mem=1000,
+        mem=2500,
         disk=0,
         gpus=0,
     )
@@ -79,7 +79,7 @@ def test_get_resource_request_only_pending_pods(pending_pods):
 def test_get_resource_request_pending_pods_and_metrics(allocated_resources, pending_pods):
     assert _get_resource_request(allocated_resources, pending_pods) == SignalResourceRequest(
         cpus=165,
-        mem=2000,
+        mem=3500,
         disk=500,
         gpus=0,
     )

--- a/tests/signals/pending_pods_signal_test.py
+++ b/tests/signals/pending_pods_signal_test.py
@@ -69,7 +69,7 @@ def test_get_resource_request_no_pending_pods(allocated_resources):
 
 def test_get_resource_request_only_pending_pods(pending_pods):
     assert _get_resource_request(ClustermanResources(), pending_pods) == SignalResourceRequest(
-        cpus=6,
+        cpus=15,
         mem=1000,
         disk=0,
         gpus=0,
@@ -78,7 +78,7 @@ def test_get_resource_request_only_pending_pods(pending_pods):
 
 def test_get_resource_request_pending_pods_and_metrics(allocated_resources, pending_pods):
     assert _get_resource_request(allocated_resources, pending_pods) == SignalResourceRequest(
-        cpus=156,
+        cpus=165,
         mem=2000,
         disk=500,
         gpus=0,


### PR DESCRIPTION
This should force a scale up if there are pending pods, which will hopefully help get us unstuck with binpacking and Flink workloads.

