### PR TITLE
CLUSTERMAN-812: reload k8s client only once

### DIFF
--- a/clusterman/kubernetes/kubernetes_cluster_connector.py
+++ b/clusterman/kubernetes/kubernetes_cluster_connector.py
@@ -99,6 +99,8 @@ class KubernetesClusterConnector(ClusterConnector):
             node_label_selector = self.pool_config.read_string("node_label_key", default="clusterman.com/pool")
             self._label_selectors.append(f"{node_label_selector}={self.pool}")
 
+        self.reload_client()
+
     def reload_state(self, load_pods_info: bool = True) -> None:
         """Reload information from cluster/pool
 
@@ -106,8 +108,6 @@ class KubernetesClusterConnector(ClusterConnector):
                                     NOTE: all resouce utilization metrics won't be available when setting this
         """
         logger.info("Reloading nodes")
-
-        self.reload_client()
 
         # store the previous _nodes_by_ip for use in get_removed_nodes_before_last_reload()
         self._prev_nodes_by_ip = copy.deepcopy(self._nodes_by_ip)


### PR DESCRIPTION
This is addressing the same problem as #341 but by initializing the k8s clients only once per instantiation of KubernetesClusterConnector.

Signed-off-by: Max Falk <gfalk@yelp.com>