### PR TITLE
Temporarily upper-bound acceptance toxenv urllib3

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -77,6 +77,7 @@ deps =
     docker-compose
     boto3
     simplejson
+    urllib3<1.27
 commands =
     docker-compose -f acceptance/docker-compose.yaml down
     docker-compose -f acceptance/docker-compose.yaml pull


### PR DESCRIPTION
We're being slightly bad here and using an unpinned set of dependencies, which has finally come back to bite us.

We can probably get rid of this since my understanding is that the acceptance tests are mesos-only OR we can generate some requirements files to fully pin things OR we can use a single venv for all this (i.e., use the normal env with our dev dependencies)