### PR TITLE
update arrow to relatively newer version

### DIFF
--- a/clusterman/migration/event.py
+++ b/clusterman/migration/event.py
@@ -198,5 +198,5 @@ class MigrationEvent(NamedTuple):
             label_selectors=event_data.get("label_selectors", []),
             condition=MigrationCondition.from_dict(event_data["condition"]),
             previous_attempts=int(crd["metadata"]["labels"].get(MIGRATION_CRD_ATTEMPTS_LABEL, 0)),
-            created=arrow.get(crd["metadata"].get("creationTimestamp", None)),  # current time by default
+            created=arrow.get(crd["metadata"].get("creationTimestamp", arrow.now())),
         )

--- a/itests/steps/simulation.py
+++ b/itests/steps/simulation.py
@@ -86,7 +86,7 @@ def run_simulator(context, hours, per_second_billing):
         for join_time, market_counts in context.market_counts:
             context.simulator.add_event(
                 ModifyClusterSizeEvent(
-                    arrow.get(join_time),
+                    arrow.get(int(join_time)),
                     market_counts,
                     use_join_delay=getattr(context, "use_join_delay", True),
                 )

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -1,4 +1,4 @@
-arrow<=0.14.6  # need to restrict for now because of https://github.com/crsmithdev/arrow/issues/612
+arrow
 boto3
 botocore
 cachetools

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-arrow==0.14.6
+arrow==0.17.0
 boto3==1.11.11
 botocore==1.14.11
 cachetools==3.1.1


### PR DESCRIPTION
This gets rid of a bunch of this kind of warnings which `arrow.get` would be spitting out:

```
2023-02-20T12:02:22.221090388Z /code/virtualenv_run/lib/python3.7/site-packages/arrow/factory.py:208: ArrowParseWarning: The .get() parsing method without a format string will parse more strictly in version 0.15.0.See https://github.com/crsmithdev/arrow/issues/612 for more details.
2023-02-20T12:02:22.221132397Z   ArrowParseWarning,
```

I've looked around all the usages of that method, and only found a couple which would break and fixed them. Everything else should be receiving ISO timestamps or datetime objects, which are still supported just fine.

I didn't go for the very latest version cause there are other libraries pinning `arrow<1.0`, and I didn't want to start digging a rabbit hole. 