### PR TITLE
Ignoring expired pending pods

### DIFF
--- a/clusterman/signals/pending_pods_signal.py
+++ b/clusterman/signals/pending_pods_signal.py
@@ -94,6 +94,10 @@ class PendingPodsSignal(Signal):
         pending_pods = pending_pods or []
         filtered_pending_pods = [pod for pod in pending_pods if not self._ignore_peding_pod(pod)]
 
+        ignored_pending_pods_count = len(pending_pods) - len(filtered_pending_pods)
+        if ignored_pending_pods_count > 0:
+            logger.info(f"Ignoring {ignored_pending_pods_count} Pending pods due to max_scheduling_seconds")
+
         if len(filtered_pending_pods) > 0:
             for pod in filtered_pending_pods:
                 resource_request += total_pod_resources(pod) * multiplier

--- a/tests/signals/pending_pods_signal_test.py
+++ b/tests/signals/pending_pods_signal_test.py
@@ -1,3 +1,4 @@
+import datetime
 from unittest import mock
 
 import pytest
@@ -49,7 +50,10 @@ def target_capacity_margin():
 def pending_pods():
     return [
         V1Pod(
-            metadata=V1ObjectMeta(name="pod1"),
+            metadata=V1ObjectMeta(
+                name="pod1",
+                creation_timestamp=datetime.datetime(2023, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc),
+            ),
             status=V1PodStatus(
                 phase="Pending",
                 conditions=[V1PodCondition(status="False", type="PodScheduled", reason="Unschedulable")],


### PR DESCRIPTION
### Description

We want to have limit for pending pods. If pending pods exist more than configured time, we will ignore them to calculate needed resources. Because probably they misconfigured. 
