### PR TITLE
CLUSTERMAN-812: upgrade k8s client library

### DIFF
--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -24,8 +24,8 @@ import arrow
 import colorlog
 import kubernetes
 import staticconf
-from kubernetes.client import V1Eviction
 from kubernetes.client import V1DeleteOptions
+from kubernetes.client import V1Eviction
 from kubernetes.client import V1ObjectMeta
 from kubernetes.client.models.v1_node import V1Node as KubernetesNode
 from kubernetes.client.models.v1_pod import V1Pod as KubernetesPod

--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -24,7 +24,7 @@ import arrow
 import colorlog
 import kubernetes
 import staticconf
-from kubernetes.client import V1beta1Eviction
+from kubernetes.client import V1Eviction
 from kubernetes.client import V1DeleteOptions
 from kubernetes.client import V1ObjectMeta
 from kubernetes.client.models.v1_node import V1Node as KubernetesNode
@@ -356,7 +356,7 @@ class KubernetesClusterConnector(ClusterConnector):
         self._core_api.create_namespaced_pod_eviction(
             name=pod.metadata.name,
             namespace=pod.metadata.namespace,
-            body=V1beta1Eviction(
+            body=V1Eviction(
                 metadata=V1ObjectMeta(
                     name=pod.metadata.name,
                     namespace=pod.metadata.namespace,

--- a/clusterman/kubernetes/util.py
+++ b/clusterman/kubernetes/util.py
@@ -30,6 +30,7 @@ from kubernetes.client.models.v1_node import V1Node as KubernetesNode
 from kubernetes.client.models.v1_node_selector_requirement import V1NodeSelectorRequirement
 from kubernetes.client.models.v1_node_selector_term import V1NodeSelectorTerm
 from kubernetes.client.models.v1_pod import V1Pod as KubernetesPod
+from kubernetes.config.config_exception import ConfigException
 
 from clusterman.util import ClustermanResources
 
@@ -72,7 +73,7 @@ class KubeApiClientWrapper:
                 kubernetes.config.load_incluster_config()
             else:
                 kubernetes.config.load_kube_config(kubeconfig_path, context=os.getenv("KUBECONTEXT"))
-        except TypeError:
+        except (TypeError, ConfigException):
             error_msg = "Could not load KUBECONFIG; is this running on Kubernetes master?"
             if "yelpcorp" in socket.getfqdn():
                 error_msg += "\nHint: try using the clusterman-k8s-<clustername> wrapper script!"

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ idna==2.8
 jmespath==0.9.4
 jsonpickle==1.4.2
 kiwisolver==1.1.0
-kubernetes==10.0.1
+kubernetes==24.2.0
 matplotlib==3.4.2
 mypy-extensions==0.4.3
 numpy==1.21.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ idna==2.8
 jmespath==0.9.4
 jsonpickle==1.4.2
 kiwisolver==1.1.0
-kubernetes==23.6.0
+kubernetes==24.2.0
 matplotlib==3.4.2
 mypy-extensions==0.4.3
 numpy==1.21.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ idna==2.8
 jmespath==0.9.4
 jsonpickle==1.4.2
 kiwisolver==1.1.0
-kubernetes==24.2.0
+kubernetes==23.6.0
 matplotlib==3.4.2
 mypy-extensions==0.4.3
 numpy==1.21.6

--- a/tests/kubernetes/util_test.py
+++ b/tests/kubernetes/util_test.py
@@ -5,6 +5,7 @@ from unittest import mock
 import pytest
 from kubernetes.client.models.v1_node_selector_requirement import V1NodeSelectorRequirement
 from kubernetes.client.models.v1_node_selector_term import V1NodeSelectorTerm
+from kubernetes.config import ConfigException
 
 from clusterman.kubernetes.util import CachedCoreV1Api
 from clusterman.kubernetes.util import ConciseCRDApi
@@ -21,7 +22,7 @@ def mock_cached_core_v1_api():
 
 
 def test_cached_corev1_api_no_kubeconfig(caplog):
-    with pytest.raises(TypeError):
+    with pytest.raises(ConfigException):
         CachedCoreV1Api("/foo/bar/admin.conf")
         assert "Could not load KUBECONFIG" in caplog.text
 


### PR DESCRIPTION
Upgrading k8s library to match our k8s clusters up to including k8s 1.24.

Note: Since we're using V1Eviction which only became available with k8s 1.22, we must wait with rollout until all clusters are on at least k8s 1.22.

Signed-off-by: Max Falk <gfalk@yelp.com>