### PR TITLE
Grant home dir permission to user nobody

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,13 +29,15 @@ COPY    tox.ini requirements.txt requirements-bootstrap.txt extra-requirements-y
 RUN     cd code && tox -e virtualenv_run
 RUN     cd code && virtualenv_run/bin/pip3 install -rextra-requirements-yelp.txt
 
-RUN     mkdir /home/nobody
+RUN     mkdir /home/nobody  \
+        && chown nobody /home/nobody
 ENV     HOME /home/nobody
 
 # Code is COPY'ed here after the pip install above, so that code changes do not
 # break the preceding cache layer.
 COPY    . /code
 RUN     chown nobody /code
+
 
 # This is needed so that we can pass PaaSTA itests on Jenkins; for some reason (probably aufs-related?)
 # root can't modify the contents of /code on Jenkins, even though it works locally.  Root needs to

--- a/Dockerfile.external
+++ b/Dockerfile.external
@@ -40,7 +40,8 @@ RUN     apt-get update && apt-get upgrade -y \
 RUN     /usr/bin/pip3 install setuptools supervisor tox==3.24.4
 COPY    tox.ini requirements.txt requirements-bootstrap.txt /code/
 
-RUN     mkdir /home/nobody
+RUN     mkdir /home/nobody  \
+        && chown nobody /home/nobody
 ENV     HOME /home/nobody
 
 # Code is COPY'ed here after the pip install above, so that code changes do not


### PR DESCRIPTION
### Description
Currently, using AWS CLI to get access tokens is not possible due to failure in creating `.aws `dir. This PR fix `homedir` permissions so that user `nobody` can create the required `.aws` dir 
Please fill out!

### Testing Done

To test the changes, I created a new docker container with the new image. With this change, new docker container is started with right permissions on `/home/nobody` dir
