### PR TITLE
SEC-18515: Bump boto3 to enable IMDSv2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ colorama==0.4.1
 colorlog==4.0.2
 cycler==0.10.0
 decorator==4.4.0
-docutils==0.15.2
 future==0.18.0
 google-auth==1.6.3
 humanfriendly==4.18

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 arrow==0.17.0
-boto3==1.11.11
-botocore==1.14.11
+boto3==1.34.11
+botocore==1.34.11
 cachetools==3.1.1
 certifi==2019.9.11
 chardet==3.0.4
@@ -37,7 +37,7 @@ requests==2.22.0
 requests-oauthlib==1.2.0
 retry==0.9.2
 rsa==4.6
-s3transfer==0.3.2
+s3transfer==0.10.0
 semver==2.13.0
 setuptools==49.2.1
 signalfx==1.1.1


### PR DESCRIPTION
Ticket: [SEC-18515](https://jira.yelpcorp.com/browse/SEC-18515)

We want to enforce IMDSv2 usage everywhere, and every boto3 version below 1.12.6 does not support IMDSv2. 
I bumped this by with `pip install --upgrade boto3` and using the new package versions
