### PR TITLE
Upgrade numpy to silence numpy warnings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ kubernetes==10.0.1
 matplotlib==3.1.1
 more-itertools==7.2.0
 mypy-extensions==0.4.3
-numpy==1.17.2
+numpy==1.21.6
 oauthlib==3.1.0
 packaging==19.2
 parsedatetime==2.4


### PR DESCRIPTION
This removes the following two warnings when using the Clusterman CLI on Jammy boxes:
```
RuntimeError: module compiled against API version 0xe but this version of
numpy is 0xd
```
and
```
ImportError: numpy.core.multiarray failed to import, unable to import code
to make reports, some simulator commands will fail
```
