### PR TITLE
Updating typing dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ simplejson==3.16.0
 six==1.15.0
 sortedcontainers==2.1.0
 sseclient-py==1.7
-typing-extensions==4.3.0
+typing-extensions==4.7.1
 urllib3==1.25.9
 websocket-client==0.56.0
 ws4py==0.5.1


### PR DESCRIPTION
Dependencies needs to be updated to have the pipeline working since version 4.3.0 for typing-extensions is incompatible with filelock