### PR TITLE
Move get resource request

### DIFF
--- a/clusterman/signals/pending_pods_signal.py
+++ b/clusterman/signals/pending_pods_signal.py
@@ -52,6 +52,8 @@ class PendingPodsSignal(Signal):
         """Given a list of metrics, construct a resource request based on the most recent
         data for allocated and pending pods"""
 
+        multiplier = self.parameters.get("pending_pods_multiplier", 2)
+
         resource_request = SignalResourceRequest()
         pending_pods = pending_pods or []
         if pending_pods:
@@ -59,6 +61,7 @@ class PendingPodsSignal(Signal):
                 # This is a temporary measure to try to improve scaling behaviour when Clusterman thinks
                 # there are enough resources but no single box can hold a new pod.  The goal is to replace
                 # this with a more intelligent solution in the future.
-                resource_request += total_pod_resources(pod) * 5
+                resource_request += total_pod_resources(pod) * multiplier
+            logger.info(f"Pending pods adding resource request: {resource_request} (multiplier {multiplier})")
 
         return resource_request + allocated_resources

--- a/clusterman/signals/pending_pods_signal.py
+++ b/clusterman/signals/pending_pods_signal.py
@@ -16,25 +16,6 @@ from clusterman.util import SignalResourceRequest
 logger = colorlog.getLogger(__name__)
 
 
-def _get_resource_request(
-    allocated_resources: ClustermanResources,
-    pending_pods: Optional[List[KubernetesPod]] = None,
-) -> SignalResourceRequest:
-    """Given a list of metrics, construct a resource request based on the most recent
-    data for allocated and pending pods"""
-
-    resource_request = SignalResourceRequest()
-    pending_pods = pending_pods or []
-    if pending_pods:
-        for pod in pending_pods:
-            # This is a temporary measure to try to improve scaling behaviour when Clusterman thinks
-            # there are enough resources but no single box can hold a new pod.  The goal is to replace
-            # this with a more intelligent solution in the future.
-            resource_request += total_pod_resources(pod) * 5
-
-    return resource_request + allocated_resources
-
-
 class PendingPodsSignal(Signal):
     def __init__(
         self,
@@ -61,4 +42,23 @@ class PendingPodsSignal(Signal):
         if self.parameters.get("per_pod_resource_requests"):
             return pending_pods
         else:
-            return _get_resource_request(allocated_resources, pending_pods)
+            return self._get_resource_request(allocated_resources, pending_pods)
+
+    def _get_resource_request(
+        self,
+        allocated_resources: ClustermanResources,
+        pending_pods: Optional[List[KubernetesPod]] = None,
+    ) -> SignalResourceRequest:
+        """Given a list of metrics, construct a resource request based on the most recent
+        data for allocated and pending pods"""
+
+        resource_request = SignalResourceRequest()
+        pending_pods = pending_pods or []
+        if pending_pods:
+            for pod in pending_pods:
+                # This is a temporary measure to try to improve scaling behaviour when Clusterman thinks
+                # there are enough resources but no single box can hold a new pod.  The goal is to replace
+                # this with a more intelligent solution in the future.
+                resource_request += total_pod_resources(pod) * 5
+
+        return resource_request + allocated_resources

--- a/itests/autoscaler_scaling.feature
+++ b/itests/autoscaler_scaling.feature
@@ -72,7 +72,7 @@ Feature: make sure the autoscaler scales to the proper amount
       Examples:
         | pending   | rg1_target | rg2_target |
         | 0         | 10         | 10         |
-        | 14        | 23         | 22         |
+        | 14        | 16         | 15         |
         | 1000      | 50         | 50         |
 
     @wip

--- a/tests/signals/pending_pods_signal_test.py
+++ b/tests/signals/pending_pods_signal_test.py
@@ -60,6 +60,7 @@ def pending_pods():
     ]
 
 
+# Just the existing resources, no pending pods
 def test_get_resource_request_no_pending_pods(allocated_resources, pending_pods_signal):
     assert pending_pods_signal._get_resource_request(allocated_resources) == SignalResourceRequest(
         cpus=150,
@@ -69,19 +70,32 @@ def test_get_resource_request_no_pending_pods(allocated_resources, pending_pods_
     )
 
 
+# Just the increase from pending pods (2 pods with 1.5 CPU = 3 x default multiplier 2), with no existing resources
 def test_get_resource_request_only_pending_pods(pending_pods, pending_pods_signal):
     assert pending_pods_signal._get_resource_request(ClustermanResources(), pending_pods) == SignalResourceRequest(
-        cpus=15,
-        mem=2500,
+        cpus=6,
+        mem=1000,
         disk=0,
         gpus=0,
     )
 
 
+# Existing resources AND pending pods, so sum of both
 def test_get_resource_request_pending_pods_and_metrics(allocated_resources, pending_pods, pending_pods_signal):
     assert pending_pods_signal._get_resource_request(allocated_resources, pending_pods) == SignalResourceRequest(
-        cpus=165,
-        mem=3500,
+        cpus=156,
+        mem=2000,
         disk=500,
+        gpus=0,
+    )
+
+
+# Increase from pending pods but higher multipler
+def test_get_resource_request_only_pending_pods_custom_multipler(pending_pods, pending_pods_signal):
+    pending_pods_signal.parameters["pending_pods_multiplier"] = 20
+    assert pending_pods_signal._get_resource_request(ClustermanResources(), pending_pods) == SignalResourceRequest(
+        cpus=60,
+        mem=10000,
+        disk=0,
         gpus=0,
     )

--- a/tests/signals/pending_pods_signal_test.py
+++ b/tests/signals/pending_pods_signal_test.py
@@ -1,6 +1,8 @@
 from unittest import mock
 
 import pytest
+import staticconf
+import staticconf.testing
 from kubernetes.client import V1Container
 from kubernetes.client import V1ObjectMeta
 from kubernetes.client import V1Pod
@@ -9,7 +11,6 @@ from kubernetes.client import V1PodSpec
 from kubernetes.client import V1PodStatus
 from kubernetes.client import V1ResourceRequirements
 
-from clusterman.signals.pending_pods_signal import _get_resource_request
 from clusterman.signals.pending_pods_signal import PendingPodsSignal
 from clusterman.util import ClustermanResources
 from clusterman.util import SignalResourceRequest
@@ -17,15 +18,16 @@ from clusterman.util import SignalResourceRequest
 
 @pytest.fixture
 def pending_pods_signal():
-    return PendingPodsSignal(
-        "foo",
-        "bar",
-        "kube",
-        "app1",
-        "bar.kube_config",
-        mock.Mock(),
-        mock.Mock(get_unschedulable_pods=mock.Mock(return_value=[])),
-    )
+    with staticconf.testing.PatchConfiguration({"autoscale_signal.period_minutes": 5}, namespace="bar.kube_config"):
+        return PendingPodsSignal(
+            "foo",
+            "bar",
+            "kube",
+            "app1",
+            "bar.kube_config",
+            mock.Mock(),
+            mock.Mock(get_unschedulable_pods=mock.Mock(return_value=[])),
+        )
 
 
 @pytest.fixture
@@ -58,8 +60,8 @@ def pending_pods():
     ]
 
 
-def test_get_resource_request_no_pending_pods(allocated_resources):
-    assert _get_resource_request(allocated_resources) == SignalResourceRequest(
+def test_get_resource_request_no_pending_pods(allocated_resources, pending_pods_signal):
+    assert pending_pods_signal._get_resource_request(allocated_resources) == SignalResourceRequest(
         cpus=150,
         mem=1000,
         disk=500,
@@ -67,8 +69,8 @@ def test_get_resource_request_no_pending_pods(allocated_resources):
     )
 
 
-def test_get_resource_request_only_pending_pods(pending_pods):
-    assert _get_resource_request(ClustermanResources(), pending_pods) == SignalResourceRequest(
+def test_get_resource_request_only_pending_pods(pending_pods, pending_pods_signal):
+    assert pending_pods_signal._get_resource_request(ClustermanResources(), pending_pods) == SignalResourceRequest(
         cpus=15,
         mem=2500,
         disk=0,
@@ -76,8 +78,8 @@ def test_get_resource_request_only_pending_pods(pending_pods):
     )
 
 
-def test_get_resource_request_pending_pods_and_metrics(allocated_resources, pending_pods):
-    assert _get_resource_request(allocated_resources, pending_pods) == SignalResourceRequest(
+def test_get_resource_request_pending_pods_and_metrics(allocated_resources, pending_pods, pending_pods_signal):
+    assert pending_pods_signal._get_resource_request(allocated_resources, pending_pods) == SignalResourceRequest(
         cpus=165,
         mem=3500,
         disk=500,


### PR DESCRIPTION
### Description

Revert the change to the multiplier for now, and make it configurable per pool as per @mattmb s request.

This will allow us to turn it up for Flink pools independently of anything else for testing.

Also add log line which will tell us how many resources the `PendingPodsSignal` is adding, to allow us to work out what a correct multiplier should actually look like, and generally better work out what is going on.

### Testing Done

Added unit tests for the new config value.

### Related context
https://yelp.slack.com/archives/CA6TN8J3G/p1676386279337199
[CLUSTERMAN-779](https://jira.yelpcorp.com/browse/CLUSTERMAN-779)
