### PR TITLE
Add support to use in-cluster service account

### DIFF
--- a/clusterman/kubernetes/util.py
+++ b/clusterman/kubernetes/util.py
@@ -63,10 +63,10 @@ class KubeApiClientWrapper:
             """
             https://kubernetes.io/docs/concepts/containers/container-environment/#container-environment
             Every pod in k8s gets some default environment variable injected, including KUBERNETES_SERVICE_HOST
-            which points to K8s service. We are using this variable to distinguise between when cluterman is started in
-            a pod vs when it's started on host. For clusterman instances running inside a k8s cluster, we prioritise using
-            K8s Service account since that let us avoid creating any kubeconfig in advance.
-            For clusterman CLI invocation we continue using provided KUBECONFIG file
+            which points to default kuberbetes service. We are using this variable to distinguise between
+            when cluterman is started in a pod vs when it's started on host. For clusterman instances running inside
+            a k8s cluster, we prioritise using K8s Service account since that let us avoid creating any kubeconfig
+            in advance. For clusterman CLI invocation we continue using provided KUBECONFIG file
             """
             if os.getenv("KUBERNETES_SERVICE_HOST"):
                 kubernetes.config.load_incluster_config()

--- a/clusterman/kubernetes/util.py
+++ b/clusterman/kubernetes/util.py
@@ -62,7 +62,7 @@ class KubeApiClientWrapper:
         try:
             """
             https://kubernetes.io/docs/concepts/containers/container-environment/#container-environment
-            Every pod in k8s get some default enviornment variable injected, Including KUBERNETES_SERVICE_HOST
+            Every pod in k8s gets some default environment variable injected, including KUBERNETES_SERVICE_HOST
             which points to K8s service. We are using this variable to distinguise between when cluterman is started in
             a pod vs when it's started on host. For clusterman instances running inside a k8s cluster, we prioritise using
             K8s Service account since that let us avoid creating any kubeconfig in advance.

--- a/clusterman/kubernetes/util.py
+++ b/clusterman/kubernetes/util.py
@@ -64,7 +64,7 @@ class KubeApiClientWrapper:
             https://kubernetes.io/docs/concepts/containers/container-environment/#container-environment
             Every pod in k8s get some default enviornment variable injected, Including KUBERNETES_SERVICE_HOST
             which points to K8s service. We are using this variable to distinguise between when cluterman is started in
-            a pod vs when it's started on host. For clusterman services running inside a k8s cluster, We priiotise using
+            a pod vs when it's started on host. For clusterman instances running inside a k8s cluster, we prioritise using
             K8s Service account since that let us avoid creating any kubeconfig in advance.
             For clusterman CLI invokation we continue using provided KUBECONFIG file
             """

--- a/clusterman/kubernetes/util.py
+++ b/clusterman/kubernetes/util.py
@@ -66,7 +66,7 @@ class KubeApiClientWrapper:
             which points to K8s service. We are using this variable to distinguise between when cluterman is started in
             a pod vs when it's started on host. For clusterman instances running inside a k8s cluster, we prioritise using
             K8s Service account since that let us avoid creating any kubeconfig in advance.
-            For clusterman CLI invokation we continue using provided KUBECONFIG file
+            For clusterman CLI invocation we continue using provided KUBECONFIG file
             """
             if os.getenv("KUBERNETES_SERVICE_HOST"):
                 kubernetes.config.load_incluster_config()

--- a/tests/kubernetes/util_test.py
+++ b/tests/kubernetes/util_test.py
@@ -20,12 +20,6 @@ def mock_cached_core_v1_api():
         yield CachedCoreV1Api("/foo/bar/admin.conf")
 
 
-@pytest.fixture
-def mock_load_incluster_config():
-    with mock.patch("clusterman.kubernetes.util.kubernetes.config.load_incluster_config") as mock_load_incluster_config:
-        yield mock_load_incluster_config
-
-
 def test_cached_corev1_api_no_kubeconfig(caplog):
     with pytest.raises(TypeError):
         CachedCoreV1Api("/foo/bar/admin.conf")


### PR DESCRIPTION
### Description
Currently running clusterman inside a pod requires out of band setup since clusterman needs kubeconfig to access k8s api server. We can fix this by making clusterman the already created Service account which is attached to clusterman pod. 
In cases where clusterman is started outside of a pod ( Like clusterman cli), It falls back to using provided kubeconfig file.

### Testing Done
Added tests to confirm that right load function is called while running inside Pod vs running on host.
