### PR TITLE
Allow setting an AWS profile override (+ support pod identity)

### DIFF
--- a/clusterman/aws/client.py
+++ b/clusterman/aws/client.py
@@ -86,14 +86,6 @@ def _init_session():
             _session = boto3.session.Session(
                 region_name=staticconf.read_string("aws.region"),
             )
-        # this should only be used when running clusterman in paasta using pod identity
-        elif os.getenv("AWS_WEB_IDENTITY_TOKEN_FILE"):
-            _session = boto3.session.Session(
-                # unfortunately, it doesn't seem like the pod identity webhook lets us magically
-                # obviate the region name we're targetting (for clients that are region-aware) so
-                # we'll continue reading this value from soaconfigs
-                region_name=staticconf.read_string("aws.region"),
-            )
         else:
             _session = boto3.session.Session(
                 staticconf.read_string("accessKeyId", namespace=CREDENTIALS_NAMESPACE),

--- a/clusterman/cli/util.py
+++ b/clusterman/cli/util.py
@@ -21,16 +21,15 @@ from clusterman.util import limit_function_runtime
 
 
 logger = colorlog.getLogger(__name__)
-TIMEOUT_TIME_SECONDS = 15
+TIMEOUT_TIME_SECONDS = 5
 
 
 def timeout_wrapper(main):
     def wrapper(args: argparse.Namespace):
-        # After 10s, prints a warning message if the command is running from the wrong place
         def timeout_handler():
-            warning_string = "This command is taking a long time to run; are you running from the right account?"
+            warning_string = "This command is taking a long time to run; you're likely targetting a large pool/cluster."
             if "yelpcorp" in socket.getfqdn():
-                warning_string += "\nHINT: try ssh'ing to adhoc-prod or another box in the right account."
+                warning_string += "\nIf this command hasn't returned in several minutes, reach out to #clusterman"
             logger.warning(warning_string)
 
         limit_function_runtime(partial(main, args), TIMEOUT_TIME_SECONDS, timeout_handler)

--- a/clusterman/exceptions.py
+++ b/clusterman/exceptions.py
@@ -77,3 +77,7 @@ class SignalConnectionError(ClustermanSignalError):
 
 class SimulationError(ClustermanException):
     pass
+
+
+class InvalidConfigurationError(ClustermanException):
+    pass

--- a/clusterman/exceptions.py
+++ b/clusterman/exceptions.py
@@ -77,7 +77,3 @@ class SignalConnectionError(ClustermanSignalError):
 
 class SimulationError(ClustermanException):
     pass
-
-
-class InvalidConfigurationError(ClustermanException):
-    pass

--- a/clusterman/run.py
+++ b/clusterman/run.py
@@ -27,16 +27,7 @@ def main(argv=None):
     setup_logging(args.log_level)
     setup_config(args)
 
-    try:
-        args.entrypoint(args)
-    except Exception as e:
-        print(f"Exception of type {e.__class__.__name__} occured")
-
-        if e.args:
-            for arg in e.args:
-                print(arg)
-
-        exit(1)
+    args.entrypoint(args)
 
 
 if __name__ == "__main__":

--- a/tox.ini
+++ b/tox.ini
@@ -7,11 +7,16 @@ tox_pip_extensions_ext_venv_update = true
 passenv = HOME SSH_AUTH_SOCK USER LANG PIP_INDEX_URL
 basepython = python3.7
 envdir = virtualenv_run
+usedevelop = true
 deps =
     -rrequirements.txt
     -rrequirements-dev.txt
 commands =
     check-requirements -v
+    # optionally install yelpy requirements - this is fine to fail in GHA
+    # this is also explicitly *after* check-requirements as it does not
+    # understand these extra files
+    -pip install -rextra-requirements-yelp.txt -rextra-requirements-yelp-dev.txt
     mypy clusterman tests
     coverage erase
     coverage run -m pytest tests


### PR DESCRIPTION
Right now, Clusterman will always use /etc/boto_cfg creds - which means that we will not be able to access prod resources from devboxen normally.

We can do one of two things:
* Use our personal permissions
* Route folks to boxes like adhoc-prod for running clusterman against prod clusters

We'd like to minimize our usage of adhoc-prod in general, so I've gone for the first option and will be setting the relevant env vars in our wrappers.

Additionally, this PR allows us to use Pod Identity if the required environment variables are present