### PR TITLE
Allow overriding srv-configs-provided kubeconfig

### DIFF
--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import copy
+import os
 from collections import defaultdict
 from typing import List
 from typing import Mapping
@@ -79,7 +80,11 @@ class KubernetesClusterConnector(ClusterConnector):
 
     def __init__(self, cluster: str, pool: Optional[str], init_crd: bool = False) -> None:
         super().__init__(cluster, pool)
-        self.kubeconfig_path = staticconf.read_string(f"clusters.{cluster}.kubeconfig_path")
+
+        # we'll always prefer a kubeconfig path passed in as an envvar as this is the only way
+        # for our yelp-internal CLI wrappers to pass in a different kubeconfig without needing
+        # to plumb through a whole mountain of files
+        self.kubeconfig_path = os.getenv("KUBECONFIG") or staticconf.read_string(f"clusters.{cluster}.kubeconfig_path")
         self._safe_to_evict_annotation = staticconf.read_string(
             f"clusters.{cluster}.pod_safe_to_evict_annotation",
             default="cluster-autoscaler.kubernetes.io/safe-to-evict",

--- a/clusterman/kubernetes/util.py
+++ b/clusterman/kubernetes/util.py
@@ -60,7 +60,7 @@ class KubeApiClientWrapper:
         :param Type client_class: k8s client class to initialize
         """
         try:
-            kubernetes.config.load_kube_config(kubeconfig_path)
+            kubernetes.config.load_kube_config(kubeconfig_path, context=os.getenv("KUBECONTEXT"))
         except TypeError:
             error_msg = "Could not load KUBECONFIG; is this running on Kubernetes master?"
             if "yelpcorp" in socket.getfqdn():


### PR DESCRIPTION
This serves two purposes:
* we can get rid of SSH access to our kube masters (and the sudoers
  rules for running clusterman) in favor of using the local
  PaaSTA-provided kubeconfig and aws-okta auth
* allows us to run the clusterman CLI for EKS pools (where there are no
  masters to SSH into)