### PR TITLE
Changed excluded resource (daemonset) logic

### DIFF
--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -130,7 +130,7 @@ class KubernetesClusterConnector(ClusterConnector):
             self._pods_by_ip, self._unschedulable_pods, self._excluded_pods = (
                 dict.fromkeys(self._nodes_by_ip, []),
                 [],
-                {},
+                [],
             )
 
     def reload_client(self) -> None:

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -71,7 +71,7 @@ class KubernetesClusterConnector(ClusterConnector):
     _prev_nodes_by_ip: Mapping[str, KubernetesNode]
     _nodes_by_ip: Mapping[str, KubernetesNode]
     _unschedulable_pods: List[KubernetesPod]
-    _excluded_pods_by_ip: Mapping[str, List[KubernetesPod]]
+    _excluded_pods: List[KubernetesPod]
     _pods_by_ip: Mapping[str, List[KubernetesPod]]
     _label_selectors: List[str]
     _unschedulable_pods_resources: ClustermanResources
@@ -114,19 +114,20 @@ class KubernetesClusterConnector(ClusterConnector):
             (
                 self._pods_by_ip,
                 self._unschedulable_pods,
-                self._excluded_pods_by_ip,
                 self._unschedulable_pods_resources,
                 self._allocated_pods_resources,
             ) = self._get_pods_info_with_label()
+            self._excluded_pods = self._get_excluded_pods()
+
             pods_by_ip_count = sum(len(self._pods_by_ip[ip]) for ip in self._pods_by_ip)
-            excluded_pods_by_ip_count = sum(len(self._excluded_pods_by_ip[ip]) for ip in self._excluded_pods_by_ip)
+            excluded_pods_count = len(self._excluded_pods)
             logger.info(
                 f"Successfully reloaded pods: {pods_by_ip_count} running/recently scheduled pods, "
-                f"{len(self._unschedulable_pods)} unscheduled pods, {excluded_pods_by_ip_count} excluded pods."
+                f"{len(self._unschedulable_pods)} unscheduled pods, {excluded_pods_count} excluded pods (per node)."
             )
 
         else:
-            self._pods_by_ip, self._unschedulable_pods, self._excluded_pods_by_ip = (
+            self._pods_by_ip, self._unschedulable_pods, self._excluded_pods = (
                 dict.fromkeys(self._nodes_by_ip, []),
                 [],
                 {},
@@ -171,24 +172,18 @@ class KubernetesClusterConnector(ClusterConnector):
         return getattr(self._allocated_pods_resources, resource_name)
 
     def get_resource_total(self, resource_name: str) -> float:
-        if self._excluded_pods_by_ip:
+        if self._excluded_pods:
             logger.info(f"Excluded {self.get_resource_excluded(resource_name)} {resource_name} from daemonset pods")
         return sum(
             getattr(
-                total_node_resources(node, self._excluded_pods_by_ip.get(node_ip, [])),
+                total_node_resources(node, self._excluded_pods),
                 resource_name,
             )
             for node_ip, node in self._nodes_by_ip.items()
         )
 
     def get_resource_excluded(self, resource_name: str) -> float:
-        return sum(
-            getattr(
-                allocated_node_resources(self._excluded_pods_by_ip.get(node_ip, [])),
-                resource_name,
-            )
-            for node_ip in self._nodes_by_ip.keys()
-        )
+        return getattr(allocated_node_resources(self._excluded_pods), resource_name) * len(self._nodes_by_ip)
 
     def get_unschedulable_pods(self) -> List[KubernetesPod]:
         return self._unschedulable_pods
@@ -390,7 +385,7 @@ class KubernetesClusterConnector(ClusterConnector):
             batch_task_count=self._count_batch_tasks(node_ip),
             state=(AgentState.RUNNING if self._pods_by_ip[node_ip] else AgentState.IDLE),
             task_count=len(self._pods_by_ip[node_ip]),
-            total_resources=total_node_resources(node, self._excluded_pods_by_ip.get(node_ip, [])),
+            total_resources=total_node_resources(node, self._excluded_pods),
             kernel=get_node_kernel_version(node),
             lsbrelease=get_node_lsbrelease(node),
         )
@@ -423,26 +418,18 @@ class KubernetesClusterConnector(ClusterConnector):
     ) -> Tuple[
         Mapping[str, List[KubernetesPod]],
         List[KubernetesPod],
-        Mapping[str, List[KubernetesPod]],
         ClustermanResources,
         ClustermanResources,
     ]:
         pods_by_ip: Mapping[str, List[KubernetesPod]] = defaultdict(list)
         unschedulable_pods: List[KubernetesPod] = []
-        excluded_pods_by_ip: Mapping[str, List[KubernetesPod]] = defaultdict(list)
+
         unschedulable_pods_resources: ClustermanResources = ClustermanResources()
         allocated_pods_resources: ClustermanResources = ClustermanResources()
-
-        exclude_daemonset_pods = self.pool_config.read_bool(
-            "exclude_daemonset_pods",
-            default=staticconf.read_bool("exclude_daemonset_pods", default=False),
-        )
         label_selector = f"{self.pool_label_key}={self.pool}"
 
         for pod in self._core_api.list_pod_for_all_namespaces(label_selector=label_selector).items:
-            if exclude_daemonset_pods and self._pod_belongs_to_daemonset(pod):
-                excluded_pods_by_ip[pod.status.host_ip].append(pod)
-            elif pod.status.phase == "Running" or self._is_recently_scheduled(pod):
+            if pod.status.phase == "Running" or self._is_recently_scheduled(pod):
                 pods_by_ip[pod.status.host_ip].append(pod)
                 allocated_pods_resources += total_pod_resources(pod)
             elif self._is_unschedulable(pod):
@@ -451,10 +438,29 @@ class KubernetesClusterConnector(ClusterConnector):
         return (
             pods_by_ip,
             unschedulable_pods,
-            excluded_pods_by_ip,
             unschedulable_pods_resources,
             allocated_pods_resources,
         )
+
+    def _get_excluded_pods(self) -> List[KubernetesPod]:
+        excluded_pods: List[KubernetesPod]= []
+
+        exclude_daemonset_pods = self.pool_config.read_bool(
+            "exclude_daemonset_pods",
+            default=staticconf.read_bool("exclude_daemonset_pods", default=False),
+        )
+        if len(self._nodes_by_ip) == 0 or not exclude_daemonset_pods:
+            return excluded_pods
+
+        # deamonsets pods are same on any node in the pool, therefore checking one node will be enough
+        arbitrary_node = self._nodes_by_ip[next(iter(self._nodes_by_ip))]
+        arbitrary_node_pods = self._list_all_pods_on_node(arbitrary_node.metadata.name)
+        for pod in arbitrary_node_pods:
+            if self._pod_belongs_to_daemonset(pod):
+                excluded_pods.append(pod)
+
+        return excluded_pods
+
 
     def _count_batch_tasks(self, node_ip: str) -> int:
         count = 0

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -415,12 +415,7 @@ class KubernetesClusterConnector(ClusterConnector):
 
     def _get_pods_info_with_label(
         self,
-    ) -> Tuple[
-        Mapping[str, List[KubernetesPod]],
-        List[KubernetesPod],
-        ClustermanResources,
-        ClustermanResources,
-    ]:
+    ) -> Tuple[Mapping[str, List[KubernetesPod]], List[KubernetesPod], ClustermanResources, ClustermanResources,]:
         pods_by_ip: Mapping[str, List[KubernetesPod]] = defaultdict(list)
         unschedulable_pods: List[KubernetesPod] = []
 
@@ -451,7 +446,7 @@ class KubernetesClusterConnector(ClusterConnector):
         )
 
     def _get_excluded_pods(self) -> List[KubernetesPod]:
-        excluded_pods: List[KubernetesPod]= []
+        excluded_pods: List[KubernetesPod] = []
 
         exclude_daemonset_pods = self.pool_config.read_bool(
             "exclude_daemonset_pods",
@@ -468,7 +463,6 @@ class KubernetesClusterConnector(ClusterConnector):
                 excluded_pods.append(pod)
 
         return excluded_pods
-
 
     def _count_batch_tasks(self, node_ip: str) -> int:
         count = 0

--- a/tests/kubernetes/kubernetes_cluster_connector_test.py
+++ b/tests/kubernetes/kubernetes_cluster_connector_test.py
@@ -384,9 +384,8 @@ def mock_cluster_connector_crd(mock_cluster_connector):
 )
 def test_get_agent_metadata(mock_cluster_connector, ip_address, expected_state):
     with PatchConfiguration(
-            {"exclude_daemonset_pods": True},
-            namespace=POOL_NAMESPACE.format(pool=mock_cluster_connector.pool,
-                                            scheduler=mock_cluster_connector.SCHEDULER),
+        {"exclude_daemonset_pods": True},
+        namespace=POOL_NAMESPACE.format(pool=mock_cluster_connector.pool, scheduler=mock_cluster_connector.SCHEDULER),
     ):
         mock_cluster_connector.reload_state()
         agent_metadata = mock_cluster_connector.get_agent_metadata(ip_address)
@@ -420,9 +419,7 @@ def test_allocation_with_excluded_pods(mock_cluster_connector, daemonset_pod_1, 
         "clusterman.kubernetes.kubernetes_cluster_connector.KubernetesClusterConnector._list_all_pods_on_node",
         autospec=True,
     ) as mock_list_all_pods_on_node:
-        mock_list_all_pods_on_node.return_value = [
-            daemonset_pod_1
-        ]
+        mock_list_all_pods_on_node.return_value = [daemonset_pod_1]
         mock_cluster_connector.reload_state()
         assert daemonset_pod_1 not in mock_cluster_connector._pods_by_ip["10.10.10.1"]
         assert daemonset_pod_2 not in mock_cluster_connector._pods_by_ip["10.10.10.2"]

--- a/tests/kubernetes/kubernetes_cluster_connector_test.py
+++ b/tests/kubernetes/kubernetes_cluster_connector_test.py
@@ -156,7 +156,30 @@ def pending_pod():
 
 
 @pytest.fixture
-def daemonset_pod():
+def daemonset_pod_1():
+    return V1Pod(
+        metadata=V1ObjectMeta(
+            name="daemonset_pod",
+            annotations=dict(),
+            owner_references=[V1OwnerReference(kind="DaemonSet", api_version="foo", name="daemonset", uid="bar")],
+        ),
+        status=V1PodStatus(
+            phase="Running",
+            host_ip="10.10.10.1",
+        ),
+        spec=V1PodSpec(
+            containers=[
+                V1Container(
+                    name="container1",
+                    resources=V1ResourceRequirements(requests={"cpu": "1.5"}),
+                )
+            ],
+        ),
+    )
+
+
+@pytest.fixture
+def daemonset_pod_2():
     return V1Pod(
         metadata=V1ObjectMeta(
             name="daemonset_pod",
@@ -166,6 +189,29 @@ def daemonset_pod():
         status=V1PodStatus(
             phase="Running",
             host_ip="10.10.10.2",
+        ),
+        spec=V1PodSpec(
+            containers=[
+                V1Container(
+                    name="container1",
+                    resources=V1ResourceRequirements(requests={"cpu": "1.5"}),
+                )
+            ],
+        ),
+    )
+
+
+@pytest.fixture
+def daemonset_pod_3():
+    return V1Pod(
+        metadata=V1ObjectMeta(
+            name="daemonset_pod",
+            annotations=dict(),
+            owner_references=[V1OwnerReference(kind="DaemonSet", api_version="foo", name="daemonset", uid="bar")],
+        ),
+        status=V1PodStatus(
+            phase="Running",
+            host_ip="10.10.10.3",
         ),
         spec=V1PodSpec(
             containers=[
@@ -269,7 +315,9 @@ def mock_cluster_connector(
     unevictable_pod,
     unschedulable_pod,
     pending_pod,
-    daemonset_pod,
+    daemonset_pod_1,
+    daemonset_pod_2,
+    daemonset_pod_3,
 ):
     with mock.patch("clusterman.kubernetes.kubernetes_cluster_connector.kubernetes",), mock.patch(
         "clusterman.kubernetes.kubernetes_cluster_connector.CachedCoreV1Api",
@@ -309,7 +357,9 @@ def mock_cluster_connector(
             unevictable_pod,
             unschedulable_pod,
             pending_pod,
-            daemonset_pod,
+            daemonset_pod_1,
+            daemonset_pod_2,
+            daemonset_pod_3,
         ]
         mock_cluster_connector = KubernetesClusterConnector("kubernetes-test", "bar")
         mock_cluster_connector.reload_state()
@@ -333,9 +383,15 @@ def mock_cluster_connector_crd(mock_cluster_connector):
     ],
 )
 def test_get_agent_metadata(mock_cluster_connector, ip_address, expected_state):
-    agent_metadata = mock_cluster_connector.get_agent_metadata(ip_address)
-    assert agent_metadata.is_safe_to_kill == (ip_address != "10.10.10.2")
-    assert agent_metadata.state == expected_state
+    with PatchConfiguration(
+            {"exclude_daemonset_pods": True},
+            namespace=POOL_NAMESPACE.format(pool=mock_cluster_connector.pool,
+                                            scheduler=mock_cluster_connector.SCHEDULER),
+    ):
+        mock_cluster_connector.reload_state()
+        agent_metadata = mock_cluster_connector.get_agent_metadata(ip_address)
+        assert agent_metadata.is_safe_to_kill == (ip_address != "10.10.10.2")
+        assert agent_metadata.state == expected_state
 
 
 def test_get_nodes_by_ip(mock_cluster_connector):
@@ -353,17 +409,25 @@ def test_reload_state_no_pods(mock_cluster_connector):
 
 
 def test_allocation(mock_cluster_connector):
-    assert mock_cluster_connector.get_resource_allocation("cpus") == 7.5
+    assert mock_cluster_connector.get_resource_allocation("cpus") == 10.5
 
 
-def test_allocation_with_excluded_pods(mock_cluster_connector, daemonset_pod):
+def test_allocation_with_excluded_pods(mock_cluster_connector, daemonset_pod_1, daemonset_pod_2, daemonset_pod_3):
     with PatchConfiguration(
         {"exclude_daemonset_pods": True},
         namespace=POOL_NAMESPACE.format(pool=mock_cluster_connector.pool, scheduler=mock_cluster_connector.SCHEDULER),
-    ):
+    ), mock.patch(
+        "clusterman.kubernetes.kubernetes_cluster_connector.KubernetesClusterConnector._list_all_pods_on_node",
+        autospec=True,
+    ) as mock_list_all_pods_on_node:
+        mock_list_all_pods_on_node.return_value = [
+            daemonset_pod_1
+        ]
         mock_cluster_connector.reload_state()
-        assert daemonset_pod not in mock_cluster_connector._pods_by_ip["10.10.10.2"]
-        assert mock_cluster_connector.get_resource_total("cpus") == 10
+        assert daemonset_pod_1 not in mock_cluster_connector._pods_by_ip["10.10.10.1"]
+        assert daemonset_pod_2 not in mock_cluster_connector._pods_by_ip["10.10.10.2"]
+        assert daemonset_pod_3 not in mock_cluster_connector._pods_by_ip["10.10.10.3"]
+        assert mock_cluster_connector.get_resource_total("cpus") == 7
         assert mock_cluster_connector.get_resource_allocation("cpus") == 6
 
 
@@ -379,9 +443,9 @@ def test_pending_cpus(mock_cluster_connector):
     assert mock_cluster_connector.get_resource_pending("cpus") == 1.5
 
 
-def test_pod_belongs_to_daemonset(mock_cluster_connector, running_pod_1, daemonset_pod):
+def test_pod_belongs_to_daemonset(mock_cluster_connector, running_pod_1, daemonset_pod_1):
     assert not mock_cluster_connector._pod_belongs_to_daemonset(running_pod_1)
-    assert mock_cluster_connector._pod_belongs_to_daemonset(daemonset_pod)
+    assert mock_cluster_connector._pod_belongs_to_daemonset(daemonset_pod_1)
 
 
 def test_list_node_migration_resources(mock_cluster_connector_crd):


### PR DESCRIPTION
### Description

After moving pool label based filtering for pods (CLUSTERMAN-582) we lost excluding daemonset resource feature.
Because daemonsets don't have pool label, which is expected.
We are going to move single excluded resource logic for the pool, because we have same daemonset pods on all node in the same pool. 
