### PR TITLE
bump yelp-batch to 11.2.7

### DIFF
--- a/extra-requirements-yelp.txt
+++ b/extra-requirements-yelp.txt
@@ -1,7 +1,7 @@
 clusterman-metrics==2.2.1
 monk==1.1.0
 pysensu-yelp==0.4.1
-yelp-batch==10.1.3
+yelp-batch==11.2.7
 yelp-clog==4.1.0
 yelp-lib==13.1.5
 yelp-meteorite==1.5.1


### PR DESCRIPTION
### Description

This is needed for compatibility with cgroups v2.

### Testing Done

`make test` seems happy. This shouldn't bring any changes to the interfaces used by this service anyway.