### PR TITLE
pin cryptography for acceptance venv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -78,6 +78,7 @@ deps =
     boto3
     simplejson
     urllib3<1.27
+    cryptography==39.0.1
 commands =
     docker-compose -f acceptance/docker-compose.yaml down
     docker-compose -f acceptance/docker-compose.yaml pull


### PR DESCRIPTION
Deploy pipeline is currently broken due to this as we don't have a py37 wheel for the latest version of `cryptography`.
I used the same version pinned in `requirements.txt`