### PR TITLE
Bump timeout.

### DIFF
--- a/clusterman/cli/util.py
+++ b/clusterman/cli/util.py
@@ -21,7 +21,7 @@ from clusterman.util import limit_function_runtime
 
 
 logger = colorlog.getLogger(__name__)
-TIMEOUT_TIME_SECONDS = 10
+TIMEOUT_TIME_SECONDS = 15
 
 
 def timeout_wrapper(main):


### PR DESCRIPTION
Almost everything takes just over 10s, so this warning comes up all the time even when things are working fine. Lets adjust the timeout to make it more useful

