### PR TITLE
Update PATH variable in supervisod.conf

### DIFF
--- a/clusterman/supervisord/supervisord.conf
+++ b/clusterman/supervisord/supervisord.conf
@@ -45,7 +45,7 @@ redirect_stderr=true
 
 [program:autoscaler]
 directory=/code
-environment=PATH=/code/virtualenv_run/bin
+environment=PATH=/code/virtualenv_run/bin:%(ENV_PATH)s
 command=python -m clusterman.batch.autoscaler %(ENV_CMAN_ARGS)s
 autostart=false
 autorestart=false


### PR DESCRIPTION
### Description
While trying to use `exec based` plugin in `kubeconfig`, we discovered that clusterman `autoscaler.py` was failing due to not able to find aws cli. After doing more investigation we found out that, this is due to `superviosrd` overwriting `PATH` env variable before launching `autoscaler.py` process. This PR fix the issue by preserving PATH variable in supervisor config.  
