### PR TITLE
fix comparison of MigrationEvent objects

### DIFF
--- a/clusterman/migration/event.py
+++ b/clusterman/migration/event.py
@@ -148,6 +148,13 @@ class MigrationEvent(NamedTuple):
         """Simplified object hash since resource_name should be unique"""
         return cast(Tuple[str, str, str], self[:3]).__hash__()
 
+    def __eq__(self, other: object) -> bool:
+        """On the same line of __hash__ above"""
+        return (
+            isinstance(other, MigrationEvent)
+            and cast(Tuple[str, str, str], self)[:3] == cast(Tuple[str, str, str], other)[:3]
+        )
+
     def __str__(self) -> str:
         return (
             f"MigrationEvent(cluster={self.cluster}, pool={self.pool},"

--- a/tests/migration/migration_event_test.py
+++ b/tests/migration/migration_event_test.py
@@ -174,3 +174,22 @@ def test_condition_matches_uptime_offset(condition, current_time, result):
         instance=InstanceMetadata(market=InstanceMarket("m5.4xlarge", None), weight=None, uptime=timedelta(days=10)),
     )
     assert condition.matches(node_metadata, current_time) is result
+
+
+def test_migration_event_equality():
+    event1 = MigrationEvent(
+        resource_name="mesos-test-bar-111222333",
+        cluster="mesos-test",
+        pool="bar",
+        label_selectors=[],
+        condition=MigrationCondition(
+            ConditionTrait.KERNEL,
+            ConditionOperator.IN,
+            [semver.VersionInfo.parse("1.2.3"), semver.VersionInfo.parse("3.4.5")],
+        ),
+        previous_attempts=0,
+        created=arrow.get("2023-02-10T11:18:17Z"),
+    )
+    event2 = MigrationEvent(**{**event1._asdict(), "previous_attempts": 1})
+    assert event2 in {event1}
+    assert event2 == event1


### PR DESCRIPTION
When implementing this I overlooked the fact that a set lookup will also do a full comparison, after looking up the object hash, which means this

https://github.com/Yelp/clusterman/blob/3fe6a4588a53a26f32828b4cfa3ccd4dbd0a3ed7/clusterman/batch/node_migration.py#L224

has effectively always been partially broken. It only became apparent recently since the introduction of the `previous_attempts` which actually can vary, compared to the all other fields.

It's not a big bug, since there's also another downstream check preventing to create multiple worker processes for the same pool, but it does cause some annoying noise in the logs.