### PR TITLE
Better prioritization for choosing nodes as victim for scaling down

### DIFF
--- a/clusterman/interfaces/types.py
+++ b/clusterman/interfaces/types.py
@@ -21,6 +21,7 @@ class AgentMetadata(NamedTuple):
     batch_task_count: int = 0
     is_safe_to_kill: bool = True
     is_draining: bool = False
+    priority: float = 0.0
     state: AgentState = AgentState.UNKNOWN
     task_count: int = 0
     total_resources: ClustermanResources = ClustermanResources()

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -501,7 +501,7 @@ class KubernetesClusterConnector(ClusterConnector):
 
     def get_node_priority(self, node_id: str) -> float:
         pods = self._pods_by_ip[node_id]
-        if not pods or len(pods) == 0:
+        if not pods:
             return 0.0
         max_requested_resource = max([self.get_pod_resources_score(pod) for pod in pods])
         # nodes have bigger pods = higher priority = lower possibility for choosing termination

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -383,6 +383,7 @@ class KubernetesClusterConnector(ClusterConnector):
             is_safe_to_kill=self._is_node_safe_to_kill(node_ip),
             is_draining=self._is_node_draining(node),
             batch_task_count=self._count_batch_tasks(node_ip),
+            priority=self.get_node_priority(node_ip),
             state=(AgentState.RUNNING if self._pods_by_ip[node_ip] else AgentState.IDLE),
             task_count=len(self._pods_by_ip[node_ip]),
             total_resources=total_node_resources(node, self._excluded_pods),
@@ -497,6 +498,20 @@ class KubernetesClusterConnector(ClusterConnector):
             if condition.type == "PodScheduled" and condition.reason == "Unschedulable":
                 return True
         return False
+
+    def get_node_priority(self, node_id: str) -> float:
+        pods = self._pods_by_ip[node_id]
+        if not pods or len(pods) == 0:
+            return 0.0
+        max_requested_resource = max([self.get_pod_resources_score(pod) for pod in pods])
+        # nodes have bigger pods = higher priority = lower possibility for choosing termination
+        return max_requested_resource
+
+    def get_pod_resources_score(self, pod: KubernetesPod) -> float:
+        resource = total_pod_resources(pod)
+        cpus = getattr(resource, "cpus") * 2
+        mem = getattr(resource, "mem") / 1000
+        return cpus + mem
 
     @property
     def pool_label_key(self):

--- a/clusterman/simulator/simulated_pool_manager.py
+++ b/clusterman/simulator/simulated_pool_manager.py
@@ -58,6 +58,9 @@ class SimulatedPoolManager(PoolManager):
             self.pool_config.read_int("scaling_limits.min_node_scalein_uptime_seconds", default=-1),
             MAX_MIN_NODE_SCALEIN_UPTIME_SECONDS,
         )
+        self.killable_nodes_prioritizing_v2 = self.pool_config.read_bool(
+            "autoscaling.killable_nodes_prioritizing_v2", default=False
+        )
         monitoring_info = {"cluster": cluster, "pool": pool}
         self.killable_nodes_counter = get_monitoring_client().create_counter(SFX_KILLABLE_NODES_COUNT, monitoring_info)
 


### PR DESCRIPTION
### Description

Default pool case:
They have nrt search pods (which request bigger resources, and mostly we have only 1 or 2 nrt pods in our nodes)
Clusterman chooses nodes which has less pods for termination. This caused many scale up/down in mentioned pools.

- Clusterman sees pending pods, bumps capacity
- Nrt pods are scheduled
- Clusterman wants to scale down, because pending pods signal v2 bumps a bit more as expected.
- Clusterman delete nodes which have nrt (because they have small amount pods)

And again and again. 
I’m expecting this will support for better bin-packing as well.
